### PR TITLE
feat: add tournament database schema

### DIFF
--- a/backend/db_models.py
+++ b/backend/db_models.py
@@ -115,6 +115,84 @@ class UserMovie(Base):
     movie: Mapped[Movie] = relationship()
 
 
+class Tournament(Base):
+    __tablename__ = "tournaments"
+    __table_args__ = (Index("ix_tournaments_user_id", "user_id"),)
+
+    id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), primary_key=True, default=uuid.uuid4
+    )
+    user_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("users.id", ondelete="CASCADE"), nullable=False
+    )
+    name: Mapped[str] = mapped_column(Text, nullable=False)
+    filter_type: Mapped[Optional[str]] = mapped_column(Text, nullable=True)
+    filter_value: Mapped[Optional[str]] = mapped_column(Text, nullable=True)
+    bracket_size: Mapped[int] = mapped_column(Integer, nullable=False)
+    status: Mapped[str] = mapped_column(
+        Text, nullable=False, server_default="active"
+    )
+    champion_movie_id: Mapped[Optional[uuid.UUID]] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("movies.id"), nullable=True
+    )
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), default=lambda: datetime.now(timezone.utc)
+    )
+    completed_at: Mapped[Optional[datetime]] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
+
+    user: Mapped[User] = relationship()
+    champion_movie: Mapped[Optional[Movie]] = relationship(
+        foreign_keys=[champion_movie_id]
+    )
+    matches: Mapped[list[TournamentMatch]] = relationship(
+        back_populates="tournament", cascade="all, delete-orphan"
+    )
+
+
+class TournamentMatch(Base):
+    __tablename__ = "tournament_matches"
+    __table_args__ = (
+        UniqueConstraint("tournament_id", "round", "position"),
+        Index("ix_tournament_matches_tournament_id", "tournament_id"),
+    )
+
+    id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), primary_key=True, default=uuid.uuid4
+    )
+    tournament_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("tournaments.id", ondelete="CASCADE"),
+        nullable=False,
+    )
+    round: Mapped[int] = mapped_column(Integer, nullable=False)
+    position: Mapped[int] = mapped_column(Integer, nullable=False)
+    movie_a_id: Mapped[Optional[uuid.UUID]] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("movies.id"), nullable=True
+    )
+    movie_b_id: Mapped[Optional[uuid.UUID]] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("movies.id"), nullable=True
+    )
+    winner_movie_id: Mapped[Optional[uuid.UUID]] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("movies.id"), nullable=True
+    )
+    duel_id: Mapped[Optional[uuid.UUID]] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("duels.id"), nullable=True
+    )
+    played_at: Mapped[Optional[datetime]] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
+
+    tournament: Mapped[Tournament] = relationship(back_populates="matches")
+    movie_a: Mapped[Optional[Movie]] = relationship(foreign_keys=[movie_a_id])
+    movie_b: Mapped[Optional[Movie]] = relationship(foreign_keys=[movie_b_id])
+    winner_movie: Mapped[Optional[Movie]] = relationship(
+        foreign_keys=[winner_movie_id]
+    )
+    duel: Mapped[Optional[Duel]] = relationship()
+
+
 class Duel(Base):
     __tablename__ = "duels"
     __table_args__ = (Index("ix_duels_user_id", "user_id"),)

--- a/backend/migrations/versions/005_add_tournament_tables.py
+++ b/backend/migrations/versions/005_add_tournament_tables.py
@@ -1,0 +1,96 @@
+"""Add tournaments and tournament_matches tables
+
+Revision ID: 005
+Revises: 004
+Create Date: 2026-04-11
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects.postgresql import UUID
+
+revision: str = "005"
+down_revision: Union[str, None] = "004"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "tournaments",
+        sa.Column("id", UUID(as_uuid=True), primary_key=True),
+        sa.Column(
+            "user_id",
+            UUID(as_uuid=True),
+            sa.ForeignKey("users.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column("name", sa.Text(), nullable=False),
+        sa.Column("filter_type", sa.Text(), nullable=True),
+        sa.Column("filter_value", sa.Text(), nullable=True),
+        sa.Column("bracket_size", sa.Integer(), nullable=False),
+        sa.Column("status", sa.Text(), nullable=False, server_default="active"),
+        sa.Column(
+            "champion_movie_id",
+            UUID(as_uuid=True),
+            sa.ForeignKey("movies.id"),
+            nullable=True,
+        ),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.func.now(),
+        ),
+        sa.Column("completed_at", sa.DateTime(timezone=True), nullable=True),
+    )
+    op.create_index("ix_tournaments_user_id", "tournaments", ["user_id"])
+
+    op.create_table(
+        "tournament_matches",
+        sa.Column("id", UUID(as_uuid=True), primary_key=True),
+        sa.Column(
+            "tournament_id",
+            UUID(as_uuid=True),
+            sa.ForeignKey("tournaments.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column("round", sa.Integer(), nullable=False),
+        sa.Column("position", sa.Integer(), nullable=False),
+        sa.Column(
+            "movie_a_id",
+            UUID(as_uuid=True),
+            sa.ForeignKey("movies.id"),
+            nullable=True,
+        ),
+        sa.Column(
+            "movie_b_id",
+            UUID(as_uuid=True),
+            sa.ForeignKey("movies.id"),
+            nullable=True,
+        ),
+        sa.Column(
+            "winner_movie_id",
+            UUID(as_uuid=True),
+            sa.ForeignKey("movies.id"),
+            nullable=True,
+        ),
+        sa.Column(
+            "duel_id",
+            UUID(as_uuid=True),
+            sa.ForeignKey("duels.id"),
+            nullable=True,
+        ),
+        sa.Column("played_at", sa.DateTime(timezone=True), nullable=True),
+        sa.UniqueConstraint("tournament_id", "round", "position"),
+    )
+    op.create_index(
+        "ix_tournament_matches_tournament_id",
+        "tournament_matches",
+        ["tournament_id"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("tournament_matches")
+    op.drop_table("tournaments")

--- a/backend/schemas.py
+++ b/backend/schemas.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from datetime import datetime
 from enum import Enum
-from typing import Optional
+from typing import Literal, Optional
 
 from pydantic import BaseModel
 
@@ -108,3 +108,45 @@ class StatsResponse(BaseModel):
     average_elo: float
     highest_rated: Optional[RankedMovie] = None
     lowest_rated: Optional[RankedMovie] = None
+
+
+# ── Tournament schemas ──────────────────────────────────────────────
+
+
+class TournamentCreate(BaseModel):
+    name: str
+    filter_type: Optional[str] = None
+    filter_value: Optional[str] = None
+    bracket_size: Literal[8, 16, 32, 64]
+
+
+class TournamentMatchSchema(BaseModel):
+    id: str
+    round: int
+    position: int
+    movie_a: Optional[MovieSchema] = None
+    movie_b: Optional[MovieSchema] = None
+    winner_movie_id: Optional[str] = None
+    played_at: Optional[datetime] = None
+
+
+class TournamentSchema(BaseModel):
+    id: str
+    name: str
+    filter_type: Optional[str] = None
+    filter_value: Optional[str] = None
+    bracket_size: int
+    status: str
+    champion_movie_id: Optional[str] = None
+    created_at: datetime
+    completed_at: Optional[datetime] = None
+    matches: list[TournamentMatchSchema] = []
+
+
+class TournamentListItem(BaseModel):
+    id: str
+    name: str
+    bracket_size: int
+    status: str
+    created_at: datetime
+    progress: str = ""


### PR DESCRIPTION
## Summary
- Add `Tournament` and `TournamentMatch` SQLAlchemy ORM models with full relationships, indexes, and constraints
- Add Pydantic schemas: `TournamentCreate`, `TournamentMatchSchema`, `TournamentSchema`, `TournamentListItem`
- Add Alembic migration 005 creating both tables with indexes on `tournaments(user_id)` and `tournament_matches(tournament_id)`

## Test plan
- [ ] Run `alembic upgrade head` against dev DB and verify tables created
- [ ] Run `alembic downgrade -1` and verify clean rollback
- [ ] Verify ORM model imports work: `from backend.db_models import Tournament, TournamentMatch`
- [ ] Verify schema validation: `TournamentCreate(name="test", bracket_size=16)` succeeds, `bracket_size=12` rejected

🤖 Generated with [Claude Code](https://claude.com/claude-code)