### PR TITLE
feat: rewrite duels endpoint for ELO v2 and film state model

### DIFF
--- a/backend/routers/duels.py
+++ b/backend/routers/duels.py
@@ -14,7 +14,7 @@ from backend.db import async_session_factory, get_db
 from backend.db_models import Duel, Movie, User, UserMovie
 from backend.schemas import DuelSubmit, DuelResult
 from backend.routers.auth import get_current_user
-from backend.services.elo import outcome_to_scores, update_elo
+from backend.services.elo import get_initial_elo, update_elo
 from backend.services.sync import sync_post_duel
 
 logger = logging.getLogger(__name__)
@@ -60,6 +60,7 @@ async def submit_duel(
     movie_a_id = uuid.UUID(body.movie_a_id)
     movie_b_id = uuid.UUID(body.movie_b_id)
     outcome = body.outcome.value
+    mode = body.mode
 
     async def get_or_create_user_movie(mid: uuid.UUID) -> UserMovie:
         stmt = select(UserMovie).where(
@@ -75,61 +76,91 @@ async def submit_duel(
 
     um_a = await get_or_create_user_movie(movie_a_id)
     um_b = await get_or_create_user_movie(movie_b_id)
-    old_elo_a = um_a.elo
-    old_elo_b = um_b.elo
 
-    if outcome == "a_only":
-        um_a.seen, um_b.seen = True, False
+    new_elo_a: int | None = um_a.elo
+    new_elo_b: int | None = um_b.elo
+    delta_a = 0
+    delta_b = 0
+
+    if outcome in ("a_wins", "b_wins"):
+        # Both films become Ranked: seen=True, elo initialized, battles incremented
+        um_a.seen = True
+        um_b.seen = True
+
+        # Initialize ELO for first-time ranked films (elo is NULL, battles=0)
+        elo_a = um_a.elo if um_a.elo is not None else get_initial_elo(um_a.seeded_elo)
+        elo_b = um_b.elo if um_b.elo is not None else get_initial_elo(um_b.seeded_elo)
+
+        if outcome == "a_wins":
+            new_elo_a, new_elo_b = update_elo(
+                elo_a, elo_b, um_a.battles, um_b.battles
+            )
+        else:  # b_wins
+            new_elo_b, new_elo_a = update_elo(
+                elo_b, elo_a, um_b.battles, um_a.battles
+            )
+
+        delta_a = new_elo_a - elo_a
+        delta_b = new_elo_b - elo_b
+
+        um_a.elo = new_elo_a
+        um_b.elo = new_elo_b
+        um_a.battles += 1
+        um_b.battles += 1
+        um_a.last_dueled_at = datetime.now(timezone.utc)
+        um_b.last_dueled_at = datetime.now(timezone.utc)
+        um_a.updated_at = datetime.now(timezone.utc)
+        um_b.updated_at = datetime.now(timezone.utc)
+
+    elif outcome == "a_only":
+        # A -> seen (if was unknown/null), B -> unseen (never gets ELO)
+        if um_a.seen is None:
+            um_a.seen = True
+        um_b.seen = False
+        um_a.updated_at = datetime.now(timezone.utc)
+        um_b.updated_at = datetime.now(timezone.utc)
+
     elif outcome == "b_only":
-        um_a.seen, um_b.seen = False, True
-    elif outcome in ("a_wins", "b_wins", "draw"):
-        um_a.seen, um_b.seen = True, True
+        # B -> seen (if was unknown/null), A -> unseen (never gets ELO)
+        if um_b.seen is None:
+            um_b.seen = True
+        um_a.seen = False
+        um_a.updated_at = datetime.now(timezone.utc)
+        um_b.updated_at = datetime.now(timezone.utc)
+
     elif outcome == "neither":
-        um_a.seen, um_b.seen = False, False
+        # Both -> unseen
+        um_a.seen = False
+        um_b.seen = False
+        um_a.updated_at = datetime.now(timezone.utc)
+        um_b.updated_at = datetime.now(timezone.utc)
 
-    score_a, score_b = outcome_to_scores(outcome)
-    if outcome in ("neither", "a_only", "b_only"):
-        new_elo_a, new_elo_b = old_elo_a, old_elo_b
-    elif outcome == "a_wins":
-        new_elo_a, new_elo_b = update_elo(
-            old_elo_a, old_elo_b, um_a.battles, um_b.battles
-        )
-    else:  # b_wins
-        new_elo_b, new_elo_a = update_elo(
-            old_elo_b, old_elo_a, um_b.battles, um_a.battles
-        )
-
-    delta_a = new_elo_a - old_elo_a
-    delta_b = new_elo_b - old_elo_b
-
-    um_a.elo = new_elo_a
-    um_a.battles += 1
-    um_a.last_dueled_at = datetime.now(timezone.utc)
-    um_a.updated_at = datetime.now(timezone.utc)
-    um_b.elo = new_elo_b
-    um_b.battles += 1
-    um_b.last_dueled_at = datetime.now(timezone.utc)
-    um_b.updated_at = datetime.now(timezone.utc)
-
+    # Build duel record
     winner_id = loser_id = None
     w_elo_before = l_elo_before = w_elo_after = l_elo_after = None
-    if outcome in ("a_wins", "a_only"):
+    if outcome == "a_wins":
         winner_id, loser_id = movie_a_id, movie_b_id
-        w_elo_before, l_elo_before = old_elo_a, old_elo_b
+        w_elo_before, l_elo_before = elo_a, elo_b
         w_elo_after, l_elo_after = new_elo_a, new_elo_b
-    elif outcome in ("b_wins", "b_only"):
+    elif outcome == "b_wins":
         winner_id, loser_id = movie_b_id, movie_a_id
-        w_elo_before, l_elo_before = old_elo_b, old_elo_a
+        w_elo_before, l_elo_before = elo_b, elo_a
         w_elo_after, l_elo_after = new_elo_b, new_elo_a
 
     duel = Duel(
-        user_id=uid, winner_movie_id=winner_id, loser_movie_id=loser_id,
-        winner_elo_before=w_elo_before, loser_elo_before=l_elo_before,
-        winner_elo_after=w_elo_after, loser_elo_after=l_elo_after,
+        user_id=uid,
+        winner_movie_id=winner_id,
+        loser_movie_id=loser_id,
+        winner_elo_before=w_elo_before,
+        loser_elo_before=l_elo_before,
+        winner_elo_after=w_elo_after,
+        loser_elo_after=l_elo_after,
+        mode=mode,
     )
     db.add(duel)
 
-    if outcome in ("a_wins", "b_wins", "draw"):
+    # Fire background Trakt sync only for ranking outcomes
+    if outcome in ("a_wins", "b_wins"):
         background_tasks.add_task(
             _sync_ratings_background, uid, movie_a_id, new_elo_a, movie_b_id, new_elo_b,
         )


### PR DESCRIPTION
## Summary
- Rewrites `POST /api/duels` to implement the Film State Model from the PRD
- Initializes ELO from `seeded_elo` (via `get_initial_elo()`) on a film's first ranking duel instead of assuming default 1000
- Uses per-player K factors by passing `winner_battles`/`loser_battles` to `update_elo()`
- Handles all five outcomes correctly: `a_wins`/`b_wins` rank both films with ELO updates; `a_only`/`b_only` mark the seen film and unsee the other; `neither` marks both unseen
- Stores `mode` from request body on the Duel record
- Only increments battles and fires background Trakt sync on ranking outcomes (`a_wins`/`b_wins`)

## Test plan
- [ ] Submit `a_wins` duel with two fresh films (elo=NULL) — both should get ELO initialized from seeded_elo or 1000, then updated
- [ ] Submit `a_wins` with one established film (battles>5) and one new — verify different K factors applied
- [ ] Submit `a_only` — verify A stays seen (if was null), B marked unseen, no ELO changes
- [ ] Submit `b_only` — reverse of above
- [ ] Submit `neither` — both marked unseen, no ELO changes
- [ ] Verify `mode` field persisted on Duel record
- [ ] Verify Trakt sync fires only on a_wins/b_wins

🤖 Generated with [Claude Code](https://claude.com/claude-code)