### PR TITLE
feat: server-side genre and decade filtering for rankings

### DIFF
--- a/backend/routers/rankings.py
+++ b/backend/routers/rankings.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import csv
 import io
+from typing import Optional
 
 from fastapi import APIRouter, Depends, Query
 from fastapi.responses import StreamingResponse
@@ -12,7 +13,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import joinedload
 
 from backend.db import get_db
-from backend.db_models import User, UserMovie
+from backend.db_models import Movie, User, UserMovie
 from backend.schemas import MovieSchema, RankedMovie, RankingsResponse, StatsResponse
 from backend.routers.auth import get_current_user
 
@@ -32,6 +33,7 @@ def _build_ranked_movie(um: UserMovie, rank: int) -> RankedMovie:
             year=movie.year,
             poster_url=movie.poster_url,
             overview=movie.overview,
+            genres=movie.genres,
         ),
         elo=um.elo,
         battles=um.battles,
@@ -44,28 +46,43 @@ async def get_rankings(
     db: AsyncSession = Depends(get_db),
     limit: int = Query(default=50, le=200),
     offset: int = Query(default=0, ge=0),
+    genre: Optional[str] = Query(default=None),
+    decade: Optional[str] = Query(default=None),
 ):
     """Return the user's ranked movies sorted by ELO descending."""
     uid = current_user.id
+    needs_movie_join = genre is not None or decade is not None
 
     # Only show movies the user has actually seen and battled
     stmt = (
         select(UserMovie)
         .options(joinedload(UserMovie.movie))
         .where(UserMovie.user_id == uid, UserMovie.seen.is_(True), UserMovie.battles > 0)
-        .order_by(UserMovie.elo.desc())
-        .offset(offset)
-        .limit(limit)
     )
-    result = await db.execute(stmt)
-    user_movies = result.unique().scalars().all()
-
-    # Count total
     count_stmt = (
         select(func.count())
         .select_from(UserMovie)
         .where(UserMovie.user_id == uid, UserMovie.seen.is_(True), UserMovie.battles > 0)
     )
+
+    if needs_movie_join:
+        stmt = stmt.join(Movie, UserMovie.movie_id == Movie.id)
+        count_stmt = count_stmt.join(Movie, UserMovie.movie_id == Movie.id)
+
+    if genre:
+        stmt = stmt.where(Movie.genres.any(genre))
+        count_stmt = count_stmt.where(Movie.genres.any(genre))
+
+    if decade:
+        decade_start = int(decade.rstrip("s"))
+        stmt = stmt.where(Movie.year >= decade_start, Movie.year <= decade_start + 9)
+        count_stmt = count_stmt.where(Movie.year >= decade_start, Movie.year <= decade_start + 9)
+
+    stmt = stmt.order_by(UserMovie.elo.desc()).offset(offset).limit(limit)
+
+    result = await db.execute(stmt)
+    user_movies = result.unique().scalars().all()
+
     count_result = await db.execute(count_stmt)
     total = count_result.scalar() or 0
 

--- a/backend/schemas.py
+++ b/backend/schemas.py
@@ -24,6 +24,7 @@ class MovieSchema(BaseModel):
     year: Optional[int] = None
     poster_url: Optional[str] = None
     overview: Optional[str] = None
+    genres: Optional[list[str]] = None
 
 
 class MovieWithStateSchema(MovieSchema):

--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -32,8 +32,11 @@ export function submitDuel(movieAId, movieBId, outcome, mode = "discovery") {
   });
 }
 
-export function getRankings(limit = 50, offset = 0) {
-  return request(`/api/rankings?limit=${limit}&offset=${offset}`);
+export function getRankings(limit = 50, offset = 0, genre = null, decade = null) {
+  const params = new URLSearchParams({ limit, offset });
+  if (genre) params.set("genre", genre);
+  if (decade) params.set("decade", decade);
+  return request(`/api/rankings?${params}`);
 }
 
 export function fetchStats() { return request("/api/rankings/stats"); }

--- a/frontend/src/pages/Rankings.jsx
+++ b/frontend/src/pages/Rankings.jsx
@@ -8,15 +8,19 @@ export default function Rankings() {
   const [stats, setStats] = useState(null);
   const [loading, setLoading] = useState(true);
   const [activeFilter, setActiveFilter] = useState("All");
+  const [total, setTotal] = useState(0);
 
   useEffect(() => {
     async function load() {
+      setLoading(true);
       try {
+        const genre = activeFilter === "All" ? null : activeFilter;
         const [rankData, statsData] = await Promise.all([
-          getRankings(50),
+          getRankings(50, 0, genre),
           fetchStats(),
         ]);
         setRankings(rankData.rankings);
+        setTotal(rankData.total);
         setStats(statsData);
       } catch (err) {
         console.error("Failed to load rankings:", err);
@@ -25,16 +29,7 @@ export default function Rankings() {
       }
     }
     load();
-  }, []);
-
-  const filteredRankings =
-    activeFilter === "All"
-      ? rankings
-      : rankings.filter((r) =>
-          (r.movie.genres || [])
-            .map((g) => g.toLowerCase())
-            .includes(activeFilter.toLowerCase())
-        );
+  }, [activeFilter]);
 
   if (loading) {
     return (
@@ -73,7 +68,7 @@ export default function Rankings() {
       </header>
 
       {/* Rankings List */}
-      {filteredRankings.length === 0 ? (
+      {rankings.length === 0 ? (
         <div className="p-8 text-center text-[#6B6760] bg-[#1d1b1a] font-body">
           {rankings.length === 0
             ? "No rankings yet. Start dueling to build your list!"
@@ -81,7 +76,7 @@ export default function Rankings() {
         </div>
       ) : (
         <div className="space-y-4">
-          {filteredRankings.map((r, idx) => {
+          {rankings.map((r, idx) => {
             const isFirst = idx === 0;
             const rank = String(idx + 1).padStart(2, "0");
 


### PR DESCRIPTION
## Summary
- Add `genre` and `decade` query parameters to `GET /api/rankings` endpoint, moving filtering from client-side to server-side
- Genre filter uses PostgreSQL array `any()` on `Movie.genres`; decade filter parses "1990s" format and filters `Movie.year` range
- Both data and count queries apply the same filters for correct pagination totals
- Add `genres` field to `MovieSchema` so ranking cards receive genre data
- Frontend `Rankings.jsx` re-fetches from API when filter changes instead of filtering locally

## Test plan
- [ ] Load rankings page — verify all movies load without filters
- [ ] Click a genre pill (e.g. Drama) — verify only movies of that genre appear, with correct total count
- [ ] Verify decade param works: `GET /api/rankings?decade=1990s` returns only 1990-1999 films
- [ ] Verify pagination total updates correctly when filters are applied
- [ ] Verify no duplicate results from joinedload + explicit join interaction

🤖 Generated with [Claude Code](https://claude.com/claude-code)