### PR TITLE
feat: ELO v2 — per-player K factors and seeded ELO

### DIFF
--- a/backend/routers/duels.py
+++ b/backend/routers/duels.py
@@ -90,8 +90,14 @@ async def submit_duel(
     score_a, score_b = outcome_to_scores(outcome)
     if outcome in ("neither", "a_only", "b_only"):
         new_elo_a, new_elo_b = old_elo_a, old_elo_b
-    else:
-        new_elo_a, new_elo_b = update_elo(old_elo_a, old_elo_b, score_a)
+    elif outcome == "a_wins":
+        new_elo_a, new_elo_b = update_elo(
+            old_elo_a, old_elo_b, um_a.battles, um_b.battles
+        )
+    else:  # b_wins
+        new_elo_b, new_elo_a = update_elo(
+            old_elo_b, old_elo_a, um_b.battles, um_a.battles
+        )
 
     delta_a = new_elo_a - old_elo_a
     delta_b = new_elo_b - old_elo_b

--- a/backend/services/elo.py
+++ b/backend/services/elo.py
@@ -1,9 +1,23 @@
 """ELO rating calculation.
 
-Uses the standard ELO formula with K=32, default rating 1000.
+Uses the standard ELO formula with per-player K factors based on battle
+count (provisional K=64 for fewer than 5 battles, otherwise K=32).
+Default starting rating is 1000.
 """
 
-K_FACTOR = 32
+PROVISIONAL_THRESHOLD = 5
+K_PROVISIONAL = 64
+K_ESTABLISHED = 32
+DEFAULT_ELO = 1000
+
+
+def k_factor(battles: int) -> int:
+    """Return K factor based on number of battles played.
+
+    Provisional players (< 5 battles) get K=64 for faster convergence.
+    Established players get K=32.
+    """
+    return K_PROVISIONAL if battles < PROVISIONAL_THRESHOLD else K_ESTABLISHED
 
 
 def expected_score(rating_a: int, rating_b: int) -> float:
@@ -12,29 +26,57 @@ def expected_score(rating_a: int, rating_b: int) -> float:
 
 
 def update_elo(
-    rating_a: int,
-    rating_b: int,
-    score_a: float,
-    k: int = K_FACTOR,
+    winner_elo: int,
+    loser_elo: int,
+    winner_battles: int,
+    loser_battles: int,
 ) -> tuple[int, int]:
     """Compute new ELO ratings after a match.
 
+    Each player's K factor is determined independently by their battle count,
+    so a provisional player's rating moves more than an established player's.
+
     Args:
-        rating_a: Current ELO rating of player A.
-        rating_b: Current ELO rating of player B.
-        score_a: Actual score for A (1.0 = win, 0.0 = loss).
-        k: K-factor controlling rating volatility.
+        winner_elo: Current ELO rating of the winner.
+        loser_elo: Current ELO rating of the loser.
+        winner_battles: Number of battles the winner has played (before this one).
+        loser_battles: Number of battles the loser has played (before this one).
 
     Returns:
-        Tuple of (new_rating_a, new_rating_b).
+        Tuple of (new_winner_elo, new_loser_elo).
     """
-    ea = expected_score(rating_a, rating_b)
-    score_b = 1.0 - score_a
+    e_winner = expected_score(winner_elo, loser_elo)
+    e_loser = 1.0 - e_winner
 
-    new_a = round(rating_a + k * (score_a - ea))
-    new_b = round(rating_b + k * (score_b - (1.0 - ea)))
+    k_winner = k_factor(winner_battles)
+    k_loser = k_factor(loser_battles)
 
-    return new_a, new_b
+    new_winner = round(winner_elo + k_winner * (1.0 - e_winner))
+    new_loser = round(loser_elo + k_loser * (0.0 - e_loser))
+
+    return new_winner, new_loser
+
+
+def trakt_rating_to_seeded_elo(rating: int) -> int:
+    """Convert a Trakt rating (1-10) to a seeded ELO.
+
+    Maps 1->600, 5->~956, 10->1400.
+    """
+    return round(600 + (rating - 1) * (800 / 9))
+
+
+def elo_to_trakt_rating(elo: int) -> int:
+    """Convert ELO to Trakt's 1-10 scale."""
+    return max(1, min(10, round((elo - 600) * 9 / 800) + 1))
+
+
+def get_initial_elo(seeded_elo: int | None) -> int:
+    """Return the starting ELO for a film.
+
+    Uses the seeded ELO (derived from Trakt rating) if available,
+    otherwise falls back to the default 1000.
+    """
+    return seeded_elo if seeded_elo is not None else DEFAULT_ELO
 
 
 def outcome_to_scores(outcome: str) -> tuple[float, float]:
@@ -55,16 +97,3 @@ def outcome_to_scores(outcome: str) -> tuple[float, float]:
         "neither": (0.0, 0.0),
     }
     return mapping[outcome]
-
-
-def trakt_rating_to_elo(trakt_rating: int) -> int:
-    """Convert a Trakt rating (1-10) to starting ELO.
-
-    Maps 1->600, 5.5->1000, 10->1400.
-    """
-    return round(600 + (trakt_rating - 1) * (800 / 9))
-
-
-def elo_to_trakt_rating(elo: int) -> int:
-    """Convert ELO to Trakt's 1-10 scale."""
-    return max(1, min(10, round((elo - 600) * 9 / 800) + 1))

--- a/backend/tests/test_elo.py
+++ b/backend/tests/test_elo.py
@@ -1,6 +1,32 @@
 """Tests for ELO calculation logic."""
 
