### PR TITLE
feat: schema v2 — seeded_elo, nullable elo, duel mode

### DIFF
--- a/backend/db_models.py
+++ b/backend/db_models.py
@@ -73,7 +73,12 @@ class UserMovie(Base):
         UniqueConstraint("user_id", "movie_id"),
         Index("ix_user_movies_user_id", "user_id"),
         Index("ix_user_movies_user_seen", "user_id", "seen"),
-        Index("ix_user_movies_user_elo", "user_id", "elo"),
+        Index(
+            "ix_user_movies_user_elo",
+            "user_id",
+            "elo",
+            postgresql_where="elo IS NOT NULL",
+        ),
     )
 
     id: Mapped[uuid.UUID] = mapped_column(
@@ -86,7 +91,8 @@ class UserMovie(Base):
         UUID(as_uuid=True), ForeignKey("movies.id", ondelete="CASCADE"), nullable=False
     )
     seen: Mapped[Optional[bool]] = mapped_column(Boolean, nullable=True)
-    elo: Mapped[int] = mapped_column(Integer, nullable=False, default=1000)
+    elo: Mapped[Optional[int]] = mapped_column(Integer, nullable=True, default=None)
+    seeded_elo: Mapped[Optional[int]] = mapped_column(Integer, nullable=True)
     battles: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
     trakt_rating: Mapped[Optional[int]] = mapped_column(Integer, nullable=True)
     last_dueled_at: Mapped[Optional[datetime]] = mapped_column(
@@ -120,6 +126,7 @@ class Duel(Base):
     loser_elo_before: Mapped[Optional[int]] = mapped_column(Integer, nullable=True)
     winner_elo_after: Mapped[Optional[int]] = mapped_column(Integer, nullable=True)
     loser_elo_after: Mapped[Optional[int]] = mapped_column(Integer, nullable=True)
+    mode: Mapped[str] = mapped_column(Text, nullable=False, server_default="discovery")
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), default=lambda: datetime.now(timezone.utc)
     )

--- a/backend/migrations/versions/002_add_seeded_elo_nullable_elo_mode.py
+++ b/backend/migrations/versions/002_add_seeded_elo_nullable_elo_mode.py
@@ -1,0 +1,67 @@
+"""Add seeded_elo, nullable elo, mode on duels
+
+Revision ID: 002
+Revises: 001
+Create Date: 2026-04-11
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+revision: str = "002"
+down_revision: Union[str, None] = "001"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    # Add seeded_elo column to user_movies
+    op.add_column(
+        "user_movies",
+        sa.Column("seeded_elo", sa.Integer(), nullable=True),
+    )
+
+    # Make elo nullable and change default from 1000 to NULL
+    op.alter_column(
+        "user_movies",
+        "elo",
+        existing_type=sa.Integer(),
+        nullable=True,
+        server_default=None,
+    )
+
+    # Drop old non-partial index, recreate as partial (WHERE elo IS NOT NULL)
+    op.drop_index("ix_user_movies_user_elo", table_name="user_movies")
+    op.execute(
+        'CREATE INDEX ix_user_movies_user_elo ON user_movies (user_id, elo) '
+        'WHERE elo IS NOT NULL'
+    )
+
+    # Add mode column to duels
+    op.add_column(
+        "duels",
+        sa.Column("mode", sa.Text(), nullable=False, server_default="discovery"),
+    )
+
+
+def downgrade() -> None:
+    # Remove mode from duels
+    op.drop_column("duels", "mode")
+
+    # Restore non-partial index
+    op.drop_index("ix_user_movies_user_elo", table_name="user_movies")
+    op.create_index("ix_user_movies_user_elo", "user_movies", ["user_id", "elo"])
+
+    # Revert elo to non-nullable with default 1000
+    op.execute("UPDATE user_movies SET elo = 1000 WHERE elo IS NULL")
+    op.alter_column(
+        "user_movies",
+        "elo",
+        existing_type=sa.Integer(),
+        nullable=False,
+        server_default="1000",
+    )
+
+    # Drop seeded_elo
+    op.drop_column("user_movies", "seeded_elo")

--- a/backend/schemas.py
+++ b/backend/schemas.py
@@ -44,6 +44,7 @@ class DuelSubmit(BaseModel):
     movie_a_id: str
     movie_b_id: str
     outcome: DuelOutcome
+    mode: str = "discovery"
 
 
 class DuelResult(BaseModel):


### PR DESCRIPTION
## Summary
- Make `elo` nullable (default NULL) on `user_movies` to support discovery flow where new movies start unranked
- Add `seeded_elo` column to `user_movies` for storing ELO seed from Trakt rating import
- Add `mode` column (`discovery`/`refinement`/`playoff`) to `duels` table with server_default `discovery`
- Update `DuelSubmit` Pydantic schema to accept `mode` parameter
- Convert `ix_user_movies_user_elo` index to partial index (`WHERE elo IS NOT NULL`)
- Alembic migration 002 with full upgrade/downgrade support

## Test plan
- [ ] Run `alembic upgrade head` against dev database
- [ ] Verify new columns exist with correct types and defaults
- [ ] Verify partial index is created correctly
- [ ] Run `alembic downgrade 001` to confirm rollback works
- [ ] Verify API still accepts DuelSubmit with and without mode field

🤖 Generated with [Claude Code](https://claude.com/claude-code)