### PR TITLE
feat: add TMDB poster fetching

### DIFF
--- a/backend/routers/auth.py
+++ b/backend/routers/auth.py
@@ -7,15 +7,16 @@ from datetime import datetime, timedelta, timezone
 from urllib.parse import urlencode
 
 import jwt
-from fastapi import APIRouter, Depends, HTTPException, Request, Response
+from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException, Request, Response
 from fastapi.responses import RedirectResponse
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from backend.config import Settings, get_settings
-from backend.db import get_db
+from backend.db import async_session_factory, get_db
 from backend.db_models import User
 from backend.schemas import UserResponse
+from backend.services.tmdb import backfill_posters
 from backend.services.trakt import TraktClient
 
 router = APIRouter(prefix="/api/auth", tags=["auth"])
@@ -96,6 +97,12 @@ async def ensure_fresh_token(user: User, db: AsyncSession) -> User:
     return user
 
 
+async def _backfill_posters_background() -> None:
+    """Run poster backfill in a standalone session (background task)."""
+    async with async_session_factory() as session:
+        await backfill_posters(session)
+
+
 @router.get("/login")
 async def login(settings: Settings = Depends(get_settings)):
     """Redirect the user to Trakt's OAuth authorization page."""
@@ -112,6 +119,7 @@ async def login(settings: Settings = Depends(get_settings)):
 @router.get("/callback")
 async def callback(
     code: str,
+    background_tasks: BackgroundTasks,
     settings: Settings = Depends(get_settings),
     db: AsyncSession = Depends(get_db),
 ):
@@ -157,6 +165,9 @@ async def callback(
         db.add(user)
 
     await db.flush()
+
+    # Backfill missing poster URLs in the background
+    background_tasks.add_task(_backfill_posters_background)
 
     # Set session cookie
     token = create_jwt(str(user.id), settings)

--- a/backend/services/tmdb.py
+++ b/backend/services/tmdb.py
@@ -1,0 +1,60 @@
+"""TMDB API client — fetch poster URLs for movies."""
+
+from __future__ import annotations
+
+import logging
+
+import httpx
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from backend.config import get_settings
+from backend.db_models import Movie
+
+logger = logging.getLogger(__name__)
+
+
+async def fetch_poster_url(tmdb_id: int) -> str | None:
+    """Fetch poster URL from TMDB API. Returns full URL or None."""
+    settings = get_settings()
+    if not settings.TMDB_API_KEY or not tmdb_id:
+        return None
+    async with httpx.AsyncClient() as client:
+        resp = await client.get(
+            f"https://api.themoviedb.org/3/movie/{tmdb_id}",
+            params={"api_key": settings.TMDB_API_KEY},
+        )
+        if resp.status_code != 200:
+            logger.warning("TMDB API returned %d for tmdb_id=%d", resp.status_code, tmdb_id)
+            return None
+        data = resp.json()
+        poster_path = data.get("poster_path")
+        if poster_path:
+            return f"https://image.tmdb.org/t/p/w500{poster_path}"
+        return None
+
+
+async def backfill_posters(db: AsyncSession) -> None:
+    """Fetch poster URLs for movies that have tmdb_id but no poster_url."""
+    stmt = (
+        select(Movie)
+        .where(Movie.tmdb_id.isnot(None), Movie.poster_url.is_(None))
+        .limit(50)
+    )
+    result = await db.execute(stmt)
+    movies = result.scalars().all()
+
+    if not movies:
+        return
+
+    logger.info("Backfilling posters for %d movies", len(movies))
+    filled = 0
+    for movie in movies:
+        url = await fetch_poster_url(movie.tmdb_id)
+        if url:
+            movie.poster_url = url
+            filled += 1
+
+    if filled:
+        await db.commit()
+        logger.info("Backfilled %d poster URLs", filled)


### PR DESCRIPTION
## Summary
- Adds `backend/services/tmdb.py` with `fetch_poster_url()` and `backfill_posters()` functions
- `fetch_poster_url` hits TMDB API v3 to get poster path, returns full `image.tmdb.org/t/p/w500` URL
- `backfill_posters` queries up to 50 movies with `tmdb_id` but no `poster_url` and fills them in
- Hooks into auth callback as a `BackgroundTasks` task so posters are backfilled on each login

## Test plan
- [ ] Set `TMDB_API_KEY` env var and verify poster URLs populate after login
- [ ] Verify movies without `tmdb_id` are skipped
- [ ] Verify backfill is batched to 50 and commits only when URLs are found

🤖 Generated with [Claude Code](https://claude.com/claude-code)