### PR TITLE
feat: duel page frontend with pick-winner flow

### DIFF
--- a/backend/schemas.py
+++ b/backend/schemas.py
@@ -68,6 +68,7 @@ class RankingsResponse(BaseModel):
 class StatsResponse(BaseModel):
     total_duels: int
     total_movies_ranked: int
+    unseen_count: int = 0
     average_elo: float
     highest_rated: Optional[RankedMovie] = None
     lowest_rated: Optional[RankedMovie] = None

--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -33,27 +33,38 @@ export function getMe() {
   return request("/auth/me");
 }
 
-export function getMoviePair() {
-  return request("/movies/pair");
+export function fetchPair(mode = "discovery") {
+  return request(`/movies/pair?mode=${encodeURIComponent(mode)}`);
 }
 
-export function submitDuel(movieAId, movieBId, outcome) {
+// Legacy alias
+export function getMoviePair() {
+  return fetchPair("discovery");
+}
+
+export function submitDuel(movieAId, movieBId, outcome, mode = "discovery") {
   return request("/duels", {
     method: "POST",
     body: JSON.stringify({
       movie_a_id: movieAId,
       movie_b_id: movieBId,
       outcome,
+      mode,
     }),
   });
 }
 
-export function getRankings(limit = 50, offset = 0) {
-  return request(`/rankings?limit=${limit}&offset=${offset}`);
+export function fetchStats() {
+  return request("/rankings/stats");
 }
 
+// Legacy alias
 export function getStats() {
-  return request("/rankings/stats");
+  return fetchStats();
+}
+
+export function getRankings(limit = 50, offset = 0) {
+  return request(`/rankings?limit=${limit}&offset=${offset}`);
 }
 
 export function logout() {

--- a/frontend/src/components/MovieCard.jsx
+++ b/frontend/src/components/MovieCard.jsx
@@ -1,49 +1,105 @@
 import { Card, CardContent } from "./ui/card";
+import { Badge } from "./ui/badge";
 import { cn } from "../lib/utils";
 
-export default function MovieCard({ movie, onClick, delta, highlight }) {
+export default function MovieCard({
+  movie,
+  onClick,
+  delta,
+  highlight,
+  clickable = false,
+  compact = false,
+}) {
   const posterSrc = movie.poster_url
     ? movie.poster_url
     : "https://via.placeholder.com/300x450?text=No+Poster";
 
+  const genres = (movie.genres || []).slice(0, 2);
+
   return (
     <Card
       className={cn(
-        "w-full max-w-[280px] overflow-hidden cursor-pointer transition-all duration-200 hover:scale-[1.02] hover:shadow-lg hover:shadow-primary/10",
-        highlight && "ring-2 ring-primary"
+        "w-full overflow-hidden transition-all duration-200",
+        compact ? "max-w-[200px]" : "max-w-[280px]",
+        clickable &&
+          "cursor-pointer hover:scale-[1.03] hover:shadow-xl hover:shadow-primary/20 focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background active:scale-[0.98]",
+        !clickable && "cursor-default",
+        highlight && "ring-2 ring-primary shadow-lg shadow-primary/20"
       )}
-      onClick={onClick}
-      role="button"
-      tabIndex={0}
+      onClick={clickable ? onClick : undefined}
+      role={clickable ? "button" : undefined}
+      tabIndex={clickable ? 0 : undefined}
+      onKeyDown={
+        clickable
+          ? (e) => {
+              if (e.key === "Enter" || e.key === " ") {
+                e.preventDefault();
+                onClick?.();
+              }
+            }
+          : undefined
+      }
     >
-      <div className="aspect-[2/3] overflow-hidden">
+      <div className="aspect-[2/3] overflow-hidden bg-secondary relative">
         <img
           className="w-full h-full object-cover"
           src={posterSrc}
           alt={`${movie.title} poster`}
           loading="lazy"
+          onError={(e) => {
+            e.target.src =
+              "https://via.placeholder.com/300x450/1a1a2e/666?text=No+Poster";
+          }}
         />
+        {clickable && (
+          <div className="absolute inset-0 bg-primary/0 hover:bg-primary/10 transition-colors" />
+        )}
       </div>
-      <CardContent className="p-4">
-        <h3 className="font-semibold text-base leading-tight truncate">
+      <CardContent className="p-3 space-y-1.5">
+        <h3 className="font-semibold text-sm leading-tight line-clamp-2">
           {movie.title}
         </h3>
-        <div className="flex items-center justify-between mt-1">
+        <div className="flex items-center gap-2">
           {movie.year && (
-            <span className="text-sm text-muted-foreground">{movie.year}</span>
+            <span className="text-xs text-muted-foreground">{movie.year}</span>
           )}
-          {delta !== undefined && delta !== null && (
+          {genres.map((g) => (
+            <Badge
+              key={g}
+              variant="secondary"
+              className="text-[10px] px-1.5 py-0"
+            >
+              {g}
+            </Badge>
+          ))}
+        </div>
+        {/* ELO + battles for ranked movies */}
+        {movie.elo != null && (
+          <div className="flex items-center justify-between pt-0.5">
+            <span className="text-xs font-mono font-semibold text-primary">
+              {movie.elo} ELO
+            </span>
+            {movie.battles != null && (
+              <span className="text-[10px] text-muted-foreground">
+                {movie.battles} battles
+              </span>
+            )}
+          </div>
+        )}
+        {/* ELO delta after duel */}
+        {delta !== undefined && delta !== null && (
+          <div className="pt-0.5">
             <span
               className={cn(
-                "text-sm font-bold",
+                "text-sm font-bold font-mono",
                 delta >= 0 ? "text-positive" : "text-negative"
               )}
             >
               {delta >= 0 ? "+" : ""}
               {delta}
             </span>
-          )}
-        </div>
+          </div>
+        )}
       </CardContent>
     </Card>
   );

--- a/frontend/src/pages/Duel.jsx
+++ b/frontend/src/pages/Duel.jsx
@@ -1,54 +1,100 @@
-import { useState, useEffect, useCallback } from "react";
-import { Swords, Eye, EyeOff } from "lucide-react";
-import { getMoviePair, submitDuel, getStats } from "../api";
+import { useState, useEffect, useCallback, useRef } from "react";
+import { Swords, Eye, EyeOff, CheckCircle2 } from "lucide-react";
+import { fetchPair, submitDuel, fetchStats } from "../api";
 import MovieCard from "../components/MovieCard";
 import { Button } from "../components/ui/button";
+import { cn } from "../lib/utils";
+
+const MODE = "discovery";
+
+function SkeletonCard() {
+  return (
+    <div className="w-full max-w-[280px] rounded-xl border border-border bg-card overflow-hidden animate-pulse">
+      <div className="aspect-[2/3] bg-secondary" />
+      <div className="p-3 space-y-2">
+        <div className="h-4 bg-secondary rounded w-3/4" />
+        <div className="h-3 bg-secondary rounded w-1/2" />
+      </div>
+    </div>
+  );
+}
 
 export default function Duel() {
   const [pair, setPair] = useState(null);
   const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
   const [result, setResult] = useState(null);
   const [submitting, setSubmitting] = useState(false);
   const [stats, setStats] = useState(null);
+  const [pickMode, setPickMode] = useState(false);
+  const [animateKey, setAnimateKey] = useState(0);
+  const prefetchRef = useRef(null);
 
   const loadStats = useCallback(async () => {
     try {
-      const data = await getStats();
+      const data = await fetchStats();
       setStats(data);
     } catch (err) {
       console.error("Failed to load stats:", err);
     }
   }, []);
 
-  const loadPair = useCallback(async () => {
-    setLoading(true);
-    setResult(null);
-    try {
-      const data = await getMoviePair();
-      setPair(data);
-    } catch (err) {
-      console.error("Failed to load movie pair:", err);
-      setPair(null);
-    } finally {
-      setLoading(false);
-    }
+  const prefetchNext = useCallback(() => {
+    prefetchRef.current = fetchPair(MODE).catch(() => null);
   }, []);
+
+  const loadPair = useCallback(
+    async (usePrefetch = false) => {
+      setLoading(true);
+      setResult(null);
+      setPickMode(false);
+      setError(null);
+      try {
+        let data;
+        if (usePrefetch && prefetchRef.current) {
+          data = await prefetchRef.current;
+          prefetchRef.current = null;
+        }
+        if (!data) {
+          data = await fetchPair(MODE);
+        }
+        setPair(data);
+        setAnimateKey((k) => k + 1);
+      } catch (err) {
+        console.error("Failed to load movie pair:", err);
+        setError(err.message);
+        setPair(null);
+      } finally {
+        setLoading(false);
+      }
+    },
+    []
+  );
 
   useEffect(() => {
     loadPair();
     loadStats();
   }, [loadPair, loadStats]);
 
-  const handleChoice = async (outcome) => {
+  const handleSubmit = async (outcome) => {
     if (!pair || submitting) return;
     setSubmitting(true);
+    // Start prefetching the next pair immediately
+    prefetchNext();
     try {
-      const res = await submitDuel(pair.movie_a.id, pair.movie_b.id, outcome);
+      const res = await submitDuel(
+        pair.movie_a.id,
+        pair.movie_b.id,
+        outcome,
+        MODE
+      );
       setResult(res);
+      setPickMode(false);
+      // Briefly show result, then load next
       setTimeout(() => {
-        loadPair();
+        loadPair(true);
         loadStats();
-      }, 1200);
+      }, 900);
     } catch (err) {
       console.error("Failed to submit duel:", err);
     } finally {
@@ -56,23 +102,19 @@ export default function Duel() {
     }
   };
 
-  if (loading) {
+  // Pool empty / error state
+  if (!loading && error) {
+    const isPoolEmpty =
+      error.includes("Not enough") || error.includes("pool");
     return (
-      <div className="flex items-center justify-center min-h-[60vh]">
-        <div className="text-muted-foreground text-lg animate-pulse">
-          Loading movies...
-        </div>
-      </div>
-    );
-  }
-
-  if (!pair) {
-    return (
-      <div className="flex flex-col items-center justify-center min-h-[60vh] gap-4">
-        <p className="text-muted-foreground">
-          Could not load movies. Try refreshing.
+      <div className="flex flex-col items-center justify-center min-h-[60vh] gap-6">
+        <div className="text-6xl">🎬</div>
+        <p className="text-muted-foreground text-lg text-center max-w-md">
+          {isPoolEmpty
+            ? "Watch more movies on Trakt to get started! You need at least 2 movies in your library."
+            : "Something went wrong loading your movies."}
         </p>
-        <Button variant="outline" onClick={loadPair}>
+        <Button variant="outline" onClick={() => loadPair()}>
           Try Again
         </Button>
       </div>
@@ -80,89 +122,163 @@ export default function Duel() {
   }
 
   return (
-    <div className="flex flex-col items-center gap-8">
+    <div className="flex flex-col items-center gap-6">
       {/* Stats bar */}
       {stats && (
-        <div className="flex items-center gap-6 text-sm text-muted-foreground">
+        <div className="flex items-center gap-4 text-sm text-muted-foreground bg-card/50 border border-border rounded-full px-5 py-2">
           <span>
-            <span className="font-semibold text-foreground">{stats.total_duels}</span>
-            {" duels"}
+            <span className="font-semibold text-foreground tabular-nums">
+              {stats.total_duels}
+            </span>{" "}
+            duels
           </span>
-          <span className="text-muted-foreground/40">·</span>
+          <span className="text-border">|</span>
           <span>
-            <span className="font-semibold text-foreground">{stats.total_movies_ranked}</span>
-            {" ranked"}
+            <span className="font-semibold text-foreground tabular-nums">
+              {stats.total_movies_ranked}
+            </span>{" "}
+            ranked
           </span>
-          <span className="text-muted-foreground/40">·</span>
+          <span className="text-border">|</span>
           <span>
-            <span className="font-semibold text-foreground">{stats.unseen_count}</span>
-            {" unseen"}
+            <span className="font-semibold text-foreground tabular-nums">
+              {stats.unseen_count ?? 0}
+            </span>{" "}
+            to discover
           </span>
         </div>
       )}
 
-      <h2 className="text-2xl font-bold tracking-tight">Which do you prefer?</h2>
-
-      {/* Duel arena — two cards with VS divider */}
-      <div className="flex items-center gap-4 md:gap-8 w-full justify-center">
-        <MovieCard
-          movie={pair.movie_a}
-          onClick={() => handleChoice("a_wins")}
-          delta={result?.movie_a_elo_delta}
-        />
-
-        <div className="flex flex-col items-center gap-2 shrink-0">
-          <div className="w-12 h-12 rounded-full bg-primary/20 flex items-center justify-center">
-            <Swords className="h-6 w-6 text-primary" />
+      {/* Loading skeleton */}
+      {loading && (
+        <div className="flex flex-col items-center gap-6 w-full">
+          <div className="h-7 w-48 bg-secondary rounded animate-pulse" />
+          <div className="flex items-center gap-4 md:gap-8 w-full justify-center">
+            <SkeletonCard />
+            <div className="flex flex-col items-center gap-2 shrink-0">
+              <div className="w-12 h-12 rounded-full bg-secondary animate-pulse" />
+              <div className="w-6 h-3 bg-secondary rounded animate-pulse" />
+            </div>
+            <SkeletonCard />
           </div>
-          <span className="text-sm font-bold text-muted-foreground uppercase tracking-widest">
-            vs
-          </span>
+          <div className="flex gap-3">
+            {[1, 2, 3, 4].map((i) => (
+              <div
+                key={i}
+                className="h-9 w-32 bg-secondary rounded-lg animate-pulse"
+              />
+            ))}
+          </div>
         </div>
+      )}
 
-        <MovieCard
-          movie={pair.movie_b}
-          onClick={() => handleChoice("b_wins")}
-          delta={result?.movie_b_elo_delta}
-        />
-      </div>
+      {/* Duel arena */}
+      {!loading && pair && (
+        <>
+          {pickMode ? (
+            <h2 className="text-xl font-bold tracking-tight text-primary animate-pulse">
+              Tap your winner
+            </h2>
+          ) : (
+            <h2 className="text-xl font-bold tracking-tight text-muted-foreground">
+              Which do you prefer?
+            </h2>
+          )}
 
-      {/* Action buttons */}
-      <div className="flex flex-wrap items-center justify-center gap-3">
-        <Button
-          variant="secondary"
-          onClick={() => handleChoice("a_only")}
-          disabled={submitting}
-          className="gap-2"
-        >
-          <Eye className="h-4 w-4" />
-          Only seen left
-        </Button>
-        <Button
-          variant="outline"
-          onClick={() => handleChoice("neither")}
-          disabled={submitting}
-          className="gap-2"
-        >
-          <EyeOff className="h-4 w-4" />
-          Seen neither
-        </Button>
-        <Button
-          variant="secondary"
-          onClick={() => handleChoice("b_only")}
-          disabled={submitting}
-          className="gap-2"
-        >
-          <Eye className="h-4 w-4" />
-          Only seen right
-        </Button>
-      </div>
+          <div
+            key={animateKey}
+            className="flex items-center gap-3 md:gap-8 w-full justify-center animate-in fade-in slide-in-from-bottom-4 duration-300"
+          >
+            <MovieCard
+              movie={pair.movie_a}
+              onClick={() => handleSubmit("a_wins")}
+              delta={result?.movie_a_elo_delta}
+              clickable={pickMode}
+              highlight={pickMode}
+            />
 
-      {/* Result feedback */}
-      {result && (
-        <p className="text-sm text-muted-foreground animate-in fade-in">
-          ELO updated. Next duel loading...
-        </p>
+            <div className="flex flex-col items-center gap-2 shrink-0">
+              <div
+                className={cn(
+                  "w-12 h-12 rounded-full flex items-center justify-center transition-colors",
+                  pickMode ? "bg-primary/30" : "bg-primary/10"
+                )}
+              >
+                <Swords className="h-6 w-6 text-primary" />
+              </div>
+              <span className="text-xs font-bold text-muted-foreground uppercase tracking-widest">
+                vs
+              </span>
+            </div>
+
+            <MovieCard
+              movie={pair.movie_b}
+              onClick={() => handleSubmit("b_wins")}
+              delta={result?.movie_b_elo_delta}
+              clickable={pickMode}
+              highlight={pickMode}
+            />
+          </div>
+
+          {/* Action buttons */}
+          <div className="flex flex-wrap items-center justify-center gap-2 sm:gap-3 max-w-xl">
+            <Button
+              onClick={() => setPickMode(true)}
+              disabled={submitting || pickMode}
+              className={cn(
+                "gap-2 transition-all",
+                pickMode && "ring-2 ring-primary"
+              )}
+            >
+              <CheckCircle2 className="h-4 w-4" />
+              Seen both — pick a winner
+            </Button>
+            <Button
+              variant="secondary"
+              onClick={() => handleSubmit("a_only")}
+              disabled={submitting}
+              className="gap-2"
+            >
+              <Eye className="h-4 w-4" />
+              <span className="hidden sm:inline">Only seen </span>
+              <span className="truncate max-w-[100px]">
+                {pair.movie_a.title}
+              </span>
+            </Button>
+            <Button
+              variant="secondary"
+              onClick={() => handleSubmit("b_only")}
+              disabled={submitting}
+              className="gap-2"
+            >
+              <Eye className="h-4 w-4" />
+              <span className="hidden sm:inline">Only seen </span>
+              <span className="truncate max-w-[100px]">
+                {pair.movie_b.title}
+              </span>
+            </Button>
+            <Button
+              variant="outline"
+              onClick={() => handleSubmit("neither")}
+              disabled={submitting}
+              className="gap-2 text-muted-foreground"
+            >
+              <EyeOff className="h-4 w-4" />
+              Haven't seen either
+            </Button>
+          </div>
+
+          {/* Result feedback */}
+          {result && (result.outcome === "a_wins" || result.outcome === "b_wins") ? (
+            <p className="text-sm text-primary font-medium animate-in fade-in duration-200">
+              ELO updated! Next duel loading...
+            </p>
+          ) : result ? (
+            <p className="text-sm text-muted-foreground animate-in fade-in duration-200">
+              Noted! Loading next pair...
+            </p>
+          ) : null}
+        </>
       )}
     </div>
   );

--- a/frontend/src/pages/Rankings.jsx
+++ b/frontend/src/pages/Rankings.jsx
@@ -1,6 +1,6 @@
 import { useState, useEffect } from "react";
 import { Download, Trophy, Swords, BarChart3 } from "lucide-react";
-import { getRankings, getStats } from "../api";
+import { getRankings, fetchStats } from "../api";
 import { Button } from "../components/ui/button";
 import { Badge } from "../components/ui/badge";
 import { Card, CardContent } from "../components/ui/card";
@@ -14,8 +14,8 @@ export default function Rankings() {
     async function load() {
       try {
         const [rankData, statsData] = await Promise.all([
-          getRankings(),
-          getStats(),
+          getRankings(50),
+          fetchStats(),
         ]);
         setRankings(rankData.rankings);
         setStats(statsData);
@@ -104,17 +104,20 @@ export default function Rankings() {
                 <th className="text-left p-3 text-xs font-medium text-muted-foreground uppercase tracking-wider w-12">
                   #
                 </th>
+                <th className="text-left p-3 text-xs font-medium text-muted-foreground uppercase tracking-wider w-14 hidden sm:table-cell">
+                  {/* Poster */}
+                </th>
                 <th className="text-left p-3 text-xs font-medium text-muted-foreground uppercase tracking-wider">
                   Title
                 </th>
-                <th className="text-left p-3 text-xs font-medium text-muted-foreground uppercase tracking-wider w-20 hidden sm:table-cell">
+                <th className="text-left p-3 text-xs font-medium text-muted-foreground uppercase tracking-wider w-16 hidden sm:table-cell">
                   Year
                 </th>
                 <th className="text-right p-3 text-xs font-medium text-muted-foreground uppercase tracking-wider w-20">
                   ELO
                 </th>
                 <th className="text-right p-3 text-xs font-medium text-muted-foreground uppercase tracking-wider w-20 hidden sm:table-cell">
-                  Duels
+                  Battles
                 </th>
               </tr>
             </thead>
@@ -133,6 +136,18 @@ export default function Rankings() {
                       <span className="text-muted-foreground text-sm">
                         {r.rank}
                       </span>
+                    )}
+                  </td>
+                  <td className="p-2 hidden sm:table-cell">
+                    {r.movie.poster_url ? (
+                      <img
+                        src={r.movie.poster_url}
+                        alt=""
+                        className="w-8 h-12 rounded object-cover bg-secondary"
+                        loading="lazy"
+                      />
+                    ) : (
+                      <div className="w-8 h-12 rounded bg-secondary" />
                     )}
                   </td>
                   <td className="p-3 font-medium">{r.movie.title}</td>


### PR DESCRIPTION
## Summary
- Complete rewrite of the Duel page with 4-button interaction model: "Seen both — pick a winner" (activates clickable cards), "Only seen {title}" (a_only/b_only), and "Haven't seen either" (neither)
- Stats bar at top showing duels, ranked count, and movies to discover
- Loading skeleton, empty-pool error state, prefetch-on-submit for snappy transitions, fade/slide animations
- Updated MovieCard with genre badges, ELO/battles display, and proper clickable/focus ring states
- Updated Rankings table with poster thumbnail column
- Fixed backend StatsResponse schema to include the unseen_count field already returned by the endpoint

## Test plan
- [ ] Login via Trakt, verify duel page loads with two movie cards and VS divider
- [ ] Click "Seen both — pick a winner" — cards should highlight with ring, clicking one submits a_wins/b_wins
- [ ] Click "Only seen {title}" buttons — submits a_only or b_only, next pair loads
- [ ] Click "Haven't seen either" — submits neither, next pair loads
- [ ] Verify stats bar updates after each duel
- [ ] Verify loading skeleton shows while pair fetches
- [ ] Verify error state when pool is empty
- [ ] Navigate to Rankings — verify poster thumbnails and CSV export link work

🤖 Generated with [Claude Code](https://claude.com/claude-code)