### PR TITLE
fix: use preloaded duel pair instead of re-fetching

### DIFF
--- a/frontend/src/pages/Duel.jsx
+++ b/frontend/src/pages/Duel.jsx
@@ -88,7 +88,6 @@ export default function Duel() {
   const handleSubmit = async (outcome) => {
     if (!pair || submitting) return;
     setSubmitting(true);
-    prefetchNext();
     try {
       const res = await submitDuel(
         pair.movie_a.id,


### PR DESCRIPTION
## Summary
- `prefetchNext()` was called both when a pair loads (correct) AND when user submits a pick (wrong)
- The second call overwrote `prefetchRef.current`, discarding the already-ready prefetch
- Result: 3 network calls per duel cycle instead of 2, with visible loading delay

## Fix
Remove the redundant `prefetchNext()` from `handleSubmit`. The prefetch from `loadPair` is already in flight and ready by the time the user picks.

## Test plan
- [ ] Open Network tab, start dueling
- [ ] After picking a winner, next pair should appear instantly (from prefetch)
- [ ] Only 1 `/api/movies/pair` call per duel cycle (not 2)

🤖 Generated with [Claude Code](https://claude.com/claude-code)