### PR TITLE
feat: swipe feature for film classification

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -11,7 +11,7 @@ from fastapi.responses import FileResponse
 from fastapi.staticfiles import StaticFiles
 
 from backend.config import get_settings
-from backend.routers import auth, movies, duels, rankings
+from backend.routers import auth, movies, duels, rankings, swipe
 
 settings = get_settings()
 
@@ -38,6 +38,7 @@ app.include_router(auth.router)
 app.include_router(movies.router)
 app.include_router(duels.router)
 app.include_router(rankings.router)
+app.include_router(swipe.router)
 
 
 @app.get("/health")

--- a/backend/routers/duels.py
+++ b/backend/routers/duels.py
@@ -7,7 +7,7 @@ import uuid
 from datetime import datetime, timezone
 
 from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException
-from sqlalchemy import select
+from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from backend.db import async_session_factory, get_db
@@ -165,4 +165,19 @@ async def submit_duel(
             _sync_ratings_background, uid, movie_a_id, new_elo_a, movie_b_id, new_elo_b,
         )
 
-    return DuelResult(outcome=body.outcome, movie_a_elo_delta=delta_a, movie_b_elo_delta=delta_b)
+    # Compute next_action: if fewer than 3 seen-but-unranked films, suggest swipe
+    seen_unranked_stmt = select(func.count()).where(
+        UserMovie.user_id == uid,
+        UserMovie.seen.is_(True),
+        UserMovie.battles == 0,
+    )
+    seen_unranked_result = await db.execute(seen_unranked_stmt)
+    seen_unranked = seen_unranked_result.scalar_one()
+    next_action = "swipe" if seen_unranked < 3 else "duel"
+
+    return DuelResult(
+        outcome=body.outcome,
+        movie_a_elo_delta=delta_a,
+        movie_b_elo_delta=delta_b,
+        next_action=next_action,
+    )

