### PR TITLE
feat: movie pool import from Trakt

### DIFF
--- a/backend/routers/auth.py
+++ b/backend/routers/auth.py
@@ -16,6 +16,7 @@ from backend.config import Settings, get_settings
 from backend.db import async_session_factory, get_db
 from backend.db_models import User
 from backend.schemas import UserResponse
+from backend.services.pool import populate_movie_pool
 from backend.services.tmdb import backfill_posters
 from backend.services.trakt import TraktClient
 
@@ -103,6 +104,23 @@ async def _backfill_posters_background() -> None:
         await backfill_posters(session)
 
 
+async def _sync_pool_background(user_id) -> None:
+    """Run pool sync in a background task with its own DB session."""
+    import logging
+
+    logger = logging.getLogger(__name__)
+    try:
+        async with async_session_factory() as session:
+            stmt = select(User).where(User.id == user_id)
+            result = await session.execute(stmt)
+            user = result.scalar_one_or_none()
+            if user:
+                await populate_movie_pool(user, session)
+                await session.commit()
+    except Exception:
+        logger.exception("Background pool sync failed for user %s", user_id)
+
+
 @router.get("/login")
 async def login(settings: Settings = Depends(get_settings)):
     """Redirect the user to Trakt's OAuth authorization page."""
@@ -153,7 +171,7 @@ async def callback(
         user.trakt_access_token = tokens["access_token"]
         user.trakt_refresh_token = tokens.get("refresh_token", "")
         user.trakt_token_expires_at = expires_at
-        user.last_seen_at = datetime.now(timezone.utc)
+        # Note: last_seen_at is updated by populate_movie_pool after sync
     else:
         user = User(
             trakt_user_id=trakt_user_id,
@@ -165,6 +183,10 @@ async def callback(
         db.add(user)
 
     await db.flush()
+
+    # Kick off movie pool import in the background (uses its own DB session)
+    user_id = user.id
+    background_tasks.add_task(_sync_pool_background, user_id)
 
     # Backfill missing poster URLs in the background
     background_tasks.add_task(_backfill_posters_background)

--- a/backend/services/pool.py
+++ b/backend/services/pool.py
@@ -1,0 +1,153 @@
+"""Movie pool import — fetches movies from Trakt and populates the local DB."""
+
+from __future__ import annotations
+
+import logging
+from datetime import datetime, timedelta, timezone
+
+from sqlalchemy import select
+from sqlalchemy.dialects.postgresql import insert
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from backend.config import get_settings
+from backend.db_models import Movie, User, UserMovie
+from backend.services.elo import trakt_rating_to_seeded_elo
+from backend.services.trakt import TraktClient
+
+logger = logging.getLogger(__name__)
+
+SYNC_COOLDOWN = timedelta(hours=1)
+
+
+async def populate_movie_pool(user: User, db: AsyncSession) -> None:
+    """Fetch movies from Trakt and populate the user's movie pool.
+
+    Called on login/session start. Throttled to once per hour.
+    """
+    now = datetime.now(timezone.utc)
+    last_seen = user.last_seen_at
+    if last_seen and last_seen.tzinfo is None:
+        last_seen = last_seen.replace(tzinfo=timezone.utc)
+    if last_seen and (now - last_seen) < SYNC_COOLDOWN:
+        logger.info("Skipping pool sync for %s — synced recently", user.trakt_username)
+        return
+
+    settings = get_settings()
+    client = TraktClient(
+        client_id=settings.TRAKT_CLIENT_ID,
+        access_token=user.trakt_access_token,
+    )
+
+    # Fetch all sources concurrently-ish (serial to respect Trakt rate limits)
+    popular = await client.get_popular(limit=100)
+    trending = await client.get_trending(limit=100)
+    watched = await client.get_user_watched(user.trakt_username)
+    ratings_list = await client.get_user_ratings(user.trakt_username)
+
+    # Build ratings lookup: trakt_id -> rating (1-10)
+    ratings_by_trakt_id: dict[int, int] = {
+        r["trakt_id"]: r["rating"] for r in ratings_list
+    }
+
+    # Collect all unique movies, tracking their source
+    # movie_data keyed by trakt_id -> (movie_dict, seen)
+    movie_pool: dict[int, dict] = {}
+    seen_trakt_ids: set[int] = set()
+
+    for movie in popular + trending:
+        trakt_id = movie["ids"]["trakt"]
+        if trakt_id not in movie_pool:
+            movie_pool[trakt_id] = movie
+
+    for movie in watched:
+        trakt_id = movie["ids"]["trakt"]
+        seen_trakt_ids.add(trakt_id)
+        if trakt_id not in movie_pool:
+            movie_pool[trakt_id] = movie
+
+    if not movie_pool:
+        logger.info("No movies fetched for %s", user.trakt_username)
+        return
+
+    # Upsert movies into the movies table
+    for movie_data in movie_pool.values():
+        ids = movie_data.get("ids", {})
+        stmt = insert(Movie.__table__).values(
+            trakt_id=ids["trakt"],
+            imdb_id=ids.get("imdb"),
+            tmdb_id=ids.get("tmdb"),
+            title=movie_data.get("title", "Unknown"),
+            year=movie_data.get("year"),
+            genres=movie_data.get("genres"),
+            overview=movie_data.get("overview"),
+            runtime=movie_data.get("runtime"),
+            cached_at=now,
+        ).on_conflict_do_update(
+            index_elements=["trakt_id"],
+            set_={
+                "imdb_id": ids.get("imdb"),
+                "tmdb_id": ids.get("tmdb"),
+                "title": movie_data.get("title", "Unknown"),
+                "year": movie_data.get("year"),
+                "genres": movie_data.get("genres"),
+                "overview": movie_data.get("overview"),
+                "runtime": movie_data.get("runtime"),
+                "cached_at": now,
+            },
+        )
+        await db.execute(stmt)
+
+    await db.flush()
+
+    # Fetch all movie rows we just upserted to get their UUIDs
+    trakt_ids = list(movie_pool.keys())
+    result = await db.execute(
+        select(Movie.id, Movie.trakt_id).where(Movie.trakt_id.in_(trakt_ids))
+    )
+    movie_uuid_map: dict[int, str] = {row.trakt_id: row.id for row in result.all()}
+
+    # Upsert user_movies
+    for trakt_id, movie_data in movie_pool.items():
+        movie_uuid = movie_uuid_map.get(trakt_id)
+        if not movie_uuid:
+            continue
+
+        seen = True if trakt_id in seen_trakt_ids else None
+        rating = ratings_by_trakt_id.get(trakt_id)
+        seeded_elo = trakt_rating_to_seeded_elo(rating) if rating is not None else None
+
+        stmt = insert(UserMovie.__table__).values(
+            user_id=user.id,
+            movie_id=movie_uuid,
+            seen=seen,
+            elo=None,
+            seeded_elo=seeded_elo,
+            battles=0,
+            trakt_rating=rating,
+            updated_at=now,
+        ).on_conflict_do_update(
+            index_elements=["user_id", "movie_id"],
+            set_={
+                # Update seen if we now know they watched it
+                "seen": seen if seen is True else UserMovie.__table__.c.seen,
+                # Update seeded_elo and rating if we have new data
+                "seeded_elo": seeded_elo
+                if seeded_elo is not None
+                else UserMovie.__table__.c.seeded_elo,
+                "trakt_rating": rating
+                if rating is not None
+                else UserMovie.__table__.c.trakt_rating,
+                "updated_at": now,
+            },
+        )
+        await db.execute(stmt)
+
+    # Update last_seen_at
+    user.last_seen_at = now
+    await db.flush()
+
+    logger.info(
+        "Pool sync complete for %s: %d movies imported",
+        user.trakt_username,
+        len(movie_pool),
+    )


### PR DESCRIPTION
## Summary
- Adds `backend/services/pool.py` with `populate_movie_pool()` that fetches popular (100), trending (100), user watched history, and user ratings from Trakt, then upserts into `movies` and `user_movies` tables using PostgreSQL `ON CONFLICT DO UPDATE`
- Wired into OAuth callback in `backend/routers/auth.py` as a `BackgroundTask` so login redirect is not blocked
- Throttled to once per hour via `last_seen_at` check; `last_seen_at` is updated only after successful sync

## Test plan
- [ ] Login via Trakt OAuth and verify movies appear in the DB
- [ ] Login again within 1 hour and verify sync is skipped (check logs)
- [ ] Verify watched movies get `seen=True`, popular/trending get `seen=None`
- [ ] Verify rated movies get `seeded_elo` calculated from `trakt_rating_to_seeded_elo()`
- [ ] Verify existing user_movies rows are updated (not duplicated) on re-sync

🤖 Generated with [Claude Code](https://claude.com/claude-code)