### PR TITLE
feat: background pool expansion after swipe

### DIFF
--- a/backend/db_models.py
+++ b/backend/db_models.py
@@ -224,6 +224,26 @@ class Duel(Base):
     loser_movie: Mapped[Optional[Movie]] = relationship(foreign_keys=[loser_movie_id])
 
 
+class PoolExpansion(Base):
+    __tablename__ = "pool_expansions"
+    __table_args__ = (
+        Index("ix_pool_expansions_user_source_key", "user_id", "source", "source_key"),
+    )
+
+    id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), primary_key=True, default=uuid.uuid4
+    )
+    user_id: Mapped[Optional[uuid.UUID]] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("users.id", ondelete="CASCADE"), nullable=True
+    )
+    source: Mapped[str] = mapped_column(Text, nullable=False)
+    source_key: Mapped[Optional[str]] = mapped_column(Text, nullable=True)
+    films_added: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
+    ran_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), default=lambda: datetime.now(timezone.utc)
+    )
+
+
 class SwipeResult(Base):
     __tablename__ = "swipe_results"
     __table_args__ = (Index("ix_swipe_results_user_id", "user_id"),)

--- a/backend/migrations/versions/006_add_pool_expansions.py
+++ b/backend/migrations/versions/006_add_pool_expansions.py
@@ -1,0 +1,52 @@
+"""Add pool_expansions table for tracking background pool expansion runs
+
+Revision ID: 006
+Revises: 005
+Create Date: 2026-04-12
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects.postgresql import UUID
+
+revision: str = "006"
+down_revision: Union[str, None] = "005"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "pool_expansions",
+        sa.Column(
+            "id",
+            UUID(as_uuid=True),
+            primary_key=True,
+            server_default=sa.text("gen_random_uuid()"),
+        ),
+        sa.Column(
+            "user_id",
+            UUID(as_uuid=True),
+            sa.ForeignKey("users.id", ondelete="CASCADE"),
+            nullable=True,
+        ),
+        sa.Column("source", sa.Text(), nullable=False),
+        sa.Column("source_key", sa.Text(), nullable=True),
+        sa.Column("films_added", sa.Integer(), nullable=False, server_default="0"),
+        sa.Column(
+            "ran_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.func.now(),
+            nullable=False,
+        ),
+    )
+    op.create_index(
+        "ix_pool_expansions_user_source_key",
+        "pool_expansions",
+        ["user_id", "source", "source_key"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("pool_expansions")

--- a/backend/routers/swipe.py
+++ b/backend/routers/swipe.py
@@ -6,7 +6,7 @@ import logging
 import uuid
 from datetime import datetime, timezone
 
-from fastapi import APIRouter, Depends, HTTPException
+from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException
 from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -14,6 +14,7 @@ from backend.db import get_db
 from backend.db_models import Movie, SwipeResult, User, UserMovie
 from backend.routers.auth import get_current_user
 from backend.schemas import SwipeCardSchema, SwipeResponse, SwipeSubmit
+from backend.services.expand import expand_pool
 
 logger = logging.getLogger(__name__)
 
@@ -148,6 +149,7 @@ async def get_swipe_cards(
 @router.post("/results", response_model=SwipeResponse)
 async def submit_swipe_results(
     body: SwipeSubmit,
+    background_tasks: BackgroundTasks,
     current_user: User = Depends(get_current_user),
     db: AsyncSession = Depends(get_db),
 ):
@@ -199,5 +201,16 @@ async def submit_swipe_results(
     total_seen = (await db.execute(total_seen_stmt)).scalar() or 0
 
     next_action = "duel" if total_seen >= 2 else "swipe"
+
+    # Check if pool needs expansion
+    unknown_stmt = (
+        select(func.count())
+        .select_from(UserMovie)
+        .where(UserMovie.user_id == uid, UserMovie.seen.is_(None))
+    )
+    unknown_count = (await db.execute(unknown_stmt)).scalar() or 0
+
+    if unknown_count < 50:
+        background_tasks.add_task(expand_pool, uid)
 
     return SwipeResponse(seen_count=seen_count, unseen_count=unseen_count, next_action=next_action)

--- a/backend/services/expand.py
+++ b/backend/services/expand.py
@@ -1,0 +1,427 @@
+"""Background pool expansion — fetch more movies when the swipe pool runs low."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import uuid
+from datetime import datetime, timedelta, timezone
+
+import httpx
+import sentry_sdk
+from sqlalchemy import select
+from sqlalchemy.dialects.postgresql import insert
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from backend.config import get_settings
+from backend.db import async_session_factory
+from backend.db_models import Movie, PoolExpansion, User, UserMovie
+from backend.services.tmdb import fetch_similar_films
+from backend.services.trakt import TraktClient
+
+logger = logging.getLogger(__name__)
+
+EXPANSION_COOLDOWN = timedelta(days=7)
+TARGET_ADDED = 100
+
+
+async def expand_pool(user_id: uuid.UUID) -> int:
+    """Expand a user's movie pool. Returns count of films added.
+
+    Runs in a background task with its own DB session.
+    """
+    try:
+        return await _expand_pool_inner(user_id)
+    except Exception:
+        logger.exception("Pool expansion failed for user %s", user_id)
+        sentry_sdk.capture_exception()
+        return 0
+
+
+async def _expand_pool_inner(user_id: uuid.UUID) -> int:
+    settings = get_settings()
+    total_added = 0
+
+    async with async_session_factory() as db:
+        # Load user for Trakt credentials
+        user = await db.get(User, user_id)
+        if not user:
+            logger.warning("expand_pool: user %s not found", user_id)
+            return 0
+
+        now = datetime.now(timezone.utc)
+        cutoff = now - EXPANSION_COOLDOWN
+
+        # Get recent expansion sources to skip
+        recent_stmt = (
+            select(PoolExpansion.source, PoolExpansion.source_key)
+            .where(
+                PoolExpansion.user_id == user_id,
+                PoolExpansion.ran_at >= cutoff,
+            )
+        )
+        result = await db.execute(recent_stmt)
+        recent_keys: set[tuple[str, str | None]] = {
+            (row.source, row.source_key) for row in result.all()
+        }
+
+        # Source A: TMDB similar films from top-ranked movies
+        if total_added < TARGET_ADDED:
+            added = await _expand_from_similar(
+                db, user_id, settings, recent_keys, now
+            )
+            total_added += added
+
+        # Source B: Trakt anticipated
+        if total_added < TARGET_ADDED and ("anticipated", None) not in recent_keys:
+            added = await _expand_from_anticipated(
+                db, user_id, user, settings, recent_keys, now
+            )
+            total_added += added
+
+        # Source C: Deeper popular pages
+        if total_added < TARGET_ADDED:
+            added = await _expand_from_popular_pages(
+                db, user_id, user, settings, recent_keys, now
+            )
+            total_added += added
+
+        await db.commit()
+
+    logger.info(
+        "Pool expansion complete for user %s: %d films added", user_id, total_added
+    )
+    return total_added
+
+
+async def _expand_from_similar(
+    db: AsyncSession,
+    user_id: uuid.UUID,
+    settings,
+    recent_keys: set[tuple[str, str | None]],
+    now: datetime,
+) -> int:
+    """Source A: TMDB recommendations from user's top-ranked films."""
+    if not settings.TMDB_API_KEY:
+        return 0
+
+    # Get top 10 ranked films by ELO
+    top_stmt = (
+        select(UserMovie.movie_id, Movie.tmdb_id)
+        .join(Movie, Movie.id == UserMovie.movie_id)
+        .where(
+            UserMovie.user_id == user_id,
+            UserMovie.elo.isnot(None),
+            Movie.tmdb_id.isnot(None),
+        )
+        .order_by(UserMovie.elo.desc())
+        .limit(10)
+    )
+    result = await db.execute(top_stmt)
+    top_movies = result.all()
+
+    total = 0
+    for row in top_movies:
+        source_key = str(row.tmdb_id)
+        if ("tmdb_similar", source_key) in recent_keys:
+            continue
+
+        recs = await fetch_similar_films(row.tmdb_id, settings.TMDB_API_KEY)
+        added = 0
+        for film in recs:
+            ok = await _upsert_film_from_tmdb(db, user_id, film, settings)
+            if ok:
+                added += 1
+
+        # Record expansion
+        db.add(PoolExpansion(
+            user_id=user_id,
+            source="tmdb_similar",
+            source_key=source_key,
+            films_added=added,
+            ran_at=now,
+        ))
+        total += added
+
+        # Rate-limit TMDB calls
+        await asyncio.sleep(0.3)
+
+        if total >= TARGET_ADDED:
+            break
+
+    await db.flush()
+    return total
+
+
+async def _expand_from_anticipated(
+    db: AsyncSession,
+    user_id: uuid.UUID,
+    user: User,
+    settings,
+    recent_keys: set[tuple[str, str | None]],
+    now: datetime,
+) -> int:
+    """Source B: Trakt anticipated movies."""
+    client = TraktClient(
+        client_id=settings.TRAKT_CLIENT_ID,
+        access_token=user.trakt_access_token,
+    )
+    try:
+        async with client._client() as http:
+            resp = await http.get(
+                "/movies/anticipated",
+                params={"limit": 100, "extended": "full"},
+                timeout=15.0,
+            )
+            resp.raise_for_status()
+            items = resp.json()
+    except Exception:
+        logger.exception("Failed to fetch anticipated movies")
+        return 0
+
+    added = 0
+    for item in items:
+        movie_data = item.get("movie", item)
+        ok = await _upsert_film_from_trakt(db, user_id, movie_data, now)
+        if ok:
+            added += 1
+
+    db.add(PoolExpansion(
+        user_id=user_id,
+        source="anticipated",
+        source_key=None,
+        films_added=added,
+        ran_at=now,
+    ))
+    await db.flush()
+    return added
+
+
+async def _expand_from_popular_pages(
+    db: AsyncSession,
+    user_id: uuid.UUID,
+    user: User,
+    settings,
+    recent_keys: set[tuple[str, str | None]],
+    now: datetime,
+) -> int:
+    """Source C: Deeper pages of Trakt popular movies."""
+    client = TraktClient(
+        client_id=settings.TRAKT_CLIENT_ID,
+        access_token=user.trakt_access_token,
+    )
+    total = 0
+    for page in range(2, 6):
+        source_key = str(page)
+        if ("popular_page_N", source_key) in recent_keys:
+            continue
+
+        try:
+            async with client._client() as http:
+                resp = await http.get(
+                    "/movies/popular",
+                    params={"page": page, "limit": 100, "extended": "full"},
+                    timeout=15.0,
+                )
+                resp.raise_for_status()
+                movies = resp.json()
+        except Exception:
+            logger.exception("Failed to fetch popular page %d", page)
+            continue
+
+        added = 0
+        for movie_data in movies:
+            ok = await _upsert_film_from_trakt(db, user_id, movie_data, now)
+            if ok:
+                added += 1
+
+        db.add(PoolExpansion(
+            user_id=user_id,
+            source="popular_page_N",
+            source_key=source_key,
+            films_added=added,
+            ran_at=now,
+        ))
+        total += added
+
+        if total >= TARGET_ADDED:
+            break
+
+    await db.flush()
+    return total
+
+
+async def _upsert_film_from_trakt(
+    db: AsyncSession,
+    user_id: uuid.UUID,
+    movie_data: dict,
+    now: datetime,
+) -> bool:
+    """Upsert a Trakt movie dict into movies + user_movies. Returns True if new user_movie created."""
+    ids = movie_data.get("ids", {})
+    trakt_id = ids.get("trakt")
+    if not trakt_id:
+        return False
+
+    trakt_rating = movie_data.get("rating", 0)
+    community_rating = round(trakt_rating * 10, 1) if trakt_rating else None
+
+    stmt = insert(Movie.__table__).values(
+        trakt_id=trakt_id,
+        imdb_id=ids.get("imdb"),
+        tmdb_id=ids.get("tmdb"),
+        title=movie_data.get("title", "Unknown"),
+        year=movie_data.get("year"),
+        genres=movie_data.get("genres"),
+        overview=movie_data.get("overview"),
+        runtime=movie_data.get("runtime"),
+        community_rating=community_rating,
+        cached_at=now,
+    ).on_conflict_do_update(
+        index_elements=["trakt_id"],
+        set_={
+            "imdb_id": ids.get("imdb"),
+            "tmdb_id": ids.get("tmdb"),
+            "title": movie_data.get("title", "Unknown"),
+            "year": movie_data.get("year"),
+            "genres": movie_data.get("genres"),
+            "overview": movie_data.get("overview"),
+            "runtime": movie_data.get("runtime"),
+            "community_rating": community_rating,
+            "cached_at": now,
+        },
+    )
+    await db.execute(stmt)
+    await db.flush()
+
+    # Get movie UUID
+    result = await db.execute(
+        select(Movie.id).where(Movie.trakt_id == trakt_id)
+    )
+    movie_uuid = result.scalar_one_or_none()
+    if not movie_uuid:
+        return False
+
+    # Insert user_movie only if not exists (seen=None = unknown)
+    um_stmt = insert(UserMovie.__table__).values(
+        user_id=user_id,
+        movie_id=movie_uuid,
+        seen=None,
+        elo=None,
+        battles=0,
+        updated_at=now,
+    ).on_conflict_do_nothing(
+        index_elements=["user_id", "movie_id"],
+    )
+    result = await db.execute(um_stmt)
+    return result.rowcount > 0
+
+
+async def _upsert_film_from_tmdb(
+    db: AsyncSession,
+    user_id: uuid.UUID,
+    film: dict,
+    settings,
+) -> bool:
+    """Upsert a TMDB-sourced film. Looks up trakt_id via existing DB or Trakt search API."""
+    tmdb_id = film.get("tmdb_id")
+    if not tmdb_id:
+        return False
+
+    now = datetime.now(timezone.utc)
+
+    # Check if we already have this movie by tmdb_id
+    existing = await db.execute(
+        select(Movie.id, Movie.trakt_id).where(Movie.tmdb_id == tmdb_id)
+    )
+    row = existing.first()
+
+    if row:
+        # Movie exists, just ensure user_movie
+        um_stmt = insert(UserMovie.__table__).values(
+            user_id=user_id,
+            movie_id=row.id,
+            seen=None,
+            elo=None,
+            battles=0,
+            updated_at=now,
+        ).on_conflict_do_nothing(
+            index_elements=["user_id", "movie_id"],
+        )
+        result = await db.execute(um_stmt)
+        return result.rowcount > 0
+
+    # Need trakt_id — look up via Trakt search API
+    trakt_id = await _lookup_trakt_id(tmdb_id, settings)
+    if not trakt_id:
+        return False
+
+    # Upsert the movie
+    stmt = insert(Movie.__table__).values(
+        trakt_id=trakt_id,
+        tmdb_id=tmdb_id,
+        title=film.get("title", "Unknown"),
+        year=film.get("year"),
+        genres=film.get("genres"),
+        overview=film.get("overview"),
+        cached_at=now,
+    ).on_conflict_do_update(
+        index_elements=["trakt_id"],
+        set_={
+            "tmdb_id": tmdb_id,
+            "title": film.get("title", "Unknown"),
+            "year": film.get("year"),
+            "genres": film.get("genres"),
+            "overview": film.get("overview"),
+            "cached_at": now,
+        },
+    )
+    await db.execute(stmt)
+    await db.flush()
+
+    movie_result = await db.execute(
+        select(Movie.id).where(Movie.trakt_id == trakt_id)
+    )
+    movie_uuid = movie_result.scalar_one_or_none()
+    if not movie_uuid:
+        return False
+
+    um_stmt = insert(UserMovie.__table__).values(
+        user_id=user_id,
+        movie_id=movie_uuid,
+        seen=None,
+        elo=None,
+        battles=0,
+        updated_at=now,
+    ).on_conflict_do_nothing(
+        index_elements=["user_id", "movie_id"],
+    )
+    result = await db.execute(um_stmt)
+    return result.rowcount > 0
+
+
+async def _lookup_trakt_id(tmdb_id: int, settings) -> int | None:
+    """Look up a Trakt movie ID from a TMDB ID using the Trakt search API."""
+    try:
+        async with httpx.AsyncClient(
+            base_url="https://api.trakt.tv",
+            headers={
+                "Content-Type": "application/json",
+                "trakt-api-version": "2",
+                "trakt-api-key": settings.TRAKT_CLIENT_ID,
+            },
+        ) as client:
+            resp = await client.get(
+                f"/search/tmdb/{tmdb_id}",
+                params={"type": "movie"},
+                timeout=10.0,
+            )
+            if resp.status_code != 200:
+                return None
+            data = resp.json()
+            if data and len(data) > 0:
+                movie = data[0].get("movie", {})
+                return movie.get("ids", {}).get("trakt")
+    except Exception:
+        logger.warning("Trakt search failed for tmdb_id=%d", tmdb_id)
+    return None