--- a/backend/routers/swipe.py
+++ b/backend/routers/swipe.py
@@ -1,0 +1,175 @@
+"""Swipe session routes — classify films as seen/unseen."""
+
+from __future__ import annotations
+
+import logging
+import uuid
+from datetime import datetime, timezone
+
+from fastapi import APIRouter, Depends, HTTPException
+from sqlalchemy import func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from backend.db import get_db
+from backend.db_models import Movie, SwipeResult, User, UserMovie
+from backend.routers.auth import get_current_user
+from backend.schemas import SwipeCardSchema, SwipeResponse, SwipeSubmit
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/api/swipe", tags=["swipe"])
+
+# Quality bands: (elo_low, elo_high, community_rating_low, community_rating_high)
+BANDS = [
+    ("elite", 1300, 9999, 80, 100),
+    ("strong", 1100, 1299, 65, 79),
+    ("mid", 900, 1099, 45, 64),
+    ("weak", 700, 899, 25, 44),
+    ("low", 0, 699, 0, 24),
+]
+
+
+def _elo_to_band_index(elo: int) -> int:
+    """Map an ELO value to a band index (0=elite .. 4=low)."""
+    for i, (_, low, high, _, _) in enumerate(BANDS):
+        if low <= elo <= high:
+            return i
+    return 2  # default to mid
+
+
+def _community_rating_range(band_index: int) -> tuple[float, float]:
+    """Return (low, high) community rating for a band index."""
+    _, _, _, cr_low, cr_high = BANDS[band_index]
+    return float(cr_low), float(cr_high)
+
+
+@router.get("/cards", response_model=list[SwipeCardSchema])
+async def get_swipe_cards(
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+):
+    """Return up to 10 unknown films for a swipe session, weighted by community rating band."""
+    uid = current_user.id
+
+    # Find user's median ELO to determine taste band
+    median_stmt = select(func.percentile_cont(0.5).within_group(UserMovie.elo)).where(
+        UserMovie.user_id == uid,
+        UserMovie.elo.is_not(None),
+    )
+    result = await db.execute(median_stmt)
+    median_elo = result.scalar_one_or_none()
+
+    # Base query: unknown films for this user
+    base = (
+        select(
+            Movie.id,
+            Movie.trakt_id,
+            Movie.title,
+            Movie.year,
+            Movie.genres,
+            Movie.poster_url,
+            Movie.community_rating,
+        )
+        .join(UserMovie, UserMovie.movie_id == Movie.id)
+        .where(UserMovie.user_id == uid, UserMovie.seen.is_(None))
+    )
+
+    if median_elo is None:
+        # No ranked films yet — random selection
+        stmt = base.order_by(func.random()).limit(10)
+        result = await db.execute(stmt)
+        rows = result.all()
+    else:
+        # Band-weighted selection: 60% target, 20% above, 20% below
+        band_idx = _elo_to_band_index(int(median_elo))
+
+        target_range = _community_rating_range(band_idx)
+        above_idx = max(0, band_idx - 1)
+        below_idx = min(len(BANDS) - 1, band_idx + 1)
+        above_range = _community_rating_range(above_idx)
+        below_range = _community_rating_range(below_idx)
+
+        rows = []
+        for cr_range, limit in [
+            (target_range, 6),
+            (above_range, 2),
+            (below_range, 2),
+        ]:
+            stmt = (
+                base.where(
+                    Movie.community_rating >= cr_range[0],
+                    Movie.community_rating <= cr_range[1],
+                )
+                .order_by(func.random())
+                .limit(limit)
+            )
+            result = await db.execute(stmt)
+            rows.extend(result.all())
+
+        # If we didn't get enough from banded selection, backfill randomly
+        if len(rows) < 10:
+            seen_ids = [r.id for r in rows]
+            backfill_stmt = base.order_by(func.random()).limit(10 - len(rows))
+            if seen_ids:
+                backfill_stmt = backfill_stmt.where(Movie.id.notin_(seen_ids))
+            result = await db.execute(backfill_stmt)
+            rows.extend(result.all())
+
+    if not rows:
+        raise HTTPException(
+            status_code=404,
+            detail="No unknown films available. Import more movies from Trakt.",
+        )
+
+    return [
+        SwipeCardSchema(
+            id=str(r.id),
+            trakt_id=r.trakt_id,
+            title=r.title,
+            year=r.year,
+            genres=r.genres or [],
+            poster_url=r.poster_url,
+            community_rating=float(r.community_rating) if r.community_rating else None,
+        )
+        for r in rows
+    ]
+
+
+@router.post("/results", response_model=SwipeResponse)
+async def submit_swipe_results(
+    body: SwipeSubmit,
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+):
+    """Submit all swipe results at once — bulk update seen status."""
+    uid = current_user.id
+    now = datetime.now(timezone.utc)
+    seen_count = 0
+    unseen_count = 0
+
+    for item in body.results:
+        movie_id = uuid.UUID(item.movie_id)
+
+        # Update user_movies.seen
+        stmt = select(UserMovie).where(
+            UserMovie.user_id == uid, UserMovie.movie_id == movie_id
+        )
+        result = await db.execute(stmt)
+        um = result.scalar_one_or_none()
+        if um:
+            um.seen = item.seen
+            um.updated_at = now
+        else:
+            logger.warning("UserMovie not found for user=%s movie=%s", uid, movie_id)
+            continue
+
+        # Insert swipe_results record
+        sr = SwipeResult(user_id=uid, movie_id=movie_id, seen=item.seen)
+        db.add(sr)
+
+        if item.seen:
+            seen_count += 1
+        else:
+            unseen_count += 1
+
+    return SwipeResponse(seen_count=seen_count, unseen_count=unseen_count)

--- a/backend/schemas.py
+++ b/backend/schemas.py
@@ -61,6 +61,7 @@ class DuelResult(BaseModel):
     outcome: DuelOutcome
     movie_a_elo_delta: int
     movie_b_elo_delta: int
+    next_action: str = "duel"
 
 
 class RankedMovie(BaseModel):
@@ -73,6 +74,30 @@ class RankedMovie(BaseModel):
 class RankingsResponse(BaseModel):
     rankings: list[RankedMovie]
     total: int
