### PR TITLE
feat: quality band matching for duel pair selection

### DIFF
--- a/backend/db_models.py
+++ b/backend/db_models.py
@@ -136,6 +136,7 @@ class Duel(Base):
     winner_elo_after: Mapped[Optional[int]] = mapped_column(Integer, nullable=True)
     loser_elo_after: Mapped[Optional[int]] = mapped_column(Integer, nullable=True)
     mode: Mapped[str] = mapped_column(Text, nullable=False, server_default="discovery")
+    pair_type: Mapped[Optional[str]] = mapped_column(Text, nullable=True)
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), default=lambda: datetime.now(timezone.utc)
     )

--- a/backend/migrations/versions/004_add_pair_type_to_duels.py
+++ b/backend/migrations/versions/004_add_pair_type_to_duels.py
@@ -1,0 +1,23 @@
+"""Add pair_type column to duels
+
+Revision ID: 004
+Revises: 003
+Create Date: 2026-04-11
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+revision: str = "004"
+down_revision: Union[str, None] = "003"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column("duels", sa.Column("pair_type", sa.Text(), nullable=True))
+
+
+def downgrade() -> None:
+    op.drop_column("duels", "pair_type")

--- a/backend/routers/duels.py
+++ b/backend/routers/duels.py
@@ -77,6 +77,14 @@ async def submit_duel(
     um_a = await get_or_create_user_movie(movie_a_id)
     um_b = await get_or_create_user_movie(movie_b_id)
 
+    # Compute pair_type before battles are incremented
+    if um_a.battles >= 1 and um_b.battles >= 1:
+        pair_type = "ranked_vs_ranked"
+    elif um_a.battles == 0 or um_b.battles == 0:
+        pair_type = "ranked_vs_unranked"
+    else:
+        pair_type = "unknown"
+
     new_elo_a: int | None = um_a.elo
     new_elo_b: int | None = um_b.elo
     delta_a = 0
@@ -156,6 +164,7 @@ async def submit_duel(
         winner_elo_after=w_elo_after,
         loser_elo_after=l_elo_after,
         mode=mode,
+        pair_type=pair_type,
     )
     db.add(duel)
 

--- a/backend/routers/movies.py
+++ b/backend/routers/movies.py
@@ -1,4 +1,4 @@
-"""Movie pair generation endpoint — duel pair selection."""
+"""Movie pair generation endpoint — duel pair selection with quality band matching."""
 
 from __future__ import annotations
 
@@ -17,6 +17,63 @@ from backend.schemas import MovieWithStateSchema, MoviePairResponse
 from backend.routers.auth import get_current_user
 
 router = APIRouter(prefix="/api/movies", tags=["movies"])
+
+# ---------------------------------------------------------------------------
+# Quality band helpers
+# ---------------------------------------------------------------------------
+
+BAND_ORDER = ["elite", "strong", "mid", "weak", "poor"]
+
+
+def elo_to_band(elo: int | None) -> str:
+    if elo is None:
+        return "mid"
+    if elo >= 1300:
+        return "elite"
+    if elo >= 1100:
+        return "strong"
+    if elo >= 900:
+        return "mid"
+    if elo >= 700:
+        return "weak"
+    return "poor"
+
+
+def community_rating_to_band(rating: float | None) -> str:
+    if rating is None:
+        return "mid"
+    if rating >= 80:
+        return "elite"
+    if rating >= 65:
+        return "strong"
+    if rating >= 45:
+        return "mid"
+    if rating >= 25:
+        return "weak"
+    return "poor"
+
+
+def bands_adjacent(band_a: str, band_b: str) -> bool:
+    ia = BAND_ORDER.index(band_a)
+    ib = BAND_ORDER.index(band_b)
+    return abs(ia - ib) <= 1
+
+
+def _film_band(um: UserMovie) -> str:
+    """Determine quality band for a UserMovie.
+
+    Ranked films (battles >= 1) use ELO; unranked use community_rating.
+    """
+    if um.battles >= 1:
+        return elo_to_band(um.elo)
+    return community_rating_to_band(
+        float(um.movie.community_rating) if um.movie.community_rating is not None else None
+    )
+
+
+# ---------------------------------------------------------------------------
+# Schema / token helpers
+# ---------------------------------------------------------------------------
 
 
 def _user_movie_to_schema(um: UserMovie) -> MovieWithStateSchema:
@@ -53,6 +110,11 @@ def _decode_pair_token(token: str) -> set[str] | None:
     return None
 
 
+# ---------------------------------------------------------------------------
+# Endpoint
+# ---------------------------------------------------------------------------
+
+
 @router.get("/pair", response_model=MoviePairResponse)
 async def get_movie_pair(
     mode: str = Query(default="discovery"),
@@ -85,16 +147,22 @@ async def get_movie_pair(
     )
 
 
+# ---------------------------------------------------------------------------
+# Pair selection
+# ---------------------------------------------------------------------------
+
+
 async def _select_pair(
     db: AsyncSession,
     uid,
     last_pair_ids: set[str] | None,
 ) -> tuple[UserMovie, UserMovie]:
-    """Select a duel pair from seen films only.
+    """Select a duel pair from seen films with quality band matching.
 
-    Uses settlement weight: 1/(battles+1).
-    Anchor rule: at least one film must have battles >= 1 (unless bootstrap).
-    If not enough seen films, signal swipe needed.
+    1. Pick anchor (film A) weighted by settlement: 1/(battles+1).
+    2. Determine anchor's band.
+    3. Filter candidates to same band, then adjacent, then full pool.
+    4. For ranked-vs-ranked: 70% close matches, 30% wide matches.
     """
 
     # All seen films
@@ -122,17 +190,21 @@ async def _select_pair(
     if len(anchor_pool) == 0:
         return _pick_bootstrap_pair(seen_films, last_pair_ids)
 
-    # Normal: anchor + challenger from full seen pool
+    # Normal: anchor + challenger from band-filtered pool
     for _ in range(5):
-        # Pick anchor weighted by settlement
         anchor = _weighted_sample(anchor_pool)
+        anchor_band = elo_to_band(anchor.elo)
 
-        # Pick challenger from all seen films (minus anchor)
-        candidates = [f for f in seen_films if f.movie_id != anchor.movie_id]
-        if not candidates:
+        # Build candidate pool excluding anchor
+        all_candidates = [f for f in seen_films if f.movie_id != anchor.movie_id]
+        if not all_candidates:
             break
 
-        challenger = _weighted_sample(candidates)
+        # Band filter: same band first, then adjacent, then full pool
+        candidates = _band_filtered_candidates(anchor_band, all_candidates)
+
+        # Match distance variation for ranked-vs-ranked
+        challenger = _pick_challenger(anchor, candidates)
 
         # Anti-repeat
         pair_ids = {str(anchor.movie_id), str(challenger.movie_id)}
@@ -141,6 +213,55 @@ async def _select_pair(
 
     # Fallback after retries
     return anchor, challenger  # type: ignore
+
+
+def _band_filtered_candidates(
+    anchor_band: str,
+    candidates: list[UserMovie],
+) -> list[UserMovie]:
+    """Filter candidates by quality band: same > adjacent > all."""
+    # Same band
+    same = [f for f in candidates if _film_band(f) == anchor_band]
+    if same:
+        return same
+
+    # Adjacent bands (±1 step)
+    adjacent = [f for f in candidates if bands_adjacent(anchor_band, _film_band(f))]
+    if adjacent:
+        return adjacent
+
+    # Full pool fallback
+    return candidates
+
+
+def _pick_challenger(anchor: UserMovie, candidates: list[UserMovie]) -> UserMovie:
+    """Pick challenger with match distance variation for ranked-vs-ranked pairs.
+
+    - 70%: prefer close matches (ELO diff < 150), sample from top 10
+    - 30%: prefer wide matches (ELO diff > 300)
+    Falls back to settlement-weighted sample if filters produce nothing.
+    """
+    # Separate ranked candidates (both anchor and candidate have battles >= 1)
+    ranked = [f for f in candidates if f.battles >= 1 and f.elo is not None]
+
+    if ranked and anchor.elo is not None:
+        roll = random.random()
+        if roll < 0.70:
+            # Close match: sort by abs ELO diff, take top 10
+            ranked_sorted = sorted(ranked, key=lambda f: abs(f.elo - anchor.elo))
+            close = [f for f in ranked_sorted[:10] if abs(f.elo - anchor.elo) < 150]
+            if close:
+                return _weighted_sample(close)
+            # If no close matches in top 10, use top 10 anyway
+            return _weighted_sample(ranked_sorted[:10])
+        else:
+            # Wide match: ELO diff > 300
+            wide = [f for f in ranked if abs(f.elo - anchor.elo) > 300]
+            if wide:
+                return _weighted_sample(wide)
+
+    # Default: settlement-weighted from full candidate pool
+    return _weighted_sample(candidates)
 
 
 def _pick_bootstrap_pair(


### PR DESCRIPTION
## Summary
- Implement quality band matching in `_select_pair`: anchor's ELO determines band (elite/strong/mid/weak/poor), candidates filtered to same band then adjacent bands then full pool fallback
- Match distance variation for ranked-vs-ranked pairs: 70% close (ELO diff < 150), 30% wide (ELO diff > 300)
- Store `pair_type` on duel records (`ranked_vs_ranked` / `ranked_vs_unranked`) for analytics
- Migration 004 adds `pair_type` column to duels table

## Test plan
- [ ] Verify pair endpoint returns films in similar quality bands
- [ ] Check fallback works when band has insufficient candidates
- [ ] Confirm pair_type is stored correctly on duel submission
- [ ] Run migration 004 on dev database

🤖 Generated with [Claude Code](https://claude.com/claude-code)