### PR TITLE
feat: tournament byes — allow brackets with fewer films than bracket size

### DIFF
--- a/backend/db_models.py
+++ b/backend/db_models.py
@@ -180,6 +180,7 @@ class TournamentMatch(Base):
     duel_id: Mapped[Optional[uuid.UUID]] = mapped_column(
         UUID(as_uuid=True), ForeignKey("duels.id"), nullable=True
     )
+    is_bye: Mapped[bool] = mapped_column(Boolean, nullable=False, server_default="false")
     played_at: Mapped[Optional[datetime]] = mapped_column(
         DateTime(timezone=True), nullable=True
     )

--- a/backend/migrations/versions/007_add_tournament_byes.py
+++ b/backend/migrations/versions/007_add_tournament_byes.py
@@ -1,0 +1,26 @@
+"""Add is_bye column to tournament_matches
+
+Revision ID: 007
+Revises: 005
+Create Date: 2026-04-12
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+revision: str = "007"
+down_revision: Union[str, None] = "005"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "tournament_matches",
+        sa.Column("is_bye", sa.Boolean(), nullable=False, server_default=sa.text("false")),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("tournament_matches", "is_bye")

--- a/backend/routers/tournaments.py
+++ b/backend/routers/tournaments.py
@@ -84,6 +84,7 @@ def _match_schema(m: TournamentMatch) -> TournamentMatchSchema:
         movie_a=_movie_schema(m.movie_a),
         movie_b=_movie_schema(m.movie_b),
         winner_movie_id=str(m.winner_movie_id) if m.winner_movie_id else None,
+        is_bye=m.is_bye,
         played_at=m.played_at,
     )
 
@@ -157,6 +158,48 @@ async def get_available_genres(
     return [row[0] for row in result.all()]
 
 
+@router.get("/pool-count")
+async def get_pool_count(
+    filter_type: Optional[str] = None,
+    filter_value: Optional[str] = None,
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+):
+    """Return number of ranked films matching the given filter."""
+    uid = current_user.id
+    stmt = (
+        select(UserMovie)
+        .options(joinedload(UserMovie.movie))
+        .where(
+            UserMovie.user_id == uid,
+            UserMovie.seen.is_(True),
+            UserMovie.battles >= 1,
+            UserMovie.elo.isnot(None),
+        )
+    )
+    result = await db.execute(stmt)
+    user_movies = result.unique().scalars().all()
+
+    if filter_type == "genre" and filter_value:
+        genre_lower = filter_value.lower()
+        user_movies = [
+            um for um in user_movies
+            if um.movie.genres and any(g.lower() == genre_lower for g in um.movie.genres)
+        ]
+    elif filter_type == "decade" and filter_value:
+        decade_str = filter_value.rstrip("s")
+        try:
+            decade_start = int(decade_str)
+        except ValueError:
+            return {"count": 0}
+        user_movies = [
+            um for um in user_movies
+            if um.movie.year and decade_start <= um.movie.year <= decade_start + 9
+        ]
+
+    return {"count": len(user_movies)}
+
+
 @router.post("", response_model=TournamentSchema)
 async def create_tournament(
     body: TournamentCreate,
@@ -199,16 +242,23 @@ async def create_tournament(
             if um.movie.year and decade_start <= um.movie.year <= decade_start + 9
         ]
 
-    # 3. Validate enough films
-    if len(user_movies) < body.bracket_size:
+    # 3. Validate enough films (minimum 4, max bracket = 4x pool)
+    if len(user_movies) < 4:
         raise HTTPException(
             status_code=400,
-            detail=f"Not enough ranked films. Need {body.bracket_size}, have {len(user_movies)}.",
+            detail="Need at least 4 ranked films",
+        )
+    if body.bracket_size > len(user_movies) * 4:
+        raise HTTPException(
+            status_code=400,
+            detail=f"Bracket too large. Max {len(user_movies) * 4} for {len(user_movies)} films",
         )
 
-    # 4. Sort by ELO descending, take top bracket_size
+    # 4. Sort by ELO descending, take top films (up to bracket_size)
     user_movies.sort(key=lambda um: um.elo or 0, reverse=True)
-    seeded_films = user_movies[: body.bracket_size]
+    actual_films = min(len(user_movies), body.bracket_size)
+    seeded_films = user_movies[:actual_films]
+    num_byes = body.bracket_size - actual_films
 
     # 5. Generate seeded bracket pairings
     pairings = generate_seeded_bracket(body.bracket_size)
@@ -225,18 +275,55 @@ async def create_tournament(
     db.add(tournament)
     await db.flush()
 
-    # 7. Create round 1 matches with seeded pairings
+    # 7. Create round 1 matches with seeded pairings (including byes)
     num_rounds = _num_rounds(body.bracket_size)
-    round1_matches = body.bracket_size // 2
+    now = datetime.now(timezone.utc)
 
     for position, (seed_a, seed_b) in enumerate(pairings):
-        match = TournamentMatch(
-            tournament_id=tournament.id,
-            round=1,
-            position=position,
-            movie_a_id=seeded_films[seed_a - 1].movie_id,
-            movie_b_id=seeded_films[seed_b - 1].movie_id,
-        )
+        # Seeds beyond actual_films have no film — that side is a bye
+        has_a = seed_a <= actual_films
+        has_b = seed_b <= actual_films
+
+        if has_a and has_b:
+            # Normal match — both films present
+            match = TournamentMatch(
+                tournament_id=tournament.id,
+                round=1,
+                position=position,
+                movie_a_id=seeded_films[seed_a - 1].movie_id,
+                movie_b_id=seeded_films[seed_b - 1].movie_id,
+            )
+        elif has_a and not has_b:
+            # Bye: seed_a advances automatically
+            match = TournamentMatch(
+                tournament_id=tournament.id,
+                round=1,
+                position=position,
+                movie_a_id=seeded_films[seed_a - 1].movie_id,
+                movie_b_id=None,
+                winner_movie_id=seeded_films[seed_a - 1].movie_id,
+                is_bye=True,
+                played_at=now,
+            )
+        elif has_b and not has_a:
+            # Bye: seed_b advances automatically
+            match = TournamentMatch(
+                tournament_id=tournament.id,
+                round=1,
+                position=position,
+                movie_a_id=seeded_films[seed_b - 1].movie_id,
+                movie_b_id=None,
+                winner_movie_id=seeded_films[seed_b - 1].movie_id,
+                is_bye=True,
+                played_at=now,
+            )
+        else:
+            # Both seeds missing — shouldn't happen with valid bracket sizes
+            match = TournamentMatch(
+                tournament_id=tournament.id,
+                round=1,
+                position=position,
+            )
         db.add(match)
 
     # 8. Create empty matches for subsequent rounds
@@ -251,6 +338,35 @@ async def create_tournament(
             db.add(match)
 
     await db.flush()
+
+    # 9. Propagate bye winners to round 2 slots
+    if num_byes > 0:
+        # Re-fetch round 1 matches to propagate winners
+        r1_stmt = (
+            select(TournamentMatch)
+            .where(
+                TournamentMatch.tournament_id == tournament.id,
+                TournamentMatch.round == 1,
+                TournamentMatch.is_bye.is_(True),
+            )
+        )
+        r1_result = await db.execute(r1_stmt)
+        bye_matches = r1_result.scalars().all()
+
+        for bye_match in bye_matches:
+            next_pos = bye_match.position // 2
+            next_round_stmt = select(TournamentMatch).where(
+                TournamentMatch.tournament_id == tournament.id,
+                TournamentMatch.round == 2,
+                TournamentMatch.position == next_pos,
+            )
+            next_match_obj = (await db.execute(next_round_stmt)).scalar_one()
+            if bye_match.position % 2 == 0:
+                next_match_obj.movie_a_id = bye_match.winner_movie_id
+            else:
+                next_match_obj.movie_b_id = bye_match.winner_movie_id
+
+        await db.flush()
 
     # Reload the tournament with all relationships
     tournament = await _load_tournament(tournament.id, uid, db)

--- a/backend/schemas.py
+++ b/backend/schemas.py
@@ -127,6 +127,7 @@ class TournamentMatchSchema(BaseModel):
     movie_a: Optional[MovieSchema] = None
     movie_b: Optional[MovieSchema] = None
     winner_movie_id: Optional[str] = None
+    is_bye: bool = False
     played_at: Optional[datetime] = None
 
 

--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -60,6 +60,13 @@ export function getTournamentGenres() {
   return request("/api/tournaments/genres");
 }
 
+export function getTournamentPoolCount(filterType, filterValue) {
+  const params = new URLSearchParams();
+  if (filterType) params.set("filter_type", filterType);
+  if (filterValue) params.set("filter_value", filterValue);
+  return request(`/api/tournaments/pool-count?${params}`);
+}
+
 export function createTournament(name, bracketSize, filterType, filterValue) {
   return request("/api/tournaments", {
     method: "POST",

--- a/frontend/src/pages/TournamentBracket.jsx
+++ b/frontend/src/pages/TournamentBracket.jsx
@@ -44,14 +44,17 @@ function PosterThumb({ movie, isWinner, isLoser }) {
 /** Single match card in the bracket */
 function BracketMatch({ match, isNext, totalRounds, onClick }) {
   const played = !!match.winner_movie_id;
+  const isBye = match.is_bye;
   const aWins = played && match.winner_movie_id === match.movie_a?.id;
   const bWins = played && match.winner_movie_id === match.movie_b?.id;
 
   return (
     <div
-      onClick={isNext && !played ? onClick : undefined}
+      onClick={isNext && !played && !isBye ? onClick : undefined}
       className={`relative bg-[#1d1b1a] border transition-all w-full ${
-        isNext && !played
+        isBye
+          ? "border-[#F5F0E8]/5 opacity-50"
+          : isNext && !played
           ? "border-[#E8A020]/60 shadow-[0_0_20px_rgba(232,160,32,0.15)] cursor-pointer hover:border-[#E8A020] animate-pulse-slow"
           : played
           ? "border-[#F5F0E8]/5"
@@ -61,17 +64,19 @@ function BracketMatch({ match, isNext, totalRounds, onClick }) {
       {/* Movie A */}
       <div
         className={`flex items-center gap-2 px-2 py-1.5 border-b border-[#F5F0E8]/5 ${
-          aWins ? "bg-[#E8A020]/10" : ""
+          aWins && !isBye ? "bg-[#E8A020]/10" : ""
         }`}
       >
         <PosterThumb
           movie={match.movie_a}
-          isWinner={aWins}
-          isLoser={bWins}
+          isWinner={aWins && !isBye}
+          isLoser={bWins && !isBye}
         />
         <span
           className={`text-[11px] font-headline font-bold uppercase tracking-tight truncate ${
-            aWins
+            isBye
+              ? "text-[#F5F0E8]/50"
+              : aWins
               ? "text-[#E8A020]"
               : bWins
               ? "text-[#F5F0E8]/30"
@@ -84,28 +89,39 @@ function BracketMatch({ match, isNext, totalRounds, onClick }) {
       {/* Movie B */}
       <div
         className={`flex items-center gap-2 px-2 py-1.5 ${
-          bWins ? "bg-[#E8A020]/10" : ""
+          bWins && !isBye ? "bg-[#E8A020]/10" : ""
         }`}
       >
-        <PosterThumb
-          movie={match.movie_b}
-          isWinner={bWins}
-          isLoser={aWins}
-        />
-        <span
-          className={`text-[11px] font-headline font-bold uppercase tracking-tight truncate ${
-            bWins
-              ? "text-[#E8A020]"
-              : aWins
-              ? "text-[#F5F0E8]/30"
-              : "text-[#F5F0E8]/70"
-          }`}
-        >
-          {match.movie_b?.title || "TBD"}
-        </span>
+        {isBye ? (
+          <>
+            <div className="w-8 h-12 bg-[#1d1b1a] shrink-0 border border-[#F5F0E8]/5" />
+            <span className="text-[11px] font-headline font-bold uppercase tracking-tight text-[#6B6760]">
+              BYE
+            </span>
+          </>
+        ) : (
+          <>
+            <PosterThumb
+              movie={match.movie_b}
+              isWinner={bWins}
+              isLoser={aWins}
+            />
+            <span
+              className={`text-[11px] font-headline font-bold uppercase tracking-tight truncate ${
+                bWins
+                  ? "text-[#E8A020]"
+                  : aWins
+                  ? "text-[#F5F0E8]/30"
+                  : "text-[#F5F0E8]/70"
+              }`}
+            >
+              {match.movie_b?.title || "TBD"}
+            </span>
+          </>
+        )}
       </div>
       {/* Next match indicator */}
-      {isNext && !played && (
+      {isNext && !played && !isBye && (
         <div className="absolute -top-2 left-1/2 -translate-x-1/2 z-10">
           <span className="bg-[#E8A020] text-[#0F0E0D] px-2 py-0.5 text-[8px] font-headline font-black uppercase tracking-wider">
             Next

--- a/frontend/src/pages/Tournaments.jsx
+++ b/frontend/src/pages/Tournaments.jsx
@@ -1,6 +1,6 @@
 import { useState, useEffect } from "react";
 import { useNavigate } from "react-router-dom";
-import { getTournaments, createTournament, getTournamentGenres } from "../api";
+import { getTournaments, createTournament, getTournamentGenres, getTournamentPoolCount } from "../api";
 
 const BRACKET_SIZES = [8, 16, 32, 64];
 const DECADES = ["1970s", "1980s", "1990s", "2000s", "2010s", "2020s"];
@@ -19,6 +19,7 @@ export default function Tournaments() {
   const [filterMode, setFilterMode] = useState("all"); // all | genre | decade
   const [filterValue, setFilterValue] = useState("");
   const [availableGenres, setAvailableGenres] = useState([]);
+  const [poolCount, setPoolCount] = useState(null);
 
   useEffect(() => {
     loadTournaments();
@@ -34,6 +35,16 @@ export default function Tournaments() {
       setLoading(false);
     }
   }
+
+  // Fetch pool count whenever filter changes
+  useEffect(() => {
+    if (!showCreate) return;
+    const filterType = filterMode === "all" ? null : filterMode;
+    const fv = filterMode === "all" ? null : filterValue;
+    getTournamentPoolCount(filterType, fv)
+      .then((data) => setPoolCount(data.count))
+      .catch(() => setPoolCount(null));
+  }, [showCreate, filterMode, filterValue]);
 
   async function handleOpenCreate() {
     setShowCreate(true);
@@ -129,6 +140,19 @@ export default function Tournaments() {
                 </button>
               ))}
             </div>
+            {poolCount !== null && (
+              <p className="mt-2 text-sm font-body text-[#F5F0E8]/50">
+                {poolCount >= bracketSize ? (
+                  <>{poolCount} ranked films available</>
+                ) : poolCount >= 4 ? (
+                  <>{poolCount} films + {bracketSize - poolCount} byes</>
+                ) : (
+                  <span className="text-[#C04A20]">
+                    Only {poolCount} ranked films — need at least 4
+                  </span>
+                )}
+              </p>
+            )}
           </div>
 
           {/* Filter Mode */}


### PR DESCRIPTION
## Summary
- Add `is_bye` column to `tournament_matches` via Alembic migration (007)
- Change tournament creation validation: minimum 4 films (not bracket_size), max bracket = 4x pool size
- Top-seeded films get automatic byes when pool < bracket_size — bye matches are auto-resolved and winners propagate to round 2
- New `/api/tournaments/pool-count` endpoint returns ranked film count for a given filter
- Frontend bracket view shows bye matches with muted styling and grey "BYE" label
- Create form shows ranked film count and "X films + Y byes" when pool < bracket_size

## Test plan
- [ ] Create tournament with 13 ranked films and bracket_size=16 — verify 3 byes + 5 real matches in round 1, 8 slots in round 2 with 3 pre-filled from byes
- [ ] Create tournament with exactly bracket_size films — verify no byes, works as before
- [ ] Verify pool < 4 films is rejected
- [ ] Verify bracket > 4x pool is rejected
- [ ] Check bye matches show "BYE" label in bracket view (muted, no pulse animation)
- [ ] Verify create form shows film count and bye info dynamically as filter changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)