--- a/backend/services/tmdb.py
+++ b/backend/services/tmdb.py
@@ -34,6 +34,58 @@ async def fetch_poster_url(tmdb_id: int) -> str | None:
         return None
 
 
+# TMDB genre_id -> genre name mapping (from TMDB API /genre/movie/list)
+TMDB_GENRE_MAP: dict[int, str] = {
+    28: "action", 12: "adventure", 16: "animation", 35: "comedy", 80: "crime",
+    99: "documentary", 18: "drama", 10751: "family", 14: "fantasy", 36: "history",
+    27: "horror", 10402: "music", 9648: "mystery", 10749: "romance",
+    878: "science-fiction", 10770: "tv movie", 53: "thriller", 10752: "war",
+    37: "western",
+}
+
+
+async def fetch_similar_films(tmdb_id: int, api_key: str) -> list[dict]:
+    """Fetch recommended films from TMDB for a given movie.
+
+    Returns list of dicts with keys: tmdb_id, title, year, overview, genres.
+    """
+    if not api_key or not tmdb_id:
+        return []
+    try:
+        async with httpx.AsyncClient() as client:
+            resp = await client.get(
+                f"https://api.themoviedb.org/3/movie/{tmdb_id}/recommendations",
+                params={"api_key": api_key},
+                timeout=10.0,
+            )
+            if resp.status_code != 200:
+                logger.warning(
+                    "TMDB recommendations returned %d for tmdb_id=%d",
+                    resp.status_code, tmdb_id,
+                )
+                return []
+            data = resp.json()
+            results = []
+            for item in data.get("results", []):
+                release_date = item.get("release_date", "")
+                year = int(release_date[:4]) if release_date and len(release_date) >= 4 else None
+                genres = [
+                    TMDB_GENRE_MAP[gid] for gid in item.get("genre_ids", [])
+                    if gid in TMDB_GENRE_MAP
+                ]
+                results.append({
+                    "tmdb_id": item["id"],
+                    "title": item.get("title", "Unknown"),
+                    "year": year,
+                    "overview": item.get("overview"),
+                    "genres": genres,
+                })
+            return results
+    except Exception:
+        logger.exception("Failed to fetch TMDB recommendations for tmdb_id=%d", tmdb_id)
+        return []
+
+
 async def backfill_posters(db: AsyncSession) -> None:
     """Fetch poster URLs for movies that have tmdb_id but no poster_url."""
     stmt = (


### PR DESCRIPTION
## Summary
- Adds background pool expansion triggered when unknown films drop below 50 after swipe submission
- Three expansion sources in priority order: TMDB recommendations from top-ranked films, Trakt anticipated movies, deeper Trakt popular pages (2-5)
- Tracks expansions in new `pool_expansions` table to avoid re-fetching within 7 days
- Includes Alembic migration (006), PoolExpansion model, `fetch_similar_films` TMDB API, and `expand_pool` background service with rate limiting and Sentry error capture

## Files changed
- `backend/migrations/versions/006_add_pool_expansions.py` — new migration
- `backend/db_models.py` — PoolExpansion model
- `backend/services/tmdb.py` — `fetch_similar_films()` + TMDB genre map
- `backend/services/expand.py` — new expansion service
- `backend/routers/swipe.py` — trigger expansion from swipe results endpoint

## Test plan
- [ ] Run migration: `alembic upgrade head`
- [ ] Swipe through films until unknown count < 50, verify background expansion triggers
- [ ] Check pool_expansions table for tracking records
- [ ] Verify no duplicate user_movies created on repeat expansion
- [ ] Verify TMDB rate limiting (0.3s between calls)

🤖 Generated with [Claude Code](https://claude.com/claude-code)