### PR TITLE
fix: add required env vars to CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,9 @@ on:
 jobs:
   backend:
     runs-on: ubuntu-latest
+    env:
+      SECRET_KEY: "ci-test-key-not-for-production"
+      DATABASE_URL: "postgresql+asyncpg://postgres:postgres@localhost:5432/postgres"
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
## Summary
- SECRET_KEY no longer has a default after the security fix (PR #30)
- CI import check and tests fail because the env var is missing
- Add dummy SECRET_KEY and DATABASE_URL as job-level env vars

## Test plan
- [ ] CI backend job passes (import check + tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)