### PR TITLE
Fix tournament genre loading with dedicated endpoint

### DIFF
--- a/backend/routers/tournaments.py
+++ b/backend/routers/tournaments.py
@@ -9,7 +9,7 @@ from typing import Optional
 
 from fastapi import APIRouter, Depends, HTTPException
 from pydantic import BaseModel
-from sqlalchemy import select
+from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import joinedload
 
@@ -130,6 +130,31 @@ async def _load_tournament(
 
 
 # ── Endpoints ──────────────────────────────────────────────────────────
+
+
+@router.get("/genres", response_model=list[str])
+async def get_available_genres(
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+):
+    """Return distinct genres from user's seen films for tournament filtering."""
+    uid = current_user.id
+    stmt = (
+        select(func.unnest(Movie.genres).label("genre"))
+        .select_from(UserMovie)
+        .join(Movie, UserMovie.movie_id == Movie.id)
+        .where(
+            UserMovie.user_id == uid,
+            UserMovie.seen.is_(True),
+            UserMovie.battles >= 1,
+            UserMovie.elo.isnot(None),
+            Movie.genres.isnot(None),
+        )
+        .distinct()
+        .order_by("genre")
+    )
+    result = await db.execute(stmt)
+    return [row[0] for row in result.all()]
 
 
 @router.post("", response_model=TournamentSchema)

--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -56,6 +56,10 @@ export function getTournaments() {
   return request("/api/tournaments");
 }
 
+export function getTournamentGenres() {
+  return request("/api/tournaments/genres");
+}
+
 export function createTournament(name, bracketSize, filterType, filterValue) {
   return request("/api/tournaments", {
     method: "POST",

--- a/frontend/src/pages/Tournaments.jsx
+++ b/frontend/src/pages/Tournaments.jsx
@@ -1,6 +1,6 @@
 import { useState, useEffect } from "react";
 import { useNavigate } from "react-router-dom";
-import { getTournaments, createTournament, getRankings } from "../api";
+import { getTournaments, createTournament, getTournamentGenres } from "../api";
 
 const BRACKET_SIZES = [8, 16, 32, 64];
 const DECADES = ["1970s", "1980s", "1990s", "2000s", "2010s", "2020s"];
@@ -37,14 +37,9 @@ export default function Tournaments() {
 
   async function handleOpenCreate() {
     setShowCreate(true);
-    // Fetch genres from rankings
     try {
-      const data = await getRankings(200);
-      const genreSet = new Set();
-      data.rankings.forEach((r) => {
-        (r.movie.genres || []).forEach((g) => genreSet.add(g));
-      });
-      setAvailableGenres([...genreSet].sort());
+      const genres = await getTournamentGenres();
+      setAvailableGenres(genres);
     } catch (err) {
       console.error("Failed to load genres:", err);
     }


### PR DESCRIPTION
## Summary
- Add `GET /api/tournaments/genres` endpoint that queries distinct genres from the user's ranked films using PostgreSQL `unnest()` on the `Movie.genres` array column
- Add `getTournamentGenres()` API function in the frontend
- Update `handleOpenCreate` in Tournaments.jsx to use the new endpoint instead of trying to parse genres from `MovieSchema` (which never included them)

## Test plan
- [ ] Open tournament creation form and verify genre pills appear
- [ ] Verify genres listed match genres from user's ranked films only
- [ ] Create a genre-filtered tournament and confirm correct films are selected

🤖 Generated with [Claude Code](https://claude.com/claude-code)