### PR TITLE
feat: tournament bracket frontend

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -5,6 +5,8 @@ import Login from "./pages/Login";
 import Duel from "./pages/Duel";
 import Rankings from "./pages/Rankings";
 import Swipe from "./pages/Swipe";
+import Tournaments from "./pages/Tournaments";
+import TournamentBracket from "./pages/TournamentBracket";
 
 function ProtectedRoute({ children }) {
   const [status, setStatus] = useState("loading");
@@ -73,6 +75,22 @@ export default function App() {
               </ProtectedRoute>
             }
           />
+          <Route
+            path="/tournaments"
+            element={
+              <ProtectedRoute>
+                <Tournaments />
+              </ProtectedRoute>
+            }
+          />
+          <Route
+            path="/tournaments/:id"
+            element={
+              <ProtectedRoute>
+                <TournamentBracket />
+              </ProtectedRoute>
+            }
+          />
         </Routes>
       </main>
       {/* Mobile bottom nav */}
@@ -106,6 +124,16 @@ export default function App() {
           }`}
         >
           <span className="text-[10px] font-bold uppercase tracking-[0.1em] font-headline">Rankings</span>
+        </a>
+        <a
+          href="/tournaments"
+          className={`flex flex-col items-center justify-center px-6 py-2 transition-colors ${
+            location.pathname.startsWith("/tournaments")
+              ? "text-[#E8A020] border-t-2 border-[#E8A020] bg-[#E8A020]/10"
+              : "text-[#6B6760] hover:text-[#F5F0E8]"
+          }`}
+        >
+          <span className="text-[10px] font-bold uppercase tracking-[0.1em] font-headline">Brackets</span>
         </a>
       </nav>
     </div>

--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -49,3 +49,40 @@ export function submitSwipeResults(results) {
 }
 
 export function logout() { return request("/auth/logout", { method: "POST" }); }
+
+// ── Tournaments ──────────────────────────────────────────────────────
+
+export function getTournaments() {
+  return request("/api/tournaments");
+}
+
+export function createTournament(name, bracketSize, filterType, filterValue) {
+  return request("/api/tournaments", {
+    method: "POST",
+    body: JSON.stringify({
+      name,
+      bracket_size: bracketSize,
+      filter_type: filterType || null,
+      filter_value: filterValue || null,
+    }),
+  });
+}
+
+export function getTournament(id) {
+  return request(`/api/tournaments/${id}`);
+}
+
+export function getNextMatch(tournamentId) {
+  return request(`/api/tournaments/${tournamentId}/next`);
+}
+
+export function submitTournamentMatch(tournamentId, matchId, winnerMovieId) {
+  return request(`/api/tournaments/${tournamentId}/matches/${matchId}`, {
+    method: "POST",
+    body: JSON.stringify({ winner_movie_id: winnerMovieId }),
+  });
+}
+
+export function abandonTournament(id) {
+  return request(`/api/tournaments/${id}`, { method: "DELETE" });
+}

--- a/frontend/src/components/Nav.jsx
+++ b/frontend/src/components/Nav.jsx
@@ -5,6 +5,7 @@ const navItems = [
   { path: "/", label: "Current Duel", icon: "swords" },
   { path: "/swipe", label: "Swipe", icon: "swipe" },
   { path: "/rankings", label: "Rankings", icon: "leaderboard" },
+  { path: "/tournaments", label: "Tournaments", icon: "bracket" },
 ];
 
 export default function Nav() {
@@ -35,7 +36,10 @@ export default function Nav() {
       {/* Nav items */}
       <nav className="flex-1 space-y-2">
         {navItems.map((item) => {
-          const isActive = location.pathname === item.path;
+          const isActive =
+            item.path === "/"
+              ? location.pathname === "/"
+              : location.pathname.startsWith(item.path);
           return (
             <Link
               key={item.path}

--- a/frontend/src/pages/TournamentBracket.jsx
+++ b/frontend/src/pages/TournamentBracket.jsx
@@ -1,0 +1,495 @@
+import { useState, useEffect, useCallback, useMemo } from "react";
+import { useParams, useNavigate } from "react-router-dom";
+import { getTournament, submitTournamentMatch, abandonTournament } from "../api";
+import MovieCard from "../components/MovieCard";
+
+function roundLabel(round, totalRounds) {
+  if (round === totalRounds) return "Final";
+  if (round === totalRounds - 1) return "Semifinals";
+  if (round === totalRounds - 2) return "Quarterfinals";
+  return `Round ${round}`;
+}
+
+function matchCountInRound(bracketSize, round) {
+  return bracketSize / Math.pow(2, round);
+}
+
+/** Tiny poster thumbnail for bracket cells */
+function PosterThumb({ movie, isWinner, isLoser }) {
+  if (!movie) {
+    return (
+      <div className="w-8 h-12 bg-[#1d1b1a] shrink-0 border border-[#F5F0E8]/5" />
+    );
+  }
+  return (
+    <div className="w-8 h-12 shrink-0 overflow-hidden relative">
+      <img
+        src={movie.poster_url || ""}
+        alt={movie.title}
+        className={`w-full h-full object-cover transition-all ${
+          isLoser ? "grayscale opacity-40" : ""
+        } ${isWinner ? "brightness-110" : ""}`}
+        loading="lazy"
+        onError={(e) => {
+          e.target.style.display = "none";
+        }}
+      />
+      {isWinner && (
+        <div className="absolute inset-0 border border-[#E8A020]/60" />
+      )}
+    </div>
+  );
+}
+
+/** Single match card in the bracket */
+function BracketMatch({ match, isNext, totalRounds, onClick }) {
+  const played = !!match.winner_movie_id;
+  const aWins = played && match.winner_movie_id === match.movie_a?.id;
+  const bWins = played && match.winner_movie_id === match.movie_b?.id;
+
+  return (
+    <div
+      onClick={isNext && !played ? onClick : undefined}
+      className={`relative bg-[#1d1b1a] border transition-all w-full ${
+        isNext && !played
+          ? "border-[#E8A020]/60 shadow-[0_0_20px_rgba(232,160,32,0.15)] cursor-pointer hover:border-[#E8A020] animate-pulse-slow"
+          : played
+          ? "border-[#F5F0E8]/5"
+          : "border-[#F5F0E8]/5 opacity-60"
+      }`}
+    >
+      {/* Movie A */}
+      <div
+        className={`flex items-center gap-2 px-2 py-1.5 border-b border-[#F5F0E8]/5 ${
+          aWins ? "bg-[#E8A020]/10" : ""
+        }`}
+      >
+        <PosterThumb
+          movie={match.movie_a}
+          isWinner={aWins}
+          isLoser={bWins}
+        />
+        <span
+          className={`text-[11px] font-headline font-bold uppercase tracking-tight truncate ${
+            aWins
+              ? "text-[#E8A020]"
+              : bWins
+              ? "text-[#F5F0E8]/30"
+              : "text-[#F5F0E8]/70"
+          }`}
+        >
+          {match.movie_a?.title || "TBD"}
+        </span>
+      </div>
+      {/* Movie B */}
+      <div
+        className={`flex items-center gap-2 px-2 py-1.5 ${
+          bWins ? "bg-[#E8A020]/10" : ""
+        }`}
+      >
+        <PosterThumb
+          movie={match.movie_b}
+          isWinner={bWins}
+          isLoser={aWins}
+        />
+        <span
+          className={`text-[11px] font-headline font-bold uppercase tracking-tight truncate ${
+            bWins
+              ? "text-[#E8A020]"
+              : aWins
+              ? "text-[#F5F0E8]/30"
+              : "text-[#F5F0E8]/70"
+          }`}
+        >
+          {match.movie_b?.title || "TBD"}
+        </span>
+      </div>
+      {/* Next match indicator */}
+      {isNext && !played && (
+        <div className="absolute -top-2 left-1/2 -translate-x-1/2 z-10">
+          <span className="bg-[#E8A020] text-[#0F0E0D] px-2 py-0.5 text-[8px] font-headline font-black uppercase tracking-wider">
+            Next
+          </span>
+        </div>
+      )}
+    </div>
+  );
+}
+
+export default function TournamentBracket() {
+  const { id } = useParams();
+  const navigate = useNavigate();
+  const [tournament, setTournament] = useState(null);
+  const [loading, setLoading] = useState(true);
+  const [playing, setPlaying] = useState(false); // match play mode
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState(null);
+
+  const loadTournament = useCallback(async () => {
+    try {
+      const data = await getTournament(id);
+      setTournament(data);
+    } catch (err) {
+      setError(err.message);
+    } finally {
+      setLoading(false);
+    }
+  }, [id]);
+
+  useEffect(() => {
+    loadTournament();
+  }, [loadTournament]);
+
+  // Compute bracket structure
+  const { rounds, totalRounds, nextMatch, champion } = useMemo(() => {
+    if (!tournament) return { rounds: [], totalRounds: 0, nextMatch: null, champion: null };
+
+    const tr = Math.log2(tournament.bracket_size);
+    const roundMap = {};
+    let next = null;
+
+    for (const m of tournament.matches) {
+      if (!roundMap[m.round]) roundMap[m.round] = [];
+      roundMap[m.round].push(m);
+    }
+
+    // Sort each round by position
+    const roundsList = [];
+    for (let r = 1; r <= tr; r++) {
+      const matches = (roundMap[r] || []).sort((a, b) => a.position - b.position);
+      roundsList.push({ round: r, matches });
+    }
+
+    // Find next playable match
+    for (const rd of roundsList) {
+      for (const m of rd.matches) {
+        if (m.movie_a && m.movie_b && !m.winner_movie_id) {
+          next = m;
+          break;
+        }
+      }
+      if (next) break;
+    }
+
+    // Find champion
+    let champ = null;
+    if (tournament.status === "completed" && tournament.champion_movie_id) {
+      for (const m of tournament.matches) {
+        if (m.movie_a?.id === tournament.champion_movie_id) {
+          champ = m.movie_a;
+          break;
+        }
+        if (m.movie_b?.id === tournament.champion_movie_id) {
+          champ = m.movie_b;
+          break;
+        }
+      }
+    }
+
+    return { rounds: roundsList, totalRounds: tr, nextMatch: next, champion: champ };
+  }, [tournament]);
+
+  async function handlePick(winnerMovieId) {
+    if (submitting || !nextMatch) return;
+    setSubmitting(true);
+    try {
+      const updated = await submitTournamentMatch(id, nextMatch.id, winnerMovieId);
+      setTournament(updated);
+      setPlaying(false);
+    } catch (err) {
+      setError(err.message);
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  async function handleAbandon() {
+    if (!confirm("Abandon this tournament? This cannot be undone.")) return;
+    try {
+      await abandonTournament(id);
+      navigate("/tournaments");
+    } catch (err) {
+      setError(err.message);
+    }
+  }
+
+  if (loading) {
+    return (
+      <div className="flex items-center justify-center min-h-[60vh]">
+        <div className="text-[#6B6760] text-lg font-headline uppercase tracking-widest animate-pulse">
+          Loading bracket...
+        </div>
+      </div>
+    );
+  }
+
+  if (error && !tournament) {
+    return (
+      <div className="flex flex-col items-center justify-center min-h-[60vh] gap-6 p-12">
+        <p className="text-[#C04A20] font-body text-lg">{error}</p>
+        <button
+          onClick={() => navigate("/tournaments")}
+          className="border border-[#514534]/30 hover:border-[#E8A020]/50 hover:bg-[#1d1b1a] text-[#d6c4ae] font-headline font-bold uppercase tracking-widest text-xs py-4 px-8 transition-all"
+        >
+          Back to Tournaments
+        </button>
+      </div>
+    );
+  }
+
+  // ── Match Play Mode ──────────────────────────────────────────────
+  if (playing && nextMatch) {
+    const currentRoundMatches = rounds.find((r) => r.round === nextMatch.round)?.matches || [];
+    const matchIndex = currentRoundMatches.findIndex((m) => m.id === nextMatch.id);
+    const totalInRound = currentRoundMatches.length;
+
+    return (
+      <div className="min-h-screen flex flex-col bg-[#0F0E0D] relative">
+        {/* Context header */}
+        <header className="h-16 px-6 md:px-12 flex justify-between items-center bg-[#0F0E0D]/70 backdrop-blur-xl border-b border-[#E8A020]/10 sticky top-0 z-30">
+          <div className="flex items-center gap-4">
+            <button
+              onClick={() => setPlaying(false)}
+              className="text-[#F5F0E8]/40 hover:text-[#F5F0E8] font-headline font-bold uppercase text-xs tracking-widest transition-colors"
+            >
+              Back to Bracket
+            </button>
+          </div>
+          <div className="text-center">
+            <span className="text-[10px] font-label uppercase tracking-[0.3em] text-[#E8A020]">
+              {roundLabel(nextMatch.round, totalRounds)} — Match {matchIndex + 1} of {totalInRound}
+            </span>
+          </div>
+          <div className="w-24" />
+        </header>
+
+        {/* Duel arena */}
+        <section className="flex-1 p-4 md:p-12 flex flex-col items-center justify-center gap-8 md:gap-12">
+          <p className="text-[10px] font-label uppercase tracking-[0.3em] text-[#6B6760]">
+            Tap the film you rate higher
+          </p>
+
+          <div className="w-full max-w-7xl flex flex-col md:flex-row items-center justify-between gap-4 md:gap-6 relative">
+            {/* Movie A */}
+            <div className="flex-1 w-full max-w-[500px] shadow-2xl flex justify-end">
+              <MovieCard
+                movie={nextMatch.movie_a}
+                onClick={() => handlePick(nextMatch.movie_a.id)}
+                clickable={!submitting}
+              />
+            </div>
+
+            {/* VS Badge */}
+            <div className="z-20 relative md:-mx-8 my-2 md:my-0 shrink-0">
+              <div className="w-16 h-16 md:w-20 md:h-20 bg-[#942b00] flex items-center justify-center rounded-none shadow-[0_0_40px_rgba(148,43,0,0.4)] border-2 border-[#ffb59d]/20 rotate-45">
+                <span className="font-headline font-black text-xl md:text-2xl text-[#ffb59d] -rotate-45 italic tracking-tighter">
+                  VS
+                </span>
+              </div>
+            </div>
+
+            {/* Movie B */}
+            <div className="flex-1 w-full max-w-[500px] shadow-2xl flex justify-start">
+              <MovieCard
+                movie={nextMatch.movie_b}
+                onClick={() => handlePick(nextMatch.movie_b.id)}
+                clickable={!submitting}
+              />
+            </div>
+          </div>
+
+          {submitting && (
+            <p className="text-sm text-[#E8A020] font-headline font-medium uppercase tracking-widest animate-pulse">
+              Submitting...
+            </p>
+          )}
+        </section>
+      </div>
+    );
+  }
+
+  // ── Bracket View ─────────────────────────────────────────────────
+  const isCompleted = tournament.status === "completed";
+  const isAbandoned = tournament.status === "abandoned";
+
+  return (
+    <div className="min-h-screen bg-[#0F0E0D] p-6 md:p-12 pb-32">
+      {/* Header */}
+      <header className="mb-8">
+        <div className="flex items-center gap-4 mb-2">
+          <button
+            onClick={() => navigate("/tournaments")}
+            className="text-[#F5F0E8]/40 hover:text-[#F5F0E8] font-headline font-bold uppercase text-xs tracking-widest transition-colors"
+          >
+            Tournaments
+          </button>
+          <span className="text-[#F5F0E8]/20">/</span>
+        </div>
+        <h2 className="text-4xl md:text-6xl font-headline font-black uppercase tracking-tighter text-[#F5F0E8] leading-none mb-4">
+          {tournament.name}
+        </h2>
+        <div className="flex items-center gap-6 flex-wrap">
+          <span className="text-[10px] font-label uppercase tracking-[0.3em] text-[#6B6760]">
+            {tournament.bracket_size} films
+          </span>
+          <span
+            className={`text-[10px] font-label uppercase tracking-[0.3em] ${
+              isCompleted ? "text-[#E8A020]" : isAbandoned ? "text-[#C04A20]" : "text-[#6B6760]"
+            }`}
+          >
+            {tournament.status}
+          </span>
+          {tournament.filter_type && (
+            <span className="text-[10px] font-label uppercase tracking-[0.3em] text-[#6B6760]">
+              {tournament.filter_type}: {tournament.filter_value}
+            </span>
+          )}
+        </div>
+      </header>
+
+      {/* Champion Banner */}
+      {isCompleted && champion && (
+        <div className="mb-10 bg-[#1d1b1a] border-l-4 border-[#E8A020] p-6 md:p-8 flex items-center gap-6 shadow-[inset_0_0_60px_rgba(232,160,32,0.05)]">
+          <div className="w-20 h-28 md:w-28 md:h-40 shrink-0 overflow-hidden relative">
+            {champion.poster_url && (
+              <img
+                src={champion.poster_url}
+                alt={champion.title}
+                className="w-full h-full object-cover"
+              />
+            )}
+            <div className="absolute inset-0 noir-gradient" />
+          </div>
+          <div>
+            <span className="text-3xl md:text-4xl mb-2 block">&#127942;</span>
+            <p className="text-[10px] font-label uppercase tracking-[0.3em] text-[#E8A020] mb-1">
+              Champion
+            </p>
+            <h3 className="text-2xl md:text-4xl font-headline font-black uppercase tracking-tighter text-[#E8A020] leading-none">
+              {champion.title}
+            </h3>
+            {champion.year && (
+              <p className="text-sm font-label text-[#F5F0E8]/40 mt-1">{champion.year}</p>
+            )}
+          </div>
+        </div>
+      )}
+
+      {/* Play Next Match Button */}
+      {nextMatch && !isCompleted && !isAbandoned && (
+        <div className="mb-8">
+          <button
+            onClick={() => setPlaying(true)}
+            className="bg-[#E8A020] text-[#0F0E0D] font-headline font-black uppercase py-4 px-8 tracking-widest text-sm hover:shadow-[0_0_30px_rgba(232,160,32,0.4)] active:scale-[0.98] transition-all"
+          >
+            Play Next Match
+          </button>
+        </div>
+      )}
+
+      {/* Error */}
+      {error && (
+        <p className="text-[#C04A20] font-body text-sm mb-4">{error}</p>
+      )}
+
+      {/* Bracket Grid */}
+      <div className="overflow-x-auto pb-6 -mx-6 px-6">
+        <div
+          className="flex gap-4 md:gap-6"
+          style={{ minWidth: `${rounds.length * 200}px` }}
+        >
+          {rounds.map((rd) => (
+            <div key={rd.round} className="flex-1 min-w-[160px] md:min-w-[180px]">
+              {/* Round Header */}
+              <div className="mb-4 pb-2 border-b border-[#F5F0E8]/10">
+                <span className="text-[10px] font-label uppercase tracking-[0.3em] text-[#6B6760]">
+                  {roundLabel(rd.round, totalRounds)}
+                </span>
+              </div>
+
+              {/* Matches */}
+              <div
+                className="flex flex-col justify-around h-full gap-2"
+                style={{
+                  // Increase spacing for later rounds to align with feeder matches
+                  gap: `${Math.pow(2, rd.round - 1) * 8}px`,
+                  paddingTop: `${(Math.pow(2, rd.round - 1) - 1) * 24}px`,
+                }}
+              >
+                {rd.matches.map((m) => (
+                  <BracketMatch
+                    key={m.id}
+                    match={m}
+                    isNext={nextMatch?.id === m.id}
+                    totalRounds={totalRounds}
+                    onClick={() => setPlaying(true)}
+                  />
+                ))}
+              </div>
+            </div>
+          ))}
+
+          {/* Champion column */}
+          <div className="min-w-[140px] md:min-w-[160px]">
+            <div className="mb-4 pb-2 border-b border-[#E8A020]/30">
+              <span className="text-[10px] font-label uppercase tracking-[0.3em] text-[#E8A020]">
+                Champion
+              </span>
+            </div>
+            <div
+              className="flex flex-col justify-around h-full"
+              style={{
+                paddingTop: `${(Math.pow(2, totalRounds) - 1) * 24}px`,
+              }}
+            >
+              {champion ? (
+                <div className="bg-[#1d1b1a] border border-[#E8A020]/40 p-3 shadow-[0_0_20px_rgba(232,160,32,0.1)]">
+                  <div className="flex items-center gap-2">
+                    <PosterThumb movie={champion} isWinner />
+                    <div className="min-w-0">
+                      <span className="text-[11px] font-headline font-bold uppercase tracking-tight text-[#E8A020] truncate block">
+                        {champion.title}
+                      </span>
+                      <span className="text-[9px] text-[#F5F0E8]/40">
+                        &#127942; Winner
+                      </span>
+                    </div>
+                  </div>
+                </div>
+              ) : (
+                <div className="bg-[#1d1b1a] border border-[#F5F0E8]/5 p-3 opacity-40">
+                  <span className="text-[11px] font-headline font-bold uppercase tracking-tight text-[#F5F0E8]/30">
+                    TBD
+                  </span>
+                </div>
+              )}
+            </div>
+          </div>
+        </div>
+      </div>
+
+      {/* Bracket connector lines via CSS (visual hint) */}
+      <style>{`
+        .animate-pulse-slow {
+          animation: pulse-slow 2s ease-in-out infinite;
+        }
+        @keyframes pulse-slow {
+          0%, 100% { box-shadow: 0 0 10px rgba(232,160,32,0.1); }
+          50% { box-shadow: 0 0 25px rgba(232,160,32,0.25); }
+        }
+      `}</style>
+
+      {/* Abandon button */}
+      {!isCompleted && !isAbandoned && (
+        <div className="mt-12 pt-8 border-t border-[#F5F0E8]/5">
+          <button
+            onClick={handleAbandon}
+            className="text-[#C04A20]/60 hover:text-[#C04A20] font-headline font-bold uppercase text-xs tracking-widest transition-colors"
+          >
+            Abandon Tournament
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/pages/Tournaments.jsx
+++ b/frontend/src/pages/Tournaments.jsx
@@ -1,0 +1,319 @@
+import { useState, useEffect } from "react";
+import { useNavigate } from "react-router-dom";
+import { getTournaments, createTournament, getRankings } from "../api";
+
+const BRACKET_SIZES = [8, 16, 32, 64];
+const DECADES = ["1970s", "1980s", "1990s", "2000s", "2010s", "2020s"];
+
+export default function Tournaments() {
+  const navigate = useNavigate();
+  const [tournaments, setTournaments] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [showCreate, setShowCreate] = useState(false);
+  const [creating, setCreating] = useState(false);
+  const [error, setError] = useState(null);
+
+  // Create form state
+  const [name, setName] = useState("");
+  const [bracketSize, setBracketSize] = useState(16);
+  const [filterMode, setFilterMode] = useState("all"); // all | genre | decade
+  const [filterValue, setFilterValue] = useState("");
+  const [availableGenres, setAvailableGenres] = useState([]);
+
+  useEffect(() => {
+    loadTournaments();
+  }, []);
+
+  async function loadTournaments() {
+    try {
+      const data = await getTournaments();
+      setTournaments(data);
+    } catch (err) {
+      console.error("Failed to load tournaments:", err);
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  async function handleOpenCreate() {
+    setShowCreate(true);
+    // Fetch genres from rankings
+    try {
+      const data = await getRankings(200);
+      const genreSet = new Set();
+      data.rankings.forEach((r) => {
+        (r.movie.genres || []).forEach((g) => genreSet.add(g));
+      });
+      setAvailableGenres([...genreSet].sort());
+    } catch (err) {
+      console.error("Failed to load genres:", err);
+    }
+  }
+
+  async function handleCreate() {
+    if (!name.trim()) return;
+    setCreating(true);
+    setError(null);
+    try {
+      const filterType = filterMode === "all" ? null : filterMode;
+      const fv = filterMode === "all" ? null : filterValue;
+      const t = await createTournament(name.trim(), bracketSize, filterType, fv);
+      navigate(`/tournaments/${t.id}`);
+    } catch (err) {
+      setError(err.message);
+    } finally {
+      setCreating(false);
+    }
+  }
+
+  if (loading) {
+    return (
+      <div className="flex items-center justify-center min-h-[60vh]">
+        <div className="text-[#6B6760] text-lg font-headline uppercase tracking-widest animate-pulse">
+          Loading tournaments...
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="min-h-screen bg-[#0F0E0D] p-6 md:p-12 pb-32">
+      {/* Header */}
+      <header className="mb-12 flex items-start justify-between gap-4 flex-wrap">
+        <h2 className="text-5xl md:text-7xl font-headline font-black uppercase tracking-tighter text-[#F5F0E8] leading-none">
+          Tour<span className="text-[#E8A020]">naments</span>
+        </h2>
+        {!showCreate && (
+          <button
+            onClick={handleOpenCreate}
+            className="bg-[#E8A020] text-[#0F0E0D] font-headline font-black uppercase py-4 px-8 tracking-widest text-sm hover:shadow-[0_0_30px_rgba(232,160,32,0.4)] active:scale-[0.98] transition-all shrink-0"
+          >
+            Create Tournament
+          </button>
+        )}
+      </header>
+
+      {/* Create Form */}
+      {showCreate && (
+        <div className="mb-12 bg-[#1d1b1a] p-6 md:p-8 border-l-4 border-[#E8A020]">
+          <h3 className="text-2xl font-headline font-black uppercase tracking-tight text-[#F5F0E8] mb-6">
+            New Tournament
+          </h3>
+
+          {/* Name */}
+          <div className="mb-6">
+            <label className="text-[10px] font-label uppercase tracking-[0.3em] text-[#6B6760] block mb-2">
+              Tournament Name
+            </label>
+            <input
+              type="text"
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              placeholder="Horror Showdown"
+              className="w-full max-w-md bg-[#0F0E0D] border border-[#F5F0E8]/10 text-[#F5F0E8] font-body px-4 py-3 placeholder:text-[#6B6760]/50 focus:border-[#E8A020]/50 focus:outline-none transition-colors"
+            />
+          </div>
+
+          {/* Bracket Size */}
+          <div className="mb-6">
+            <label className="text-[10px] font-label uppercase tracking-[0.3em] text-[#6B6760] block mb-2">
+              Bracket Size
+            </label>
+            <div className="flex gap-2">
+              {BRACKET_SIZES.map((size) => (
+                <button
+                  key={size}
+                  onClick={() => setBracketSize(size)}
+                  className={
+                    bracketSize === size
+                      ? "px-6 py-2 bg-[#E8A020] text-[#0F0E0D] font-label font-bold uppercase text-xs tracking-widest border border-[#E8A020]"
+                      : "px-6 py-2 bg-transparent text-[#F5F0E8]/60 font-label font-bold uppercase text-xs tracking-widest border border-[#F5F0E8]/10 hover:border-[#E8A020]/40 transition-colors"
+                  }
+                >
+                  {size}
+                </button>
+              ))}
+            </div>
+          </div>
+
+          {/* Filter Mode */}
+          <div className="mb-6">
+            <label className="text-[10px] font-label uppercase tracking-[0.3em] text-[#6B6760] block mb-2">
+              Filter Films
+            </label>
+            <div className="flex gap-2 mb-4">
+              {[
+                { key: "all", label: "All Films" },
+                { key: "genre", label: "By Genre" },
+                { key: "decade", label: "By Decade" },
+              ].map((opt) => (
+                <button
+                  key={opt.key}
+                  onClick={() => {
+                    setFilterMode(opt.key);
+                    setFilterValue("");
+                  }}
+                  className={
+                    filterMode === opt.key
+                      ? "px-6 py-2 bg-[#E8A020] text-[#0F0E0D] font-label font-bold uppercase text-xs tracking-widest border border-[#E8A020]"
+                      : "px-6 py-2 bg-transparent text-[#F5F0E8]/60 font-label font-bold uppercase text-xs tracking-widest border border-[#F5F0E8]/10 hover:border-[#E8A020]/40 transition-colors"
+                  }
+                >
+                  {opt.label}
+                </button>
+              ))}
+            </div>
+
+            {/* Genre pills */}
+            {filterMode === "genre" && (
+              <div className="flex flex-wrap gap-2">
+                {availableGenres.map((g) => (
+                  <button
+                    key={g}
+                    onClick={() => setFilterValue(g)}
+                    className={
+                      filterValue === g
+                        ? "px-4 py-1.5 bg-[#E8A020] text-[#0F0E0D] font-label font-bold uppercase text-[10px] tracking-widest border border-[#E8A020]"
+                        : "px-4 py-1.5 bg-transparent text-[#F5F0E8]/60 font-label font-bold uppercase text-[10px] tracking-widest border border-[#F5F0E8]/10 hover:border-[#E8A020]/40 transition-colors"
+                    }
+                  >
+                    {g}
+                  </button>
+                ))}
+                {availableGenres.length === 0 && (
+                  <span className="text-[#6B6760] text-sm font-body">Loading genres...</span>
+                )}
+              </div>
+            )}
+
+            {/* Decade pills */}
+            {filterMode === "decade" && (
+              <div className="flex flex-wrap gap-2">
+                {DECADES.map((d) => (
+                  <button
+                    key={d}
+                    onClick={() => setFilterValue(d)}
+                    className={
+                      filterValue === d
+                        ? "px-4 py-1.5 bg-[#E8A020] text-[#0F0E0D] font-label font-bold uppercase text-[10px] tracking-widest border border-[#E8A020]"
+                        : "px-4 py-1.5 bg-transparent text-[#F5F0E8]/60 font-label font-bold uppercase text-[10px] tracking-widest border border-[#F5F0E8]/10 hover:border-[#E8A020]/40 transition-colors"
+                    }
+                  >
+                    {d}
+                  </button>
+                ))}
+              </div>
+            )}
+          </div>
+
+          {/* Error */}
+          {error && (
+            <p className="text-[#C04A20] font-body text-sm mb-4">{error}</p>
+          )}
+
+          {/* Actions */}
+          <div className="flex gap-3">
+            <button
+              onClick={handleCreate}
+              disabled={creating || !name.trim() || (filterMode !== "all" && !filterValue)}
+              className="bg-[#E8A020] text-[#0F0E0D] font-headline font-black uppercase py-4 px-8 tracking-widest text-sm hover:shadow-[0_0_30px_rgba(232,160,32,0.4)] active:scale-[0.98] transition-all disabled:opacity-40 disabled:cursor-not-allowed"
+            >
+              {creating ? "Creating..." : "Create & Seed"}
+            </button>
+            <button
+              onClick={() => {
+                setShowCreate(false);
+                setError(null);
+              }}
+              className="border border-[#F5F0E8]/10 hover:border-[#E8A020]/40 text-[#F5F0E8]/60 font-headline font-bold uppercase py-4 px-8 tracking-widest text-xs transition-colors"
+            >
+              Cancel
+            </button>
+          </div>
+        </div>
+      )}
+
+      {/* Tournament List */}
+      {tournaments.length === 0 && !showCreate ? (
+        <div className="p-8 text-center text-[#6B6760] bg-[#1d1b1a] font-body">
+          No tournaments yet. Create one to get started!
+        </div>
+      ) : (
+        <div className="space-y-4">
+          {tournaments.map((t) => {
+            const isActive = t.status === "active";
+            const isCompleted = t.status === "completed";
+            return (
+              <div
+                key={t.id}
+                className={`group relative flex items-center gap-4 md:gap-8 p-4 md:p-6 transition-colors ${
+                  isActive
+                    ? "bg-[#1d1b1a] border-l-4 border-[#E8A020] shadow-[inset_0_0_40px_rgba(232,160,32,0.05)]"
+                    : isCompleted
+                    ? "bg-[#141312] border-l-4 border-[#E8A020]/40 hover:bg-[#1d1b1a]"
+                    : "bg-[#141312] border-l-4 border-transparent hover:bg-[#1d1b1a] opacity-50"
+                }`}
+              >
+                {/* Info */}
+                <div className="flex-1 min-w-0">
+                  <div className="flex items-baseline gap-3 mb-1">
+                    <h3 className="font-headline font-bold uppercase text-lg md:text-2xl text-[#F5F0E8] truncate">
+                      {t.name}
+                    </h3>
+                    <span className="text-sm font-label text-[#F5F0E8]/40 shrink-0 hidden sm:inline">
+                      {t.bracket_size} films
+                    </span>
+                  </div>
+                  <div className="flex gap-4 md:gap-6 items-center">
+                    <div className="flex flex-col">
+                      <span className="text-[10px] font-label uppercase tracking-widest text-[#6B6760]">
+                        Status
+                      </span>
+                      <span
+                        className={`font-headline font-bold text-sm uppercase ${
+                          isActive
+                            ? "text-[#E8A020]"
+                            : isCompleted
+                            ? "text-[#F5F0E8]/60"
+                            : "text-[#6B6760]"
+                        }`}
+                      >
+                        {t.status}
+                      </span>
+                    </div>
+                    <div className="flex flex-col">
+                      <span className="text-[10px] font-label uppercase tracking-widest text-[#6B6760]">
+                        Progress
+                      </span>
+                      <span className="font-body text-sm text-[#F5F0E8]/60">
+                        {t.progress}
+                      </span>
+                    </div>
+                  </div>
+                </div>
+
+                {/* Action */}
+                {isActive && (
+                  <button
+                    onClick={() => navigate(`/tournaments/${t.id}`)}
+                    className="bg-[#E8A020] text-[#0F0E0D] font-headline font-black uppercase py-3 px-6 tracking-widest text-xs hover:shadow-[0_0_20px_rgba(232,160,32,0.3)] active:scale-[0.98] transition-all shrink-0"
+                  >
+                    Continue
+                  </button>
+                )}
+                {isCompleted && (
+                  <button
+                    onClick={() => navigate(`/tournaments/${t.id}`)}
+                    className="border border-[#E8A020]/30 text-[#E8A020] font-headline font-bold uppercase py-3 px-6 tracking-widest text-xs hover:bg-[#E8A020]/10 transition-all shrink-0"
+                  >
+                    View Bracket
+                  </button>
+                )}
+              </div>
+            );
+          })}
+        </div>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- **Tournament list page** (`/tournaments`): shows all user tournaments with status, progress, and continue/view actions. Create form with name input, bracket size pills (8/16/32/64), and filter toggle (all/genre/decade) with dynamic genre pills from user's ranked films.
- **Bracket visualization page** (`/tournaments/:id`): full bracket tree using CSS flexbox with columns per round (Round 1 through Final + Champion). Match cards show poster thumbnails, movie titles, and amber highlight for winners. Next playable match pulses with amber glow.
- **Match play mode**: reuses the existing MovieCard duel layout with tournament context header showing round and match number. Submits result and returns to bracket view with winner advancing.
- **Champion state**: completed tournaments show trophy banner with champion poster and title, full bracket visible below.
- **API layer**: 6 new functions in `api.js` covering list, create, get, next match, submit result, and abandon.
- **Navigation**: added "Tournaments" to sidebar nav and mobile bottom nav with prefix-based active state.

## Test plan
- [ ] Navigate to /tournaments, verify empty state shows
- [ ] Create a tournament with genre filter, verify bracket populates
- [ ] Play through matches using "Play Next Match" button
- [ ] Verify winners advance to next round after completing a round
- [ ] Complete a tournament and verify champion banner appears
- [ ] Test mobile layout: bracket scrolls horizontally, bottom nav shows Brackets tab
- [ ] Test abandon tournament flow

🤖 Generated with [Claude Code](https://claude.com/claude-code)