### PR TITLE
Fix mobile duel layout and winner feedback

### DIFF
--- a/frontend/src/components/MovieCard.jsx
+++ b/frontend/src/components/MovieCard.jsx
@@ -7,6 +7,7 @@ export default function MovieCard({
   highlight,
   clickable = false,
   compact = false,
+  chosen, // "winner" | "loser" | undefined
 }) {
   const posterSrc = movie.poster_url
     ? movie.poster_url
@@ -23,7 +24,10 @@ export default function MovieCard({
           "cursor-pointer hover:scale-[1.02] active:scale-95",
         !clickable && "cursor-default",
         highlight &&
-          "border-2 border-[#E8A020] shadow-[0_0_30px_rgba(232,160,32,0.15)]"
+          "border-2 border-[#E8A020] shadow-[0_0_30px_rgba(232,160,32,0.15)]",
+        chosen === "winner" &&
+          "border-2 border-[#E8A020] shadow-[0_0_40px_rgba(232,160,32,0.35)] scale-[1.03] animate-winner-pulse",
+        chosen === "loser" && "opacity-40 scale-[0.97]"
       )}
       onClick={clickable ? onClick : undefined}
       role={clickable ? "button" : undefined}
@@ -66,6 +70,15 @@ export default function MovieCard({
           </div>
         )}
 
+        {/* Winner label after duel */}
+        {chosen === "winner" && (
+          <div className="absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 z-20">
+            <span className="bg-[#E8A020] text-[#442b00] px-5 py-2 font-headline font-black text-lg uppercase tracking-wider shadow-[0_0_30px_rgba(232,160,32,0.5)]">
+              Winner
+            </span>
+          </div>
+        )}
+
         {/* Genre badges */}
         {genres.length > 0 && (
           <div className="absolute top-6 left-6 flex gap-2">
@@ -81,13 +94,13 @@ export default function MovieCard({
         )}
 
         {/* Overlay title content */}
-        <div className="absolute bottom-6 left-6 right-6">
+        <div className={cn("absolute left-4 right-4", compact ? "bottom-3" : "bottom-6 left-6 right-6")}>
           {movie.year && (
-            <p className="text-xs font-label uppercase tracking-[0.3em] text-[#d6c4ae]/80 mb-2">
+            <p className={cn("font-label uppercase text-[#d6c4ae]/80", compact ? "text-[9px] tracking-[0.2em] mb-1" : "text-xs tracking-[0.3em] mb-2")}>
               {movie.year}
             </p>
           )}
-          <h2 className="text-2xl md:text-3xl font-headline font-black uppercase tracking-tighter text-[#F5F0E8] leading-none">
+          <h2 className={cn("font-headline font-black uppercase tracking-tighter text-[#F5F0E8] leading-none", compact ? "text-base" : "text-2xl md:text-3xl")}>
             {movie.title}
           </h2>
         </div>

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -55,3 +55,13 @@ body {
 .noir-gradient {
   background: linear-gradient(0deg, rgba(15,14,13,1) 0%, rgba(15,14,13,0) 60%);
 }
+
+@keyframes winner-pulse {
+  0% { box-shadow: 0 0 0 0 rgba(232, 160, 32, 0.6); }
+  50% { box-shadow: 0 0 40px 8px rgba(232, 160, 32, 0.35); }
+  100% { box-shadow: 0 0 20px 2px rgba(232, 160, 32, 0.2); }
+}
+
+.animate-winner-pulse {
+  animation: winner-pulse 0.6s ease-out;
+}

--- a/frontend/src/pages/Duel.jsx
+++ b/frontend/src/pages/Duel.jsx
@@ -7,7 +7,7 @@ const MODE = "discovery";
 
 function SkeletonCard() {
   return (
-    <div className="w-full max-w-[340px] overflow-hidden animate-pulse">
+    <div className="w-full max-w-[150px] md:max-w-[340px] overflow-hidden animate-pulse">
       <div className="aspect-[2/3] bg-[#1d1b1a]" />
     </div>
   );
@@ -25,6 +25,13 @@ export default function Duel() {
   const [animateKey, setAnimateKey] = useState(0);
   const [showSwipePrompt, setShowSwipePrompt] = useState(false);
   const prefetchRef = useRef(null);
+  const [windowWidth, setWindowWidth] = useState(window.innerWidth);
+
+  useEffect(() => {
+    const handleResize = () => setWindowWidth(window.innerWidth);
+    window.addEventListener("resize", handleResize);
+    return () => window.removeEventListener("resize", handleResize);
+  }, []);
 
   const loadStats = useCallback(async () => {
     try {
@@ -203,9 +210,9 @@ export default function Duel() {
       <section className="flex-1 p-4 md:p-12 flex flex-col items-center justify-center gap-8 md:gap-12">
         {/* Loading skeleton */}
         {loading && (
-          <div className="w-full max-w-7xl flex items-center justify-center gap-6">
+          <div className="w-full max-w-7xl flex items-center justify-center gap-3 md:gap-6">
             <SkeletonCard />
-            <div className="w-20 h-20 bg-[#942b00] animate-pulse rotate-45 hidden md:block" />
+            <div className="w-10 h-10 md:w-20 md:h-20 bg-[#942b00] animate-pulse rotate-45 shrink-0" />
             <SkeletonCard />
           </div>
         )}
@@ -221,42 +228,46 @@ export default function Duel() {
             {/* Cards Container */}
             <div
               key={animateKey}
-              className="w-full max-w-7xl flex flex-col md:flex-row items-center justify-between gap-4 md:gap-6 relative"
+              className="w-full max-w-7xl flex flex-row items-center justify-center gap-3 md:gap-6 relative"
             >
               {/* Left Film Card */}
-              <div className="flex-1 w-full max-w-[500px] shadow-2xl flex justify-end">
+              <div className="flex-1 max-w-[200px] md:max-w-[500px] shadow-2xl flex justify-end">
                 <MovieCard
                   movie={pair.movie_a}
                   onClick={() => handleSubmit("a_wins")}
                   delta={result?.movie_a_elo_delta}
-                  clickable={!submitting}
+                  clickable={!submitting && !result}
+                  compact={windowWidth < 768}
+                  chosen={result ? (result.outcome === "a_wins" ? "winner" : "loser") : undefined}
                 />
               </div>
 
               {/* VS Badge */}
-              <div className="z-20 relative md:-mx-8 my-2 md:my-0 shrink-0">
-                <div className="w-16 h-16 md:w-20 md:h-20 bg-[#942b00] flex items-center justify-center rounded-none shadow-[0_0_40px_rgba(148,43,0,0.4)] border-2 border-[#ffb59d]/20 rotate-45">
-                  <span className="font-headline font-black text-xl md:text-2xl text-[#ffb59d] -rotate-45 italic tracking-tighter">
+              <div className="z-20 relative md:-mx-8 shrink-0">
+                <div className="w-10 h-10 md:w-20 md:h-20 bg-[#942b00] flex items-center justify-center rounded-none shadow-[0_0_40px_rgba(148,43,0,0.4)] border-2 border-[#ffb59d]/20 rotate-45">
+                  <span className="font-headline font-black text-sm md:text-2xl text-[#ffb59d] -rotate-45 italic tracking-tighter">
                     VS
                   </span>
                 </div>
               </div>
 
               {/* Right Film Card */}
-              <div className="flex-1 w-full max-w-[500px] shadow-2xl flex justify-start">
+              <div className="flex-1 max-w-[200px] md:max-w-[500px] shadow-2xl flex justify-start">
                 <MovieCard
                   movie={pair.movie_b}
                   onClick={() => handleSubmit("b_wins")}
                   delta={result?.movie_b_elo_delta}
-                  clickable={!submitting}
+                  clickable={!submitting && !result}
+                  compact={windowWidth < 768}
+                  chosen={result ? (result.outcome === "b_wins" ? "winner" : "loser") : undefined}
                 />
               </div>
             </div>
 
             {/* Result feedback */}
             {result && (
-              <p className="text-sm text-[#E8A020] font-headline font-medium uppercase tracking-widest">
-                ELO updated! Next duel loading...
+              <p className="text-sm text-[#E8A020] font-headline font-medium uppercase tracking-widest animate-pulse">
+                Next duel loading...
               </p>
             )}
           </>


### PR DESCRIPTION
## Summary
- **Mobile layout**: Cards now display side-by-side with compact sizing (max-w-[200px]) instead of stacked vertically. VS badge scales down on mobile (w-10/h-10 vs w-20/h-20). Skeleton loading state also updated to match.
- **Winner feedback**: After choosing a duel winner, the winning card gets a golden border glow with pulse animation and a centered "WINNER" label. The losing card dims to 40% opacity. Cards become non-clickable once a result is shown.

## Test plan
- [ ] On mobile viewport (< 768px), both cards should appear side-by-side with compact posters and smaller VS badge
- [ ] On desktop, layout should remain unchanged (large cards side-by-side)
- [ ] After tapping a card, winning card should glow gold with "WINNER" label, loser should dim
- [ ] Cards should not be clickable after result is shown
- [ ] Resizing browser window should toggle compact mode dynamically

🤖 Generated with [Claude Code](https://claude.com/claude-code)