-from backend.services.elo import expected_score, update_elo
+from backend.services.elo import (
+    elo_to_trakt_rating,
+    expected_score,
+    get_initial_elo,
+    k_factor,
+    outcome_to_scores,
+    trakt_rating_to_seeded_elo,
+    update_elo,
+)
+
+
+# --- k_factor ---
+
+
+def test_k_factor_provisional():
+    """Battles 0-4 should return K=64."""
+    for b in range(5):
+        assert k_factor(b) == 64, f"Expected 64 for {b} battles"
+
+
+def test_k_factor_established():
+    """Battles 5+ should return K=32."""
+    for b in (5, 10, 100):
+        assert k_factor(b) == 32, f"Expected 32 for {b} battles"
+
+
+# --- expected_score ---
 
 
 def test_expected_score_equal_ratings():
@@ -18,21 +44,101 @@ def test_expected_scores_sum_to_one():
     assert abs(e1 + e2 - 1.0) < 1e-10
 
 
+# --- update_elo ---
+
+
 def test_update_elo_winner_gains():
-    """A wins: score_a=1.0 means A won."""
-    new_a, new_b = update_elo(1000, 1000, score_a=1.0)
-    assert new_a > 1000
-    assert new_b < 1000
+    new_w, new_l = update_elo(1000, 1000, winner_battles=10, loser_battles=10)
+    assert new_w > 1000
+    assert new_l < 1000
 
 
-def test_update_elo_conserved():
-    new_a, new_b = update_elo(1000, 1000, score_a=1.0)
-    assert new_a + new_b == 2000
+def test_update_elo_equal_established():
+    """Two established players at equal rating: winner gains K/2 = 16."""
+    new_w, new_l = update_elo(1000, 1000, winner_battles=10, loser_battles=10)
+    assert new_w == 1016
+    assert new_l == 984
 
 
-def test_update_elo_equal_ratings_change():
-    new_a, _ = update_elo(1000, 1000, score_a=1.0, k=32)
-    assert new_a == 1016
+def test_update_elo_provisional_winner():
+    """Provisional winner (K=64) vs established loser (K=32) at equal rating."""
+    new_w, new_l = update_elo(1000, 1000, winner_battles=2, loser_battles=10)
+    # winner gains 64 * 0.5 = 32, loser loses 32 * 0.5 = 16
+    assert new_w == 1032
+    assert new_l == 984
+
+
+def test_update_elo_provisional_loser():
+    """Established winner (K=32) vs provisional loser (K=64) at equal rating."""
+    new_w, new_l = update_elo(1000, 1000, winner_battles=10, loser_battles=2)
+    # winner gains 32 * 0.5 = 16, loser loses 64 * 0.5 = 32
+    assert new_w == 1016
+    assert new_l == 968
+
+
+def test_update_elo_both_provisional():
+    """Two provisional players at equal rating."""
+    new_w, new_l = update_elo(1000, 1000, winner_battles=0, loser_battles=0)
+    # both K=64: winner gains 32, loser loses 32
+    assert new_w == 1032
+    assert new_l == 968
+
+
+# --- trakt_rating_to_seeded_elo ---
+
+
+def test_trakt_rating_to_seeded_elo_min():
+    assert trakt_rating_to_seeded_elo(1) == 600
+
+
+def test_trakt_rating_to_seeded_elo_mid():
+    elo = trakt_rating_to_seeded_elo(5)
+    # (5-1) * 800/9 + 600 = 955.56 -> 956
+    assert elo == 956
+
+
+def test_trakt_rating_to_seeded_elo_max():
+    assert trakt_rating_to_seeded_elo(10) == 1400
+
+
+# --- elo_to_trakt_rating ---
+
+
+def test_elo_to_trakt_rating_boundaries():
+    assert elo_to_trakt_rating(600) == 1
+    assert elo_to_trakt_rating(1400) == 10
+
+
+def test_elo_to_trakt_rating_clamps():
+    assert elo_to_trakt_rating(100) == 1
+    assert elo_to_trakt_rating(2000) == 10
+
+
+def test_trakt_rating_round_trip():
+    """Converting trakt->elo->trakt should preserve the original rating."""
+    for r in range(1, 11):
+        elo = trakt_rating_to_seeded_elo(r)
+        assert elo_to_trakt_rating(elo) == r
+
+
+# --- get_initial_elo ---
+
+
+def test_get_initial_elo_with_seed():
+    assert get_initial_elo(1200) == 1200
+
+
+def test_get_initial_elo_without_seed():
+    assert get_initial_elo(None) == 1000
+
+
+# --- outcome_to_scores ---
+
+
+def test_outcome_to_scores():
+    assert outcome_to_scores("a_wins") == (1.0, 0.0)
+    assert outcome_to_scores("b_wins") == (0.0, 1.0)
+    assert outcome_to_scores("neither") == (0.0, 0.0)
 
 
 def test_health_endpoint():


### PR DESCRIPTION
## Summary
- Rewrote ELO calculation with per-player K factors: provisional (< 5 battles) K=64, established K=32
- Added `k_factor`, `trakt_rating_to_seeded_elo`, `get_initial_elo` functions
- Changed `update_elo` signature to winner/loser with battle counts
- Updated duels router to use new winner/loser API
- 19 tests covering all ELO functions

## Test plan
- [x] All 19 ELO unit tests pass
- [ ] Manual test: duel submission still works end-to-end
- [ ] Verify provisional players' ratings move faster than established

🤖 Generated with [Claude Code](https://claude.com/claude-code)