+
+
+class SwipeCardSchema(BaseModel):
+    id: str
+    trakt_id: int
+    title: str
+    year: Optional[int] = None
+    genres: list[str] = []
+    poster_url: Optional[str] = None
+    community_rating: Optional[float] = None
+
+
+class SwipeResultItem(BaseModel):
+    movie_id: str
+    seen: bool
+
+
+class SwipeSubmit(BaseModel):
+    results: list[SwipeResultItem]
+
+
+class SwipeResponse(BaseModel):
+    seen_count: int
+    unseen_count: int
 
 
 class StatsResponse(BaseModel):

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -4,6 +4,7 @@ import Nav from "./components/Nav";
 import Login from "./pages/Login";
 import Duel from "./pages/Duel";
 import Rankings from "./pages/Rankings";
+import Swipe from "./pages/Swipe";
 
 function ProtectedRoute({ children }) {
   const [status, setStatus] = useState("loading");
@@ -57,6 +58,14 @@ export default function App() {
             }
           />
           <Route
+            path="/swipe"
+            element={
+              <ProtectedRoute>
+                <Swipe />
+              </ProtectedRoute>
+            }
+          />
+          <Route
             path="/rankings"
             element={
               <ProtectedRoute>
@@ -77,6 +86,16 @@ export default function App() {
           }`}
         >
           <span className="text-[10px] font-bold uppercase tracking-[0.1em] font-headline">Duel</span>
+        </a>
+        <a
+          href="/swipe"
+          className={`flex flex-col items-center justify-center px-6 py-2 transition-colors ${
+            location.pathname === "/swipe"
+              ? "text-[#E8A020] border-t-2 border-[#E8A020] bg-[#E8A020]/10"
+              : "text-[#6B6760] hover:text-[#F5F0E8]"
+          }`}
+        >
+          <span className="text-[10px] font-bold uppercase tracking-[0.1em] font-headline">Swipe</span>
         </a>
         <a
           href="/rankings"

--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -39,4 +39,13 @@ export function getRankings(limit = 50, offset = 0) {
 export function fetchStats() { return request("/api/rankings/stats"); }
 export const getStats = fetchStats;
 
+export function fetchSwipeCards() { return request("/api/swipe/cards"); }
+
+export function submitSwipeResults(results) {
+  return request("/api/swipe/results", {
+    method: "POST",
+    body: JSON.stringify({ results }),
+  });
+}
+
 export function logout() { return request("/auth/logout", { method: "POST" }); }

--- a/frontend/src/components/Nav.jsx
+++ b/frontend/src/components/Nav.jsx
@@ -3,6 +3,7 @@ import { logout } from "../api";
 
 const navItems = [
   { path: "/", label: "Current Duel", icon: "swords" },
+  { path: "/swipe", label: "Swipe", icon: "swipe" },
   { path: "/rankings", label: "Rankings", icon: "leaderboard" },
 ];
 

--- a/frontend/src/components/SwipeCard.jsx
+++ b/frontend/src/components/SwipeCard.jsx
@@ -1,0 +1,143 @@
+import { useState, useRef, useCallback } from "react";
+
+const THRESHOLD = 80;
+
+export default function SwipeCard({ movie, onSwipe }) {
+  const [offset, setOffset] = useState(0);
+  const [dragging, setDragging] = useState(false);
+  const [exiting, setExiting] = useState(null); // "left" | "right" | null
+  const startX = useRef(0);
+  const isDragging = useRef(false);
+
+  const posterSrc = movie.poster_url || "https://via.placeholder.com/300x450?text=No+Poster";
+  const genres = (movie.genres || []).slice(0, 3);
+
+  const rotation = offset * 0.08;
+  const opacity = Math.min(Math.abs(offset) / THRESHOLD, 1);
+
+  const handleStart = useCallback((clientX) => {
+    startX.current = clientX;
+    isDragging.current = true;
+    setDragging(true);
+  }, []);
+
+  const handleMove = useCallback((clientX) => {
+    if (!isDragging.current) return;
+    setOffset(clientX - startX.current);
+  }, []);
+
+  const handleEnd = useCallback(() => {
+    if (!isDragging.current) return;
+    isDragging.current = false;
+    setDragging(false);
+
+    if (Math.abs(offset) >= THRESHOLD) {
+      const direction = offset > 0 ? "right" : "left";
+      setExiting(direction);
+      setTimeout(() => {
+        onSwipe(direction === "right"); // right = seen, left = unseen
+      }, 300);
+    } else {
+      setOffset(0);
+    }
+  }, [offset, onSwipe]);
+
+  // Mouse events
+  const onMouseDown = (e) => { e.preventDefault(); handleStart(e.clientX); };
+  const onMouseMove = (e) => handleMove(e.clientX);
+  const onMouseUp = () => handleEnd();
+
+  // Touch events
+  const onTouchStart = (e) => handleStart(e.touches[0].clientX);
+  const onTouchMove = (e) => handleMove(e.touches[0].clientX);
+  const onTouchEnd = () => handleEnd();
+
+  const exitTransform = exiting === "right"
+    ? "translateX(120vw) rotate(20deg)"
+    : exiting === "left"
+    ? "translateX(-120vw) rotate(-20deg)"
+    : `translateX(${offset}px) rotate(${rotation}deg)`;
+
+  return (
+    <div
+      className="relative w-full max-w-[380px] mx-auto select-none touch-none"
+      style={{
+        transform: exitTransform,
+        transition: dragging ? "none" : "transform 0.3s ease-out",
+      }}
+      onMouseDown={onMouseDown}
+      onMouseMove={dragging ? onMouseMove : undefined}
+      onMouseUp={onMouseUp}
+      onMouseLeave={dragging ? onMouseUp : undefined}
+      onTouchStart={onTouchStart}
+      onTouchMove={onTouchMove}
+      onTouchEnd={onTouchEnd}
+    >
+      {/* Swipe labels */}
+      <div
+        className="absolute top-8 right-8 z-20 border-4 border-green-500 rounded-lg px-4 py-2 rotate-12 pointer-events-none"
+        style={{ opacity: offset > 0 ? opacity : 0 }}
+      >
+        <span className="text-green-500 font-headline font-black text-2xl uppercase tracking-wider">
+          SEEN
+        </span>
+      </div>
+      <div
+        className="absolute top-8 left-8 z-20 border-4 border-red-500 rounded-lg px-4 py-2 -rotate-12 pointer-events-none"
+        style={{ opacity: offset < 0 ? opacity : 0 }}
+      >
+        <span className="text-red-500 font-headline font-black text-2xl uppercase tracking-wider">
+          NOPE
+        </span>
+      </div>
+
+      {/* Card */}
+      <div className="aspect-[2/3] overflow-hidden bg-[#1d1b1a] relative rounded-lg shadow-2xl">
+        <img
+          className="w-full h-full object-cover"
+          src={posterSrc}
+          alt={`${movie.title} poster`}
+          loading="eager"
+          draggable={false}
+          onError={(e) => {
+            e.target.src = "https://via.placeholder.com/300x450/1a1a2e/666?text=No+Poster";
+          }}
+        />
+
+        {/* Gradient overlay */}
+        <div className="absolute inset-0 bg-gradient-to-t from-black/90 via-black/20 to-transparent" />
+
+        {/* Community rating badge */}
+        {movie.community_rating && (
+          <div className="absolute top-4 right-4 bg-[#E8A020] text-[#0F0E0D] font-headline font-black text-sm px-3 py-1">
+            {movie.community_rating.toFixed(0)}
+          </div>
+        )}
+
+        {/* Bottom overlay: title, year, genres */}
+        <div className="absolute bottom-0 left-0 right-0 p-6">
+          {genres.length > 0 && (
+            <div className="flex gap-2 mb-3">
+              {genres.map((g) => (
+                <span
+                  key={g}
+                  className="bg-[#0F0E0D]/80 backdrop-blur-md px-3 py-1 text-[10px] font-label font-bold uppercase tracking-widest border border-[#E8A020]/20 text-[#E8A020]"
+                >
+                  {g}
+                </span>
+              ))}
+            </div>
+          )}
+          {movie.year && (
+            <p className="text-xs font-label uppercase tracking-[0.3em] text-[#d6c4ae]/80 mb-1">
+              {movie.year}
+            </p>
+          )}
+          <h2 className="text-3xl font-headline font-black uppercase tracking-tighter text-[#F5F0E8] leading-none">
+            {movie.title}
+          </h2>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/pages/Duel.jsx
+++ b/frontend/src/pages/Duel.jsx
@@ -1,4 +1,5 @@
 import { useState, useEffect, useCallback, useRef } from "react";
+import { useNavigate } from "react-router-dom";
 import { fetchPair, submitDuel, fetchStats } from "../api";
 import MovieCard from "../components/MovieCard";
 import { cn } from "../lib/utils";
@@ -14,6 +15,7 @@ function SkeletonCard() {
 }
 
 export default function Duel() {
+  const navigate = useNavigate();
   const [pair, setPair] = useState(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);
@@ -22,6 +24,7 @@ export default function Duel() {
   const [stats, setStats] = useState(null);
   const [pickMode, setPickMode] = useState(false);
   const [animateKey, setAnimateKey] = useState(0);
+  const [showSwipePrompt, setShowSwipePrompt] = useState(false);
   const prefetchRef = useRef(null);
 
   const loadStats = useCallback(async () => {
@@ -83,10 +86,16 @@ export default function Duel() {
       );
       setResult(res);
       setPickMode(false);
-      setTimeout(() => {
-        loadPair(true);
-        loadStats();
-      }, 900);
+      if (res.next_action === "swipe") {
+        setTimeout(() => {
+          setShowSwipePrompt(true);
+        }, 900);
+      } else {
+        setTimeout(() => {
+          loadPair(true);
+          loadStats();
+        }, 900);
+      }
     } catch (err) {
       console.error("Failed to submit duel:", err);
     } finally {
@@ -116,7 +125,42 @@ export default function Duel() {
   }
 
   return (
-    <div className="min-h-screen flex flex-col bg-[#141312]">
+    <div className="min-h-screen flex flex-col bg-[#141312] relative">
+      {/* Swipe interstitial overlay */}
+      {showSwipePrompt && (
+        <div className="absolute inset-0 z-50 bg-[#0F0E0D]/95 backdrop-blur-xl flex flex-col items-center justify-center gap-8 p-12">
+          <div className="text-center space-y-4">
+            <p className="text-[10px] font-label uppercase tracking-[0.3em] text-[#d6c4ae]/60">
+              Running low on films
+            </p>
+            <h2 className="text-3xl md:text-4xl font-headline font-black uppercase tracking-tighter text-[#F5F0E8]">
+              Time to discover more films
+            </h2>
+            <p className="text-[#6B6760] font-body text-lg max-w-md">
+              Swipe through 10 films to classify them as seen or unseen, then come back for more duels.
+            </p>
+          </div>
+          <div className="flex flex-col gap-3 w-full max-w-xs">
+            <button
+              onClick={() => navigate("/swipe")}
+              className="bg-[#E8A020] text-[#0F0E0D] font-headline font-black py-5 uppercase tracking-[0.2em] text-base hover:shadow-[0_0_30px_rgba(232,160,32,0.4)] active:scale-[0.98] transition-all"
+            >
+              Swipe 10 Films
+            </button>
+            <button
+              onClick={() => {
+                setShowSwipePrompt(false);
+                loadPair(true);
+                loadStats();
+              }}
+              className="border border-[#514534]/30 hover:border-[#E8A020]/50 hover:bg-[#1d1b1a] text-[#d6c4ae] font-headline font-bold uppercase tracking-widest text-xs py-4 transition-all"
+            >
+              Keep Dueling
+            </button>
+          </div>
+        </div>
+      )}
+
       {/* Top Stats Bar */}
       <header className="h-20 px-6 md:px-12 flex justify-between items-center bg-[#0F0E0D]/70 backdrop-blur-xl border-b border-[#E8A020]/10 sticky top-0 z-30">
         <div className="flex gap-6 md:gap-12">

--- a/frontend/src/pages/Swipe.jsx
+++ b/frontend/src/pages/Swipe.jsx
@@ -1,0 +1,199 @@
+import { useState, useEffect, useCallback } from "react";
+import { useNavigate } from "react-router-dom";
+import { fetchSwipeCards, submitSwipeResults } from "../api";
+import SwipeCard from "../components/SwipeCard";
+
+export default function Swipe() {
+  const navigate = useNavigate();
+  const [cards, setCards] = useState([]);
+  const [currentIndex, setCurrentIndex] = useState(0);
+  const [results, setResults] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
+  const [submitting, setSubmitting] = useState(false);
+  const [summary, setSummary] = useState(null);
+  const [cardKey, setCardKey] = useState(0);
+
+  const loadCards = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    setCurrentIndex(0);
+    setResults([]);
+    setSummary(null);
+    try {
+      const data = await fetchSwipeCards();
+      setCards(data || []);
+    } catch (err) {
+      setError(err.message);
+      setCards([]);
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    loadCards();
+  }, [loadCards]);
+
+  const handleSwipe = useCallback(
+    (seen) => {
+      const card = cards[currentIndex];
+      if (!card) return;
+
+      const newResults = [...results, { movie_id: card.id, seen }];
+      setResults(newResults);
+
+      if (currentIndex + 1 >= cards.length) {
+        // All cards done, submit
+        setSubmitting(true);
+        submitSwipeResults(newResults)
+          .then((res) => {
+            setSummary(res);
+          })
+          .catch((err) => {
+            setError(err.message);
+          })
+          .finally(() => {
+            setSubmitting(false);
+          });
+      } else {
+        setCurrentIndex((i) => i + 1);
+        setCardKey((k) => k + 1);
+      }
+    },
+    [cards, currentIndex, results]
+  );
+
+  const handleButtonSwipe = (seen) => {
+    handleSwipe(seen);
+  };
+
+  // Loading state
+  if (loading) {
+    return (
+      <div className="min-h-screen flex items-center justify-center bg-[#0F0E0D]">
+        <div className="text-[#6B6760] font-headline uppercase tracking-widest animate-pulse">
+          Loading films...
+        </div>
+      </div>
+    );
+  }
+
+  // Error state
+  if (error && !cards.length) {
+    return (
+      <div className="min-h-screen flex flex-col items-center justify-center gap-6 p-12 bg-[#0F0E0D]">
+        <p className="text-[#6B6760] text-lg text-center max-w-md font-body">{error}</p>
+        <button
+          onClick={loadCards}
+          className="border border-[#514534]/30 hover:border-[#E8A020]/50 hover:bg-[#1d1b1a] text-[#d6c4ae] font-headline font-bold uppercase tracking-widest text-xs py-4 px-8 transition-all"
+        >
+          Try Again
+        </button>
+      </div>
+    );
+  }
+
+  // Summary screen
+  if (summary) {
+    return (
+      <div className="min-h-screen flex flex-col items-center justify-center gap-8 p-12 bg-[#0F0E0D]">
+        <div className="text-center space-y-4">
+          <p className="text-[10px] font-label uppercase tracking-[0.3em] text-[#d6c4ae]/60">
+            Swipe Complete
+          </p>
+          <h2 className="text-4xl md:text-5xl font-headline font-black uppercase tracking-tighter text-[#F5F0E8]">
+            You've seen {summary.seen_count} of these films
+          </h2>
+          <p className="text-[#6B6760] font-body text-lg">
+            {summary.unseen_count} new discoveries added to your pool
+          </p>
+        </div>
+
+        <div className="flex flex-col gap-3 w-full max-w-xs">
+          <button
+            onClick={() => navigate("/")}
+            className="bg-[#E8A020] text-[#0F0E0D] font-headline font-black py-5 uppercase tracking-[0.2em] text-base hover:shadow-[0_0_30px_rgba(232,160,32,0.4)] active:scale-[0.98] transition-all"
+          >
+            Start Dueling
+          </button>
+          <button
+            onClick={loadCards}
+            className="border border-[#514534]/30 hover:border-[#E8A020]/50 hover:bg-[#1d1b1a] text-[#d6c4ae] font-headline font-bold uppercase tracking-widest text-xs py-4 transition-all"
+          >
+            Swipe More
+          </button>
+        </div>
+      </div>
+    );
+  }
+
+  // No cards
+  if (!cards.length) {
+    return (
+      <div className="min-h-screen flex flex-col items-center justify-center gap-6 p-12 bg-[#0F0E0D]">
+        <p className="text-[#6B6760] text-lg text-center max-w-md font-body">
+          No unknown films left to swipe. You've classified them all!
+        </p>
+        <button
+          onClick={() => navigate("/")}
+          className="bg-[#E8A020] text-[#0F0E0D] font-headline font-black py-4 px-8 uppercase tracking-[0.2em] text-sm hover:shadow-[0_0_30px_rgba(232,160,32,0.4)] active:scale-[0.98] transition-all"
+        >
+          Back to Duels
+        </button>
+      </div>
+    );
+  }
+
+  const card = cards[currentIndex];
+  const total = cards.length;
+
+  return (
+    <div className="min-h-screen flex flex-col bg-[#0F0E0D]">
+      {/* Progress header */}
+      <header className="h-16 px-6 flex items-center justify-between bg-[#0F0E0D]/70 backdrop-blur-xl border-b border-[#E8A020]/10 sticky top-0 z-30">
+        <span className="text-[10px] font-label uppercase tracking-[0.3em] text-[#d6c4ae]/60">
+          Swipe Session
+        </span>
+        <span className="font-headline font-bold text-[#E8A020] text-lg">
+          {currentIndex + 1} / {total}
+        </span>
+      </header>
+
+      {/* Progress bar */}
+      <div className="h-1 bg-[#1d1b1a]">
+        <div
+          className="h-full bg-[#E8A020] transition-all duration-300"
+          style={{ width: `${((currentIndex + 1) / total) * 100}%` }}
+        />
+      </div>
+
+      {/* Card area */}
+      <section className="flex-1 flex flex-col items-center justify-center p-4 md:p-8 gap-6">
+        <SwipeCard key={cardKey} movie={card} onSwipe={handleSwipe} />
+
+        {/* Button controls */}
+        <div className="flex gap-4 w-full max-w-[380px]">
+          <button
+            onClick={() => handleButtonSwipe(false)}
+            disabled={submitting}
+            className="flex-1 border-2 border-[#514534]/40 hover:border-[#F5F0E8]/40 text-[#d6c4ae] font-headline font-bold uppercase tracking-widest text-xs py-4 transition-all disabled:opacity-40 hover:bg-[#1d1b1a]"
+          >
+            Never seen it
+          </button>
+          <button
+            onClick={() => handleButtonSwipe(true)}
+            disabled={submitting}
+            className="flex-1 bg-[#E8A020] text-[#0F0E0D] font-headline font-black uppercase tracking-widest text-xs py-4 hover:shadow-[0_0_20px_rgba(232,160,32,0.3)] active:scale-[0.98] transition-all disabled:opacity-40"
+          >
+            Seen it
+          </button>
+        </div>
+
+        <p className="text-[10px] font-label uppercase tracking-[0.2em] text-[#6B6760]">
+          Swipe right = seen &middot; Swipe left = not seen
+        </p>
+      </section>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- **Backend**: New `/api/swipe/cards` endpoint returns 10 unknown films weighted by community rating band matching user's median ELO; `/api/swipe/results` bulk updates seen status and records swipe history
- **Frontend**: Full Tinder-style swipe UI with draggable cards (touch + mouse), visual SEEN/NOPE labels, progress bar, summary screen with "Start Dueling" CTA
- **Duel integration**: `next_action` computed after each duel (`seen_unranked < 3` triggers "swipe"); interstitial overlay prompts users to classify more films when running low
- **Navigation**: Swipe added to desktop sidebar and mobile bottom nav

## Test plan
- [ ] Verify GET /api/swipe/cards returns up to 10 films with seen=NULL
- [ ] Verify band weighting: users with ranked films get 60/20/20 distribution
- [ ] Verify POST /api/swipe/results bulk updates user_movies.seen and inserts swipe_results
- [ ] Test swipe gesture (drag right = seen, drag left = unseen) on mobile and desktop
- [ ] Test button fallback (Seen it / Never seen it)
- [ ] Verify progress counter increments and summary screen shows correct counts
- [ ] Verify duel next_action="swipe" triggers interstitial overlay
- [ ] Verify "Keep Dueling" dismisses overlay and continues normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)