### PR TITLE
feat: rewrite TraktClient with explicit init and httpx base_url

### DIFF
--- a/backend/routers/auth.py
+++ b/backend/routers/auth.py
@@ -77,8 +77,13 @@ async def ensure_fresh_token(user: User, db: AsyncSession) -> User:
     if expires_at - now > timedelta(hours=1):
         return user
 
-    client = TraktClient()
-    tokens = await client.refresh_token(user.trakt_refresh_token)
+    settings = get_settings()
+    client = TraktClient(client_id=settings.TRAKT_CLIENT_ID)
+    tokens = await client.refresh_token(
+        user.trakt_refresh_token,
+        client_secret=settings.TRAKT_CLIENT_SECRET,
+        redirect_uri=settings.TRAKT_REDIRECT_URI,
+    )
 
     user.trakt_access_token = tokens["access_token"]
     user.trakt_refresh_token = tokens.get("refresh_token", user.trakt_refresh_token)
@@ -111,12 +116,19 @@ async def callback(
     db: AsyncSession = Depends(get_db),
 ):
     """Handle the OAuth callback from Trakt."""
-    client = TraktClient()
-    tokens = await client.exchange_code(code)
+    client = TraktClient(client_id=settings.TRAKT_CLIENT_ID)
+    tokens = await client.exchange_code(
+        code,
+        client_secret=settings.TRAKT_CLIENT_SECRET,
+        redirect_uri=settings.TRAKT_REDIRECT_URI,
+    )
 
     # Fetch user profile
-    authed_client = TraktClient(access_token=tokens["access_token"])
-    profile = await authed_client.get_user_profile()
+    authed_client = TraktClient(
+        client_id=settings.TRAKT_CLIENT_ID,
+        access_token=tokens["access_token"],
+    )
+    profile = await authed_client.get_profile()
 
     trakt_user_id = str(profile["ids"]["slug"])
     expires_at = datetime.now(timezone.utc) + timedelta(

--- a/backend/services/sync.py
+++ b/backend/services/sync.py
@@ -11,6 +11,7 @@ from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import joinedload
 
+from backend.config import get_settings
 from backend.db_models import UserMovie
 from backend.services.elo import elo_to_trakt_rating
 from backend.services.trakt import TraktClient
@@ -50,7 +51,8 @@ async def sync_post_duel(
         access_token: User's current Trakt access token.
         movie_ratings: List of (trakt_id, elo) pairs to sync.
     """
-    client = TraktClient(access_token=access_token)
+    settings = get_settings()
+    client = TraktClient(client_id=settings.TRAKT_CLIENT_ID, access_token=access_token)
     for trakt_id, elo in movie_ratings:
         rating = elo_to_trakt_rating(elo)
         await _rate_with_retry(client, trakt_id, rating)
@@ -65,7 +67,8 @@ async def sync_ratings_to_trakt(
 
     Returns a summary of synced/failed counts.
     """
-    client = TraktClient(access_token=access_token)
+    settings = get_settings()
+    client = TraktClient(client_id=settings.TRAKT_CLIENT_ID, access_token=access_token)
 
     stmt = (
         select(UserMovie)

--- a/backend/services/trakt.py
+++ b/backend/services/trakt.py
@@ -2,137 +2,138 @@
 
 from __future__ import annotations
 
-from typing import Any, Optional
-
 import httpx
-
-from backend.config import get_settings
-
-TRAKT_API_URL = "https://api.trakt.tv"
 
 
 class TraktClient:
     """Async client for the Trakt.tv API."""
 
-    def __init__(self, access_token: Optional[str] = None) -> None:
-        settings = get_settings()
-        self.client_id = settings.TRAKT_CLIENT_ID
-        self.client_secret = settings.TRAKT_CLIENT_SECRET
-        self.redirect_uri = settings.TRAKT_REDIRECT_URI
-        self.access_token = access_token
+    BASE_URL = "https://api.trakt.tv"
 
-    @property
-    def _headers(self) -> dict[str, str]:
-        headers = {
+    def __init__(self, client_id: str, access_token: str | None = None) -> None:
+        self._headers: dict[str, str] = {
             "Content-Type": "application/json",
             "trakt-api-version": "2",
-            "trakt-api-key": self.client_id,
+            "trakt-api-key": client_id,
         }
-        if self.access_token:
-            headers["Authorization"] = f"Bearer {self.access_token}"
-        return headers
+        self._client_id = client_id
+        if access_token:
+            self._headers["Authorization"] = f"Bearer {access_token}"
 
-    async def exchange_code(self, code: str) -> dict[str, Any]:
+    def _client(self) -> httpx.AsyncClient:
+        return httpx.AsyncClient(
+            base_url=self.BASE_URL,
+            headers=self._headers,
+        )
+
+    async def exchange_code(
+        self, code: str, client_secret: str, redirect_uri: str
+    ) -> dict:
         """Exchange an OAuth authorization code for tokens."""
-        async with httpx.AsyncClient() as client:
+        async with self._client() as client:
             resp = await client.post(
-                f"{TRAKT_API_URL}/oauth/token",
+                "/oauth/token",
                 json={
                     "code": code,
-                    "client_id": self.client_id,
-                    "client_secret": self.client_secret,
-                    "redirect_uri": self.redirect_uri,
+                    "client_id": self._client_id,
+                    "client_secret": client_secret,
+                    "redirect_uri": redirect_uri,
                     "grant_type": "authorization_code",
                 },
-                headers=self._headers,
             )
             resp.raise_for_status()
             return resp.json()
 
-    async def refresh_token(self, refresh_token: str) -> dict[str, Any]:
+    async def refresh_token(
+        self, refresh_token: str, client_secret: str, redirect_uri: str
+    ) -> dict:
         """Exchange a refresh token for a new access token."""
-        async with httpx.AsyncClient() as client:
+        async with self._client() as client:
             resp = await client.post(
-                f"{TRAKT_API_URL}/oauth/token",
+                "/oauth/token",
                 json={
                     "refresh_token": refresh_token,
-                    "client_id": self.client_id,
-                    "client_secret": self.client_secret,
-                    "redirect_uri": self.redirect_uri,
+                    "client_id": self._client_id,
+                    "client_secret": client_secret,
+                    "redirect_uri": redirect_uri,
                     "grant_type": "refresh_token",
                 },
-                headers=self._headers,
             )
             resp.raise_for_status()
             return resp.json()
 
-    async def get_user_profile(self) -> dict[str, Any]:
+    async def get_profile(self) -> dict:
         """Fetch the authenticated user's profile."""
-        async with httpx.AsyncClient() as client:
-            resp = await client.get(
-                f"{TRAKT_API_URL}/users/me",
-                headers=self._headers,
-            )
+        async with self._client() as client:
+            resp = await client.get("/users/me")
             resp.raise_for_status()
             return resp.json()
 
-    async def get_popular_movies(self, page: int = 1, limit: int = 50) -> list[dict[str, Any]]:
+    async def get_popular(self, limit: int = 100) -> list[dict]:
         """Fetch popular movies."""
-        async with httpx.AsyncClient() as client:
+        async with self._client() as client:
             resp = await client.get(
-                f"{TRAKT_API_URL}/movies/popular",
-                headers=self._headers,
-                params={"page": page, "limit": limit, "extended": "full"},
+                "/movies/popular",
+                params={"limit": limit, "extended": "full"},
             )
             resp.raise_for_status()
             return resp.json()
 
-    async def get_trending_movies(self, page: int = 1, limit: int = 50) -> list[dict[str, Any]]:
-        """Fetch trending movies."""
-        async with httpx.AsyncClient() as client:
+    async def get_trending(self, limit: int = 100) -> list[dict]:
+        """Fetch trending movies.
+
+        Trending returns [{watchers, movie}, ...] — this extracts the movie
+        dicts.
+        """
+        async with self._client() as client:
             resp = await client.get(
-                f"{TRAKT_API_URL}/movies/trending",
-                headers=self._headers,
-                params={"page": page, "limit": limit, "extended": "full"},
+                "/movies/trending",
+                params={"limit": limit, "extended": "full"},
             )
             resp.raise_for_status()
-            return resp.json()
+            return [item["movie"] for item in resp.json()]
 
-    async def get_user_watched(self, username: str) -> list[dict[str, Any]]:
-        """Fetch a user's watched movie history."""
-        async with httpx.AsyncClient() as client:
+    async def get_user_watched(self, username: str) -> list[dict]:
+        """Fetch a user's watched movies.
+
+        Returns [{plays, last_watched_at, movie}, ...] — this extracts the
+        movie dicts.
+        """
+        async with self._client() as client:
             resp = await client.get(
-                f"{TRAKT_API_URL}/users/{username}/watched/movies",
-                headers=self._headers,
+                f"/users/{username}/watched/movies",
                 params={"extended": "full"},
             )
             resp.raise_for_status()
-            return resp.json()
+            return [item["movie"] for item in resp.json()]
 
-    async def get_user_ratings(self, username: str) -> list[dict[str, Any]]:
-        """Fetch a user's movie ratings."""
-        async with httpx.AsyncClient() as client:
+    async def get_user_ratings(self, username: str) -> list[dict]:
+        """Fetch a user's movie ratings.
+
+        Returns [{rating, movie}, ...] — keeps rating + movie.ids.trakt.
+        """
+        async with self._client() as client:
             resp = await client.get(
-                f"{TRAKT_API_URL}/users/{username}/ratings/movies",
-                headers=self._headers,
+                f"/users/{username}/ratings/movies",
             )
             resp.raise_for_status()
-            return resp.json()
+            return [
+                {"rating": item["rating"], "trakt_id": item["movie"]["ids"]["trakt"]}
+                for item in resp.json()
+            ]
 
-    async def rate_movie(self, trakt_id: int, rating: int) -> dict[str, Any]:
+    async def rate_movie(self, trakt_id: int, rating: int) -> None:
         """Submit a rating for a movie (1-10 scale)."""
-        async with httpx.AsyncClient() as client:
+        async with self._client() as client:
             resp = await client.post(
-                f"{TRAKT_API_URL}/sync/ratings",
-                headers=self._headers,
+                "/sync/ratings",
                 json={
                     "movies": [
                         {
-                            "ids": {"trakt": trakt_id},
                             "rating": rating,
+                            "ids": {"trakt": trakt_id},
                         }
                     ]
                 },
             )
             resp.raise_for_status()
-            return resp.json()


### PR DESCRIPTION
## Summary
- Rewrote `TraktClient` to accept `client_id` and `access_token` as explicit constructor args instead of pulling from settings internally
- Uses `httpx.AsyncClient` with `base_url` and context manager pattern (one client per method call)
- `get_trending()` and `get_user_watched()` now extract movie dicts from wrapper objects
- `get_user_ratings()` returns `[{rating, trakt_id}]` instead of raw Trakt response
- `rate_movie()` returns `None` instead of the response body
- Updated all callers in `auth.py` and `sync.py` to pass settings explicitly

## Test plan
- [ ] Verify OAuth login flow still works (exchange_code + get_profile)
- [ ] Verify token refresh works in ensure_fresh_token
- [ ] Verify post-duel rating sync works
- [ ] Verify full rating sync works

🤖 Generated with [Claude Code](https://claude.com/claude-code)