### PR TITLE
feat: tournament bracket API

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -11,7 +11,7 @@ from fastapi.responses import FileResponse
 from fastapi.staticfiles import StaticFiles
 
 from backend.config import get_settings
-from backend.routers import auth, movies, duels, rankings, swipe
+from backend.routers import auth, movies, duels, rankings, swipe, tournaments
 
 settings = get_settings()
 
@@ -39,6 +39,7 @@ app.include_router(movies.router)
 app.include_router(duels.router)
 app.include_router(rankings.router)
 app.include_router(swipe.router)
+app.include_router(tournaments.router)
 
 
 @app.get("/health")

--- a/backend/routers/tournaments.py
+++ b/backend/routers/tournaments.py
@@ -1,0 +1,485 @@
+"""Tournament bracket API routes."""
+
+from __future__ import annotations
+
+import math
+import uuid
+from datetime import datetime, timezone
+from typing import Optional
+
+from fastapi import APIRouter, Depends, HTTPException
+from pydantic import BaseModel
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import joinedload
+
+from backend.db import get_db
+from backend.db_models import Duel, Movie, Tournament, TournamentMatch, User, UserMovie
+from backend.routers.auth import get_current_user
+from backend.schemas import (
+    MovieSchema,
+    TournamentCreate,
+    TournamentListItem,
+    TournamentMatchSchema,
+    TournamentSchema,
+)
+from backend.services.elo import get_initial_elo, update_elo
+
+router = APIRouter(prefix="/api/tournaments", tags=["tournaments"])
+
+
+# ── Helpers ────────────────────────────────────────────────────────────
+
+
+def generate_seeded_bracket(n: int) -> list[tuple[int, int]]:
+    """Generate standard tournament seeding for n participants.
+
+    Returns list of (seed_a, seed_b) tuples for round 1.
+    Seeds are 1-indexed.
+    """
+    if n == 2:
+        return [(1, 2)]
+    if n == 4:
+        return [(1, 4), (2, 3)]
+    if n == 8:
+        return [(1, 8), (4, 5), (2, 7), (3, 6)]
+    if n == 16:
+        return [
+            (1, 16), (8, 9), (4, 13), (5, 12),
+            (2, 15), (7, 10), (3, 14), (6, 11),
+        ]
+    if n == 32:
+        top = generate_seeded_bracket(16)
+        return [(a, 33 - a) for a, _ in top] + [(b, 33 - b) for _, b in top]
+    if n == 64:
+        top = generate_seeded_bracket(32)
+        return [(a, 65 - a) for a, _ in top] + [(b, 65 - b) for _, b in top]
+    raise ValueError(f"Unsupported bracket size: {n}")
+
+
+def _num_rounds(bracket_size: int) -> int:
+    return int(math.log2(bracket_size))
+
+
+def _movie_schema(movie: Optional[Movie]) -> Optional[MovieSchema]:
+    if movie is None:
+        return None
+    return MovieSchema(
+        id=str(movie.id),
+        trakt_id=movie.trakt_id,
+        tmdb_id=movie.tmdb_id,
+        imdb_id=movie.imdb_id,
+        title=movie.title,
+        year=movie.year,
+        poster_url=movie.poster_url,
+        overview=movie.overview,
+    )
+
+
+def _match_schema(m: TournamentMatch) -> TournamentMatchSchema:
+    return TournamentMatchSchema(
+        id=str(m.id),
+        round=m.round,
+        position=m.position,
+        movie_a=_movie_schema(m.movie_a),
+        movie_b=_movie_schema(m.movie_b),
+        winner_movie_id=str(m.winner_movie_id) if m.winner_movie_id else None,
+        played_at=m.played_at,
+    )
+
+
+def _tournament_schema(t: Tournament) -> TournamentSchema:
+    # Sort matches by round then position for consistent output
+    sorted_matches = sorted(t.matches, key=lambda m: (m.round, m.position))
+    return TournamentSchema(
+        id=str(t.id),
+        name=t.name,
+        filter_type=t.filter_type,
+        filter_value=t.filter_value,
+        bracket_size=t.bracket_size,
+        status=t.status,
+        champion_movie_id=str(t.champion_movie_id) if t.champion_movie_id else None,
+        created_at=t.created_at,
+        completed_at=t.completed_at,
+        matches=[_match_schema(m) for m in sorted_matches],
+    )
+
+
+async def _load_tournament(
+    tournament_id: uuid.UUID,
+    user_id: uuid.UUID,
+    db: AsyncSession,
+) -> Tournament:
+    """Load a tournament with all matches and movie relationships."""
+    stmt = (
+        select(Tournament)
+        .options(
+            joinedload(Tournament.matches).joinedload(TournamentMatch.movie_a),
+            joinedload(Tournament.matches).joinedload(TournamentMatch.movie_b),
+            joinedload(Tournament.matches).joinedload(TournamentMatch.winner_movie),
+        )
+        .where(Tournament.id == tournament_id)
+    )
+    result = await db.execute(stmt)
+    tournament = result.unique().scalars().first()
+    if not tournament:
+        raise HTTPException(status_code=404, detail="Tournament not found")
+    if tournament.user_id != user_id:
+        raise HTTPException(status_code=404, detail="Tournament not found")
+    return tournament
+
+
+# ── Endpoints ──────────────────────────────────────────────────────────
+
+
+@router.post("", response_model=TournamentSchema)
+async def create_tournament(
+    body: TournamentCreate,
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+):
+    """Create and seed a new tournament bracket."""
+    uid = current_user.id
+
+    # 1. Query user's ranked films
+    stmt = (
+        select(UserMovie)
+        .options(joinedload(UserMovie.movie))
+        .where(
+            UserMovie.user_id == uid,
+            UserMovie.seen.is_(True),
+            UserMovie.battles >= 1,
+            UserMovie.elo.isnot(None),
+        )
+    )
+    result = await db.execute(stmt)
+    user_movies = result.unique().scalars().all()
+
+    # 2. Filter by genre or decade if requested
+    if body.filter_type == "genre" and body.filter_value:
+        genre_lower = body.filter_value.lower()
+        user_movies = [
+            um for um in user_movies
+            if um.movie.genres and any(g.lower() == genre_lower for g in um.movie.genres)
+        ]
+    elif body.filter_type == "decade" and body.filter_value:
+        # Parse decade: "1990s" -> 1990, or just "1990" -> 1990
+        decade_str = body.filter_value.rstrip("s")
+        try:
+            decade_start = int(decade_str)
+        except ValueError:
+            raise HTTPException(status_code=400, detail="Invalid decade format")
+        user_movies = [
+            um for um in user_movies
+            if um.movie.year and decade_start <= um.movie.year <= decade_start + 9
+        ]
+
+    # 3. Validate enough films
+    if len(user_movies) < body.bracket_size:
+        raise HTTPException(
+            status_code=400,
+            detail=f"Not enough ranked films. Need {body.bracket_size}, have {len(user_movies)}.",
+        )
+
+    # 4. Sort by ELO descending, take top bracket_size
+    user_movies.sort(key=lambda um: um.elo or 0, reverse=True)
+    seeded_films = user_movies[: body.bracket_size]
+
+    # 5. Generate seeded bracket pairings
+    pairings = generate_seeded_bracket(body.bracket_size)
+
+    # 6. Create tournament record
+    tournament = Tournament(
+        user_id=uid,
+        name=body.name,
+        filter_type=body.filter_type,
+        filter_value=body.filter_value,
+        bracket_size=body.bracket_size,
+        status="active",
+    )
+    db.add(tournament)
+    await db.flush()
+
+    # 7. Create round 1 matches with seeded pairings
+    num_rounds = _num_rounds(body.bracket_size)
+    round1_matches = body.bracket_size // 2
+
+    for position, (seed_a, seed_b) in enumerate(pairings):
+        match = TournamentMatch(
+            tournament_id=tournament.id,
+            round=1,
+            position=position,
+            movie_a_id=seeded_films[seed_a - 1].movie_id,
+            movie_b_id=seeded_films[seed_b - 1].movie_id,
+        )
+        db.add(match)
+
+    # 8. Create empty matches for subsequent rounds
+    for round_num in range(2, num_rounds + 1):
+        matches_in_round = body.bracket_size // (2**round_num)
+        for position in range(matches_in_round):
+            match = TournamentMatch(
+                tournament_id=tournament.id,
+                round=round_num,
+                position=position,
+            )
+            db.add(match)
+
+    await db.flush()
+
+    # Reload the tournament with all relationships
+    tournament = await _load_tournament(tournament.id, uid, db)
+    return _tournament_schema(tournament)
+
+
+@router.get("", response_model=list[TournamentListItem])
+async def list_tournaments(
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+):
+    """List all tournaments for the current user."""
+    uid = current_user.id
+
+    stmt = (
+        select(Tournament)
+        .options(joinedload(Tournament.matches))
+        .where(Tournament.user_id == uid)
+        .order_by(Tournament.created_at.desc())
+    )
+    result = await db.execute(stmt)
+    tournaments = result.unique().scalars().all()
+
+    items = []
+    for t in tournaments:
+        # Calculate progress
+        if t.status == "completed":
+            progress = "Completed"
+        elif t.status == "abandoned":
+            progress = "Abandoned"
+        else:
+            # Find current round: earliest round with unfinished matches
+            matches_by_round: dict[int, list[TournamentMatch]] = {}
+            for m in t.matches:
+                matches_by_round.setdefault(m.round, []).append(m)
+
+            current_round = 1
+            for rnd in sorted(matches_by_round.keys()):
+                round_matches = matches_by_round[rnd]
+                played = sum(1 for m in round_matches if m.winner_movie_id is not None)
+                if played < len(round_matches):
+                    current_round = rnd
+                    total_in_round = len(round_matches)
+                    break
+            else:
+                current_round = max(matches_by_round.keys()) if matches_by_round else 1
+                played = 0
+                total_in_round = 0
+
+            progress = f"Round {current_round} \u2014 {played}/{total_in_round} matches played"
+
+        items.append(
+            TournamentListItem(
+                id=str(t.id),
+                name=t.name,
+                bracket_size=t.bracket_size,
+                status=t.status,
+                created_at=t.created_at,
+                progress=progress,
+            )
+        )
+
+    return items
+
+
+@router.get("/{tournament_id}", response_model=TournamentSchema)
+async def get_tournament(
+    tournament_id: uuid.UUID,
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+):
+    """Return full bracket state for a tournament."""
+    tournament = await _load_tournament(tournament_id, current_user.id, db)
+    return _tournament_schema(tournament)
+
+
+@router.get("/{tournament_id}/next")
+async def get_next_match(
+    tournament_id: uuid.UUID,
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+):
+    """Return the next unplayed match in the tournament."""
+    tournament = await _load_tournament(tournament_id, current_user.id, db)
+
+    if tournament.status == "completed":
+        raise HTTPException(status_code=404, detail="Tournament is complete")
+    if tournament.status == "abandoned":
+        raise HTTPException(status_code=404, detail="Tournament is abandoned")
+
+    # Find first match in earliest incomplete round with both movies set
+    sorted_matches = sorted(tournament.matches, key=lambda m: (m.round, m.position))
+    for match in sorted_matches:
+        if (
+            match.movie_a_id is not None
+            and match.movie_b_id is not None
+            and match.winner_movie_id is None
+        ):
+            return _match_schema(match)
+
+    raise HTTPException(status_code=404, detail="No playable matches found")
+
+
+class MatchResult(BaseModel):
+    winner_movie_id: str
+
+
+@router.post("/{tournament_id}/matches/{match_id}")
+async def submit_match_result(
+    tournament_id: uuid.UUID,
+    match_id: uuid.UUID,
+    body: MatchResult,
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+):
+    """Submit the result of a tournament match."""
+    uid = current_user.id
+    tournament = await _load_tournament(tournament_id, uid, db)
+
+    if tournament.status != "active":
+        raise HTTPException(status_code=400, detail="Tournament is not active")
+
+    # Find the match
+    match = None
+    for m in tournament.matches:
+        if m.id == match_id:
+            match = m
+            break
+    if not match:
+        raise HTTPException(status_code=404, detail="Match not found")
+
+    if match.winner_movie_id is not None:
+        raise HTTPException(status_code=400, detail="Match already played")
+
+    winner_id = uuid.UUID(body.winner_movie_id)
+    if winner_id not in (match.movie_a_id, match.movie_b_id):
+        raise HTTPException(status_code=400, detail="Winner must be one of the two movies")
+
+    loser_id = match.movie_b_id if winner_id == match.movie_a_id else match.movie_a_id
+
+    # Fetch user_movies for ELO update
+    stmt_winner = select(UserMovie).where(
+        UserMovie.user_id == uid, UserMovie.movie_id == winner_id
+    )
+    stmt_loser = select(UserMovie).where(
+        UserMovie.user_id == uid, UserMovie.movie_id == loser_id
+    )
+    um_winner = (await db.execute(stmt_winner)).scalar_one()
+    um_loser = (await db.execute(stmt_loser)).scalar_one()
+
+    winner_elo_before = um_winner.elo if um_winner.elo is not None else get_initial_elo(um_winner.seeded_elo)
+    loser_elo_before = um_loser.elo if um_loser.elo is not None else get_initial_elo(um_loser.seeded_elo)
+
+    new_winner_elo, new_loser_elo = update_elo(
+        winner_elo_before, loser_elo_before, um_winner.battles, um_loser.battles
+    )
+
+    # Update ELO on user_movies
+    now = datetime.now(timezone.utc)
+    um_winner.elo = new_winner_elo
+    um_loser.elo = new_loser_elo
+    um_winner.battles += 1
+    um_loser.battles += 1
+    um_winner.last_dueled_at = now
+    um_loser.last_dueled_at = now
+    um_winner.updated_at = now
+    um_loser.updated_at = now
+
+    # Create a real Duel record
+    duel = Duel(
+        user_id=uid,
+        winner_movie_id=winner_id,
+        loser_movie_id=loser_id,
+        winner_elo_before=winner_elo_before,
+        loser_elo_before=loser_elo_before,
+        winner_elo_after=new_winner_elo,
+        loser_elo_after=new_loser_elo,
+        mode="tournament",
+    )
+    db.add(duel)
+    await db.flush()
+
+    # Update match
+    # Re-fetch the match directly to avoid stale state from joinedload
+    match_stmt = select(TournamentMatch).where(TournamentMatch.id == match_id)
+    match_obj = (await db.execute(match_stmt)).scalar_one()
+    match_obj.winner_movie_id = winner_id
+    match_obj.duel_id = duel.id
+    match_obj.played_at = now
+
+    # Check if current round is complete
+    round_num = match_obj.round
+    round_matches_stmt = select(TournamentMatch).where(
+        TournamentMatch.tournament_id == tournament_id,
+        TournamentMatch.round == round_num,
+    )
+    round_matches = (await db.execute(round_matches_stmt)).scalars().all()
+    round_complete = all(m.winner_movie_id is not None for m in round_matches)
+
+    num_rounds = _num_rounds(tournament.bracket_size)
+
+    if round_complete and round_num < num_rounds:
+        # Populate next round matches with winners
+        # Sort current round by position
+        round_matches_sorted = sorted(round_matches, key=lambda m: m.position)
+
+        next_round_stmt = select(TournamentMatch).where(
+            TournamentMatch.tournament_id == tournament_id,
+            TournamentMatch.round == round_num + 1,
+        ).order_by(TournamentMatch.position)
+        next_round_matches = (await db.execute(next_round_stmt)).scalars().all()
+
+        for rm in round_matches_sorted:
+            next_pos = rm.position // 2
+            next_match = next_round_matches[next_pos]
+            if rm.position % 2 == 0:
+                next_match.movie_a_id = rm.winner_movie_id
+            else:
+                next_match.movie_b_id = rm.winner_movie_id
+
+    elif round_complete and round_num == num_rounds:
+        # Final match: set champion
+        # The match we just played is the final
+        tournament_stmt = select(Tournament).where(Tournament.id == tournament_id)
+        t = (await db.execute(tournament_stmt)).scalar_one()
+        t.champion_movie_id = winner_id
+        t.status = "completed"
+        t.completed_at = now
+
+    await db.flush()
+
+    # Reload and return updated tournament
+    tournament = await _load_tournament(tournament_id, uid, db)
+    return _tournament_schema(tournament)
+
+
+@router.delete("/{tournament_id}")
+async def abandon_tournament(
+    tournament_id: uuid.UUID,
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+):
+    """Abandon a tournament (soft delete)."""
+    uid = current_user.id
+
+    # Verify ownership
+    stmt = select(Tournament).where(Tournament.id == tournament_id)
+    result = await db.execute(stmt)
+    tournament = result.scalar_one_or_none()
+    if not tournament or tournament.user_id != uid:
+        raise HTTPException(status_code=404, detail="Tournament not found")
+
+    if tournament.status == "abandoned":
+        raise HTTPException(status_code=400, detail="Tournament already abandoned")
+
+    tournament.status = "abandoned"
+    return {"status": "abandoned"}


### PR DESCRIPTION
## Summary
- Implements all 6 tournament API endpoints: create+seed, list, get bracket, next match, submit result, abandon
- Standard tournament seeding (1v8, 4v5, 2v7, 3v6 for bracket of 8) keeps top seeds on opposite sides
- Match results create real Duel records and update ELO ratings inline
- Round advancement automatically populates next-round matches when a round completes
- Champion set and status flipped to completed when final match is played

## Test plan
- [ ] POST /api/tournaments with bracket_size=8 creates correct seedings
- [ ] Verify genre and decade filtering reduces candidate pool correctly
- [ ] Submit all matches in a bracket, verify round advancement and champion crowning
- [ ] Confirm ELO updates persist via duel records
- [ ] DELETE sets status to abandoned without deleting data
- [ ] All endpoints return 404 for other users' tournaments

🤖 Generated with [Claude Code](https://claude.com/claude-code)