### PR TITLE
feat: community_rating, swipe_results table, seen+battles index

### DIFF
--- a/backend/db_models.py
+++ b/backend/db_models.py
@@ -12,6 +12,7 @@ from sqlalchemy import (
     ForeignKey,
     Index,
     Integer,
+    Numeric,
     Text,
     UniqueConstraint,
 )
@@ -62,6 +63,7 @@ class Movie(Base):
     overview: Mapped[Optional[str]] = mapped_column(Text, nullable=True)
     runtime: Mapped[Optional[int]] = mapped_column(Integer, nullable=True)
     poster_url: Mapped[Optional[str]] = mapped_column(Text, nullable=True)
+    community_rating: Mapped[Optional[float]] = mapped_column(Numeric(4, 1), nullable=True)
     cached_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), default=lambda: datetime.now(timezone.utc)
     )
@@ -78,6 +80,13 @@ class UserMovie(Base):
             "user_id",
             "elo",
             postgresql_where="elo IS NOT NULL",
+        ),
+        Index(
+            "ix_user_movies_user_seen_battles",
+            "user_id",
+            "seen",
+            "battles",
+            postgresql_where="seen = true",
         ),
     )
 
@@ -134,3 +143,22 @@ class Duel(Base):
     user: Mapped[User] = relationship(back_populates="duels")
     winner_movie: Mapped[Optional[Movie]] = relationship(foreign_keys=[winner_movie_id])
     loser_movie: Mapped[Optional[Movie]] = relationship(foreign_keys=[loser_movie_id])
+
+
+class SwipeResult(Base):
+    __tablename__ = "swipe_results"
+    __table_args__ = (Index("ix_swipe_results_user_id", "user_id"),)
+
+    id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), primary_key=True, default=uuid.uuid4
+    )
+    user_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("users.id", ondelete="CASCADE"), nullable=False
+    )
+    movie_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("movies.id", ondelete="CASCADE"), nullable=False
+    )
+    seen: Mapped[bool] = mapped_column(Boolean, nullable=False)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), default=lambda: datetime.now(timezone.utc)
+    )

--- a/backend/migrations/versions/003_community_rating_swipe_results.py
+++ b/backend/migrations/versions/003_community_rating_swipe_results.py
@@ -1,0 +1,63 @@
+"""Add community_rating to movies, create swipe_results table, index on user_movies
+
+Revision ID: 003
+Revises: 002
+Create Date: 2026-04-11
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects.postgresql import UUID
+
+revision: str = "003"
+down_revision: Union[str, None] = "002"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    # 1. Add community_rating column to movies
+    op.add_column(
+        "movies",
+        sa.Column("community_rating", sa.Numeric(4, 1), nullable=True),
+    )
+
+    # 2. Create swipe_results table
+    op.create_table(
+        "swipe_results",
+        sa.Column("id", UUID(as_uuid=True), primary_key=True),
+        sa.Column(
+            "user_id",
+            UUID(as_uuid=True),
+            sa.ForeignKey("users.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column(
+            "movie_id",
+            UUID(as_uuid=True),
+            sa.ForeignKey("movies.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column("seen", sa.Boolean(), nullable=False),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.func.now(),
+        ),
+    )
+    op.create_index("ix_swipe_results_user_id", "swipe_results", ["user_id"])
+
+    # 3. Add partial index on user_movies(user_id, seen, battles) WHERE seen = true
+    op.execute(
+        "CREATE INDEX ix_user_movies_user_seen_battles "
+        "ON user_movies (user_id, seen, battles) "
+        "WHERE seen = true"
+    )
+
+
+def downgrade() -> None:
+    op.execute("DROP INDEX IF EXISTS ix_user_movies_user_seen_battles")
+    op.drop_index("ix_swipe_results_user_id", table_name="swipe_results")
+    op.drop_table("swipe_results")
+    op.drop_column("movies", "community_rating")

--- a/backend/services/pool.py
+++ b/backend/services/pool.py
@@ -88,6 +88,8 @@ async def populate_movie_pool(user: User, db: AsyncSession) -> None:
     # Upsert movies into the movies table
     for movie_data in movie_pool.values():
         ids = movie_data.get("ids", {})
+        trakt_rating = movie_data.get("rating", 0)
+        community_rating = round(trakt_rating * 10, 1) if trakt_rating else None
         stmt = insert(Movie.__table__).values(
             trakt_id=ids["trakt"],
             imdb_id=ids.get("imdb"),
@@ -97,6 +99,7 @@ async def populate_movie_pool(user: User, db: AsyncSession) -> None:
             genres=movie_data.get("genres"),
             overview=movie_data.get("overview"),
             runtime=movie_data.get("runtime"),
+            community_rating=community_rating,
             cached_at=now,
         ).on_conflict_do_update(
             index_elements=["trakt_id"],
@@ -108,6 +111,7 @@ async def populate_movie_pool(user: User, db: AsyncSession) -> None:
                 "genres": movie_data.get("genres"),
                 "overview": movie_data.get("overview"),
                 "runtime": movie_data.get("runtime"),
+                "community_rating": community_rating,
                 "cached_at": now,
             },
         )


### PR DESCRIPTION
## Summary
- Add `community_rating` column (Numeric 4,1) to movies table — stores Trakt community score scaled to 0-100
- Create `swipe_results` table with user_id/movie_id FKs (cascade delete), seen boolean, and created_at timestamp
- Add partial index on `user_movies(user_id, seen, battles) WHERE seen = true` for efficient seen-movie queries
- Update `pool.py` to compute and store `community_rating = trakt_rating * 10` during movie import

## Test plan
- [ ] Run `alembic upgrade head` against dev DB and verify migration applies cleanly
- [ ] Verify community_rating is populated on next pool sync
- [ ] Verify swipe_results table exists with correct schema and FK constraints

🤖 Generated with [Claude Code](https://claude.com/claude-code)