### PR TITLE
feat: AI-curated tournaments + switch LLM to Requesty/OpenRouter

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,7 @@ jobs:
     env:
       SECRET_KEY: "ci-test-key-not-for-production"
       DATABASE_URL: "postgresql+asyncpg://postgres:postgres@localhost:5432/postgres"
+      LLM_API_KEY: "test-key-not-for-production"
     steps:
       - uses: actions/checkout@v4
 

--- a/backend/config.py
+++ b/backend/config.py
@@ -22,8 +22,10 @@ class Settings(BaseSettings):
     # TMDB for poster images
     TMDB_API_KEY: str = ""
 
-    # Anthropic (for AI suggestions)
-    ANTHROPIC_API_KEY: str = ""
+    # LLM (OpenRouter / Requesty.ai)
+    LLM_API_KEY: str = ""
+    LLM_BASE_URL: str = "https://router.requesty.ai/v1"
+    LLM_MODEL: str = "anthropic/claude-sonnet-4-20250514"
 
     # Sentry
     SENTRY_DSN: str = ""

--- a/backend/db_models.py
+++ b/backend/db_models.py
@@ -16,7 +16,7 @@ from sqlalchemy import (
     Text,
     UniqueConstraint,
 )
-from sqlalchemy.dialects.postgresql import ARRAY, UUID
+from sqlalchemy.dialects.postgresql import ARRAY, JSONB, UUID
 from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column, relationship
 
 
@@ -138,6 +138,12 @@ class Tournament(Base):
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), default=lambda: datetime.now(timezone.utc)
     )
+    tagline: Mapped[Optional[str]] = mapped_column(Text, nullable=True)
+    theme_description: Mapped[Optional[str]] = mapped_column(Text, nullable=True)
+    is_ai_curated: Mapped[bool] = mapped_column(
+        Boolean, nullable=False, server_default="false"
+    )
+    llm_response: Mapped[Optional[dict]] = mapped_column(JSONB, nullable=True)
     completed_at: Mapped[Optional[datetime]] = mapped_column(
         DateTime(timezone=True), nullable=True
     )

--- a/backend/migrations/versions/010_add_ai_tournament_fields.py
+++ b/backend/migrations/versions/010_add_ai_tournament_fields.py
@@ -1,0 +1,33 @@
+"""Add AI-curated tournament fields
+
+Revision ID: 010
+Revises: 009
+Create Date: 2026-04-12
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects.postgresql import JSONB
+
+revision: str = "010"
+down_revision: Union[str, None] = "009"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column("tournaments", sa.Column("tagline", sa.Text(), nullable=True))
+    op.add_column("tournaments", sa.Column("theme_description", sa.Text(), nullable=True))
+    op.add_column(
+        "tournaments",
+        sa.Column("is_ai_curated", sa.Boolean(), nullable=False, server_default=sa.text("false")),
+    )
+    op.add_column("tournaments", sa.Column("llm_response", JSONB(), nullable=True))
+
+
+def downgrade() -> None:
+    op.drop_column("tournaments", "llm_response")
+    op.drop_column("tournaments", "is_ai_curated")
+    op.drop_column("tournaments", "theme_description")
+    op.drop_column("tournaments", "tagline")

--- a/backend/routers/suggestions.py
+++ b/backend/routers/suggestions.py
@@ -123,7 +123,7 @@ async def get_suggestions(
             status="ready",
         )
     except ValueError as e:
-        # ANTHROPIC_API_KEY not configured
+        # LLM_API_KEY not configured
         raise HTTPException(status_code=503, detail=str(e))
     except Exception:
         logger.exception("Failed to generate suggestions for user %s", uid)

--- a/backend/routers/tournaments.py
+++ b/backend/routers/tournaments.py
@@ -23,6 +23,7 @@ from backend.schemas import (
     TournamentMatchSchema,
     TournamentSchema,
 )
+from backend.services.curator import curate_tournament
 from backend.services.elo import get_initial_elo, update_elo
 
 router = APIRouter(prefix="/api/tournaments", tags=["tournaments"])
@@ -100,6 +101,10 @@ def _tournament_schema(t: Tournament) -> TournamentSchema:
         bracket_size=t.bracket_size,
         status=t.status,
         champion_movie_id=str(t.champion_movie_id) if t.champion_movie_id else None,
+        tagline=t.tagline,
+        theme_description=t.theme_description,
+        is_ai_curated=t.is_ai_curated,
+        llm_response=t.llm_response,
         created_at=t.created_at,
         completed_at=t.completed_at,
         matches=[_match_schema(m) for m in sorted_matches],
@@ -254,23 +259,82 @@ async def create_tournament(
             detail=f"Bracket too large. Max {len(user_movies) * 4} for {len(user_movies)} films",
         )
 
-    # 4. Sort by ELO descending, take top films (up to bracket_size)
+    # 4. Sort by ELO descending
     user_movies.sort(key=lambda um: um.elo or 0, reverse=True)
-    actual_films = min(len(user_movies), body.bracket_size)
-    seeded_films = user_movies[:actual_films]
+
+    # 5. AI curation or standard selection
+    ai_name = None
+    ai_tagline = None
+    ai_theme_description = None
+    ai_llm_response = None
+
+    if body.ai_curated:
+        # Build candidate list: cap at bracket_size * 3
+        candidate_pool = user_movies[: body.bracket_size * 3]
+        candidates = [
+            {
+                "id": str(um.movie_id),
+                "title": um.movie.title,
+                "year": um.movie.year,
+                "genres": um.movie.genres or [],
+                "elo": um.elo,
+                "battles": um.battles,
+            }
+            for um in candidate_pool
+        ]
+
+        filter_context = ""
+        if body.filter_type and body.filter_value:
+            filter_context = f"{body.filter_type}: {body.filter_value}"
+
+        llm_result = await curate_tournament(
+            candidates=candidates,
+            bracket_size=body.bracket_size,
+            filter_context=filter_context,
+        )
+
+        # Validate returned film_ids are all in candidate list
+        candidate_ids = {str(um.movie_id) for um in candidate_pool}
+        invalid_ids = set(llm_result["film_ids"]) - candidate_ids
+        if invalid_ids:
+            raise HTTPException(
+                status_code=500,
+                detail=f"AI selected films not in candidate pool: {invalid_ids}",
+            )
+
+        # Build seeded_films from LLM selection, ordered by ELO for seeding
+        film_id_set = set(llm_result["film_ids"])
+        selected_ums = [um for um in candidate_pool if str(um.movie_id) in film_id_set]
+        # Re-sort by ELO descending for proper seeding
+        selected_ums.sort(key=lambda um: um.elo or 0, reverse=True)
+        seeded_films = selected_ums
+
+        ai_name = llm_result["name"]
+        ai_tagline = llm_result.get("tagline")
+        ai_theme_description = llm_result.get("theme_description")
+        ai_llm_response = llm_result
+    else:
+        seeded_films = user_movies[: body.bracket_size]
+
+    actual_films = len(seeded_films)
     num_byes = body.bracket_size - actual_films
 
-    # 5. Generate seeded bracket pairings
+    # 6. Generate seeded bracket pairings
     pairings = generate_seeded_bracket(body.bracket_size)
 
-    # 6. Create tournament record
+    # 7. Create tournament record
+    tournament_name = ai_name if ai_name else body.name
     tournament = Tournament(
         user_id=uid,
-        name=body.name,
+        name=tournament_name,
         filter_type=body.filter_type,
         filter_value=body.filter_value,
         bracket_size=body.bracket_size,
         status="active",
+        tagline=ai_tagline,
+        theme_description=ai_theme_description,
+        is_ai_curated=body.ai_curated,
+        llm_response=ai_llm_response,
     )
     db.add(tournament)
     await db.flush()
@@ -370,6 +434,215 @@ async def create_tournament(
 
     # Reload the tournament with all relationships
     tournament = await _load_tournament(tournament.id, uid, db)
+    return _tournament_schema(tournament)
+
+
+@router.post("/{tournament_id}/regenerate", response_model=TournamentSchema)
+async def regenerate_tournament(
+    tournament_id: uuid.UUID,
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+):
+    """Re-run LLM curation with same candidates. Max 3 regenerations."""
+    uid = current_user.id
+    tournament = await _load_tournament(tournament_id, uid, db)
+
+    if not tournament.is_ai_curated:
+        raise HTTPException(status_code=400, detail="Only AI-curated tournaments can be regenerated")
+
+    # Check no matches have been played (excluding byes)
+    played_matches = [
+        m for m in tournament.matches
+        if m.winner_movie_id is not None and not m.is_bye
+    ]
+    if played_matches:
+        raise HTTPException(status_code=400, detail="Cannot regenerate after matches have been played")
+
+    # Track regeneration count in llm_response
+    regen_count = 0
+    if tournament.llm_response and isinstance(tournament.llm_response, dict):
+        regen_count = tournament.llm_response.get("_regen_count", 0)
+    if regen_count >= 3:
+        raise HTTPException(status_code=400, detail="Maximum regeneration attempts (3) reached")
+
+    # Rebuild candidate list from user's ranked films with same filters
+    stmt = (
+        select(UserMovie)
+        .options(joinedload(UserMovie.movie))
+        .where(
+            UserMovie.user_id == uid,
+            UserMovie.seen.is_(True),
+            UserMovie.battles >= 1,
+            UserMovie.elo.isnot(None),
+        )
+    )
+    result = await db.execute(stmt)
+    user_movies = result.unique().scalars().all()
+
+    if tournament.filter_type == "genre" and tournament.filter_value:
+        genre_lower = tournament.filter_value.lower()
+        user_movies = [
+            um for um in user_movies
+            if um.movie.genres and any(g.lower() == genre_lower for g in um.movie.genres)
+        ]
+    elif tournament.filter_type == "decade" and tournament.filter_value:
+        decade_str = tournament.filter_value.rstrip("s")
+        try:
+            decade_start = int(decade_str)
+        except ValueError:
+            raise HTTPException(status_code=400, detail="Invalid decade format")
+        user_movies = [
+            um for um in user_movies
+            if um.movie.year and decade_start <= um.movie.year <= decade_start + 9
+        ]
+
+    user_movies.sort(key=lambda um: um.elo or 0, reverse=True)
+    candidate_pool = user_movies[: tournament.bracket_size * 3]
+
+    candidates = [
+        {
+            "id": str(um.movie_id),
+            "title": um.movie.title,
+            "year": um.movie.year,
+            "genres": um.movie.genres or [],
+            "elo": um.elo,
+            "battles": um.battles,
+        }
+        for um in candidate_pool
+    ]
+
+    filter_context = ""
+    if tournament.filter_type and tournament.filter_value:
+        filter_context = f"{tournament.filter_type}: {tournament.filter_value}"
+
+    llm_result = await curate_tournament(
+        candidates=candidates,
+        bracket_size=tournament.bracket_size,
+        filter_context=filter_context,
+    )
+
+    # Validate returned film_ids
+    candidate_ids = {str(um.movie_id) for um in candidate_pool}
+    invalid_ids = set(llm_result["film_ids"]) - candidate_ids
+    if invalid_ids:
+        raise HTTPException(
+            status_code=500,
+            detail=f"AI selected films not in candidate pool: {invalid_ids}",
+        )
+
+    # Build new seeded films
+    film_id_set = set(llm_result["film_ids"])
+    selected_ums = [um for um in candidate_pool if str(um.movie_id) in film_id_set]
+    selected_ums.sort(key=lambda um: um.elo or 0, reverse=True)
+    actual_films = len(selected_ums)
+
+    # Delete existing matches
+    from sqlalchemy import delete
+
+    await db.execute(
+        delete(TournamentMatch).where(TournamentMatch.tournament_id == tournament_id)
+    )
+    await db.flush()
+
+    # Update tournament metadata
+    t_stmt = select(Tournament).where(Tournament.id == tournament_id)
+    t = (await db.execute(t_stmt)).scalar_one()
+    llm_result["_regen_count"] = regen_count + 1
+    t.name = llm_result["name"]
+    t.tagline = llm_result.get("tagline")
+    t.theme_description = llm_result.get("theme_description")
+    t.llm_response = llm_result
+
+    # Recreate bracket
+    pairings = generate_seeded_bracket(tournament.bracket_size)
+    num_rounds = _num_rounds(tournament.bracket_size)
+    now = datetime.now(timezone.utc)
+    num_byes = tournament.bracket_size - actual_films
+
+    for position, (seed_a, seed_b) in enumerate(pairings):
+        has_a = seed_a <= actual_films
+        has_b = seed_b <= actual_films
+
+        if has_a and has_b:
+            match = TournamentMatch(
+                tournament_id=tournament_id,
+                round=1,
+                position=position,
+                movie_a_id=selected_ums[seed_a - 1].movie_id,
+                movie_b_id=selected_ums[seed_b - 1].movie_id,
+            )
+        elif has_a and not has_b:
+            match = TournamentMatch(
+                tournament_id=tournament_id,
+                round=1,
+                position=position,
+                movie_a_id=selected_ums[seed_a - 1].movie_id,
+                movie_b_id=None,
+                winner_movie_id=selected_ums[seed_a - 1].movie_id,
+                is_bye=True,
+                played_at=now,
+            )
+        elif has_b and not has_a:
+            match = TournamentMatch(
+                tournament_id=tournament_id,
+                round=1,
+                position=position,
+                movie_a_id=selected_ums[seed_b - 1].movie_id,
+                movie_b_id=None,
+                winner_movie_id=selected_ums[seed_b - 1].movie_id,
+                is_bye=True,
+                played_at=now,
+            )
+        else:
+            match = TournamentMatch(
+                tournament_id=tournament_id,
+                round=1,
+                position=position,
+            )
+        db.add(match)
+
+    for round_num in range(2, num_rounds + 1):
+        matches_in_round = tournament.bracket_size // (2**round_num)
+        for position in range(matches_in_round):
+            match = TournamentMatch(
+                tournament_id=tournament_id,
+                round=round_num,
+                position=position,
+            )
+            db.add(match)
+
+    await db.flush()
+
+    # Propagate bye winners to round 2
+    if num_byes > 0:
+        r1_stmt = (
+            select(TournamentMatch)
+            .where(
+                TournamentMatch.tournament_id == tournament_id,
+                TournamentMatch.round == 1,
+                TournamentMatch.is_bye.is_(True),
+            )
+        )
+        r1_result = await db.execute(r1_stmt)
+        bye_matches = r1_result.scalars().all()
+
+        for bye_match in bye_matches:
+            next_pos = bye_match.position // 2
+            next_round_stmt = select(TournamentMatch).where(
+                TournamentMatch.tournament_id == tournament_id,
+                TournamentMatch.round == 2,
+                TournamentMatch.position == next_pos,
+            )
+            next_match_obj = (await db.execute(next_round_stmt)).scalar_one()
+            if bye_match.position % 2 == 0:
+                next_match_obj.movie_a_id = bye_match.winner_movie_id
+            else:
+                next_match_obj.movie_b_id = bye_match.winner_movie_id
+
+        await db.flush()
+
+    # Reload and return
+    tournament = await _load_tournament(tournament_id, uid, db)
     return _tournament_schema(tournament)
 
 

--- a/backend/schemas.py
+++ b/backend/schemas.py
@@ -119,6 +119,7 @@ class TournamentCreate(BaseModel):
     filter_type: Optional[str] = None
     filter_value: Optional[str] = None
     bracket_size: Literal[8, 16, 32, 64]
+    ai_curated: bool = False
 
 
 class TournamentMatchSchema(BaseModel):
@@ -140,9 +141,21 @@ class TournamentSchema(BaseModel):
     bracket_size: int
     status: str
     champion_movie_id: Optional[str] = None
+    tagline: Optional[str] = None
+    theme_description: Optional[str] = None
+    is_ai_curated: bool = False
+    llm_response: Optional[dict] = None
     created_at: datetime
     completed_at: Optional[datetime] = None
     matches: list[TournamentMatchSchema] = []
+
+
+class TournamentPreview(BaseModel):
+    name: str
+    tagline: str
+    theme_description: str
+    film_ids: list[str]
+    films: list[MovieSchema] = []
 
 
 class TournamentListItem(BaseModel):

--- a/backend/services/curator.py
+++ b/backend/services/curator.py
@@ -1,0 +1,143 @@
+"""LLM-powered film curator for AI-curated tournaments."""
+
+from __future__ import annotations
+
+import logging
+import re
+
+from fastapi import HTTPException
+
+from backend.services.llm import chat_completion, parse_json_response
+
+logger = logging.getLogger(__name__)
+
+SYSTEM_PROMPT = """\
+You are a film curator for a movie ranking app. Given a list of candidate films \
+(with titles, years, genres, and user ELO ratings), select exactly {bracket_size} \
+films that form a compelling, thematic tournament bracket.
+
+Rules:
+- Select ONLY from the candidate list (use the exact IDs provided)
+- The theme should be specific and non-obvious — not just a genre
+- Mix different ELO tiers for interesting matchups
+- The theme should connect the films in a surprising or insightful way
+
+Return ONLY valid JSON with no markdown formatting:
+{{"name": "bracket name", "tagline": "short punchy tagline", "theme_description": "2-3 sentence description of the theme and why these films were chosen", "film_ids": ["id1", "id2", ...]}}
+"""
+
+USER_PROMPT_TEMPLATE = """\
+Bracket size: {bracket_size}
+{filter_context}
+
+Candidate films:
+{candidates_text}
+"""
+
+
+async def curate_tournament(
+    candidates: list[dict],
+    bracket_size: int,
+    filter_context: str = "",
+) -> dict:
+    """Call LLM to select films and generate a theme.
+
+    Args:
+        candidates: List of dicts with keys: id, title, year, genres, elo, battles
+        bracket_size: Number of films to select
+        filter_context: Optional description of active filters (e.g. "Genre: Horror")
+
+    Returns:
+        Dict with keys: name, tagline, theme_description, film_ids
+
+    Raises:
+        HTTPException on API or parsing errors.
+    """
+    # Build candidate text
+    lines = []
+    for c in candidates:
+        genres_str = ", ".join(c.get("genres") or []) or "unknown"
+        lines.append(
+            f'- ID: {c["id"]} | "{c["title"]}" ({c.get("year", "?")})'
+            f" | Genres: {genres_str} | ELO: {c.get('elo', '?')}"
+            f" | Battles: {c.get('battles', 0)}"
+        )
+    candidates_text = "\n".join(lines)
+
+    system_prompt = SYSTEM_PROMPT.format(bracket_size=bracket_size)
+    user_prompt = USER_PROMPT_TEMPLATE.format(
+        bracket_size=bracket_size,
+        filter_context=f"Active filter: {filter_context}" if filter_context else "No filter applied",
+        candidates_text=candidates_text,
+    )
+
+    try:
+        text_content = await chat_completion(system_prompt, user_prompt)
+    except ValueError as exc:
+        # LLM_API_KEY not configured
+        raise HTTPException(
+            status_code=500,
+            detail=f"AI curation is not configured ({exc})",
+        )
+    except Exception as exc:
+        logger.error("LLM request failed during tournament curation: %s", exc)
+        raise HTTPException(
+            status_code=500,
+            detail="AI curation request failed. Please try again.",
+        )
+
+    # Parse the JSON from the LLM output
+    try:
+        result = parse_json_response(text_content)
+    except Exception:
+        # Try extracting JSON from markdown code block as fallback
+        match = re.search(r"```(?:json)?\s*(\{.*?\})\s*```", text_content, re.DOTALL)
+        if match:
+            try:
+                import json
+                result = json.loads(match.group(1))
+            except Exception:
+                logger.error("Failed to parse LLM JSON output: %s", text_content[:500])
+                raise HTTPException(
+                    status_code=500,
+                    detail="AI curation returned invalid JSON. Please try again.",
+                )
+        else:
+            logger.error("Failed to parse LLM JSON output: %s", text_content[:500])
+            raise HTTPException(
+                status_code=500,
+                detail="AI curation returned invalid JSON. Please try again.",
+            )
+
+    # Validate required fields
+    required_keys = {"name", "tagline", "theme_description", "film_ids"}
+    missing = required_keys - set(result.keys())
+    if missing:
+        logger.error("LLM response missing keys %s: %s", missing, result)
+        raise HTTPException(
+            status_code=500,
+            detail=f"AI curation response missing fields: {', '.join(missing)}",
+        )
+
+    if not isinstance(result["film_ids"], list):
+        raise HTTPException(
+            status_code=500,
+            detail="AI curation returned invalid film_ids (expected list)",
+        )
+
+    if len(result["film_ids"]) != bracket_size:
+        logger.warning(
+            "LLM returned %d films instead of %d, trimming/padding",
+            len(result["film_ids"]),
+            bracket_size,
+        )
+        # Trim if too many, but if too few that's an error
+        if len(result["film_ids"]) > bracket_size:
+            result["film_ids"] = result["film_ids"][:bracket_size]
+        else:
+            raise HTTPException(
+                status_code=500,
+                detail=f"AI selected {len(result['film_ids'])} films but bracket needs {bracket_size}. Please try again.",
+            )
+
+    return result

--- a/backend/services/llm.py
+++ b/backend/services/llm.py
@@ -1,0 +1,53 @@
+"""Shared LLM client for AI features (uses OpenRouter/Requesty API)."""
+
+import json
+import logging
+
+import httpx
+from backend.config import get_settings
+
+logger = logging.getLogger(__name__)
+
+
+async def chat_completion(
+    system: str,
+    user_message: str,
+    max_tokens: int = 500,
+) -> str:
+    """Call the LLM via OpenRouter-compatible API. Returns the text response."""
+    settings = get_settings()
+    if not settings.LLM_API_KEY:
+        raise ValueError(
+            "LLM_API_KEY is not configured. "
+            "Set it in your environment or .env file to enable AI features."
+        )
+
+    async with httpx.AsyncClient(timeout=30.0) as client:
+        resp = await client.post(
+            f"{settings.LLM_BASE_URL}/chat/completions",
+            headers={
+                "Authorization": f"Bearer {settings.LLM_API_KEY}",
+                "Content-Type": "application/json",
+            },
+            json={
+                "model": settings.LLM_MODEL,
+                "max_tokens": max_tokens,
+                "messages": [
+                    {"role": "system", "content": system},
+                    {"role": "user", "content": user_message},
+                ],
+            },
+        )
+        resp.raise_for_status()
+
+    data = resp.json()
+    return data["choices"][0]["message"]["content"]
+
+
+def parse_json_response(text: str) -> dict:
+    """Parse JSON from LLM response, handling markdown code fences."""
+    text = text.strip()
+    if text.startswith("```"):
+        lines = text.split("\n")
+        text = "\n".join(lines[1:-1]) if lines[-1].strip() == "```" else "\n".join(lines[1:])
+    return json.loads(text)

--- a/backend/services/suggest.py
+++ b/backend/services/suggest.py
@@ -6,23 +6,19 @@ unknown films, and asks an LLM to pick 6 personalised recommendations.
 
 from __future__ import annotations
 
-import json
 import logging
 import uuid
 from collections import defaultdict
 
-import httpx
-from sqlalchemy import func, select, text
+from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import joinedload
 
-from backend.config import get_settings
 from backend.db_models import Movie, UserMovie
+from backend.services.llm import chat_completion, parse_json_response
 
 logger = logging.getLogger(__name__)
 
-ANTHROPIC_API_URL = "https://api.anthropic.com/v1/messages"
-MODEL = "claude-sonnet-4-20250514"
 MIN_RANKED = 20
 NUM_PICKS = 6
 CANDIDATE_LIMIT = 50
@@ -127,14 +123,7 @@ async def _get_candidates(
 
 
 async def _call_llm(taste_profile: dict, candidates: list[dict]) -> list[dict]:
-    """Call Anthropic API to pick 6 films. Returns list of {trakt_id, reason}."""
-    settings = get_settings()
-    if not settings.ANTHROPIC_API_KEY:
-        raise ValueError(
-            "ANTHROPIC_API_KEY is not configured. "
-            "Set it in your environment or .env file to enable AI suggestions."
-        )
-
+    """Call LLM to pick 6 films. Returns list of {trakt_id, reason}."""
     system_prompt = (
         "You are a film recommendation assistant for FilmDuel, a movie ranking app. "
         "The user has ranked films via head-to-head duels, producing ELO ratings. "
@@ -176,34 +165,8 @@ async def _call_llm(taste_profile: dict, candidates: list[dict]) -> list[dict]:
         )
     )
 
-    async with httpx.AsyncClient(timeout=15.0) as client:
-        resp = await client.post(
-            ANTHROPIC_API_URL,
-            headers={
-                "x-api-key": settings.ANTHROPIC_API_KEY,
-                "anthropic-version": "2023-06-01",
-                "content-type": "application/json",
-            },
-            json={
-                "model": MODEL,
-                "max_tokens": 500,
-                "system": system_prompt,
-                "messages": [{"role": "user", "content": user_message}],
-            },
-        )
-        resp.raise_for_status()
-
-    data = resp.json()
-    text_content = data["content"][0]["text"]
-
-    # Parse JSON from response (handle markdown code fences)
-    text_clean = text_content.strip()
-    if text_clean.startswith("```"):
-        # Strip code fence
-        lines = text_clean.split("\n")
-        text_clean = "\n".join(lines[1:-1]) if lines[-1].strip() == "```" else "\n".join(lines[1:])
-
-    parsed = json.loads(text_clean)
+    text_content = await chat_completion(system_prompt, user_message)
+    parsed = parse_json_response(text_content)
     return parsed["picks"]
 
 
@@ -213,7 +176,7 @@ async def generate_suggestions(
     """Generate 6 personalized film suggestions.
 
     Returns list of {movie_id: str, reason: str}.
-    Raises ValueError if ANTHROPIC_API_KEY is not set.
+    Raises ValueError if LLM_API_KEY is not set.
     Returns empty list if user has < MIN_RANKED films (caller should check taste_profile).
     """
     taste_profile = await _build_taste_profile(user_id, db)

--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -70,7 +70,7 @@ export function getTournamentPoolCount(filterType, filterValue) {
   return request(`/api/tournaments/pool-count?${params}`);
 }
 
-export function createTournament(name, bracketSize, filterType, filterValue) {
+export function createTournament(name, bracketSize, filterType, filterValue, aiCurated = false) {
   return request("/api/tournaments", {
     method: "POST",
     body: JSON.stringify({
@@ -78,6 +78,7 @@ export function createTournament(name, bracketSize, filterType, filterValue) {
       bracket_size: bracketSize,
       filter_type: filterType || null,
       filter_value: filterValue || null,
+      ai_curated: aiCurated,
     }),
   });
 }
@@ -99,6 +100,10 @@ export function submitTournamentMatch(tournamentId, matchId, winnerMovieId) {
 
 export function abandonTournament(id) {
   return request(`/api/tournaments/${id}`, { method: "DELETE" });
+}
+
+export function regenerateTournament(id) {
+  return request(`/api/tournaments/${id}/regenerate`, { method: "POST" });
 }
 
 // ── Suggestions ─────────────────────────────────────────────────────

--- a/frontend/src/pages/TournamentBracket.jsx
+++ b/frontend/src/pages/TournamentBracket.jsx
@@ -1,6 +1,6 @@
 import { useState, useEffect, useCallback, useMemo } from "react";
 import { useParams, useNavigate } from "react-router-dom";
-import { getTournament, submitTournamentMatch, abandonTournament } from "../api";
+import { getTournament, submitTournamentMatch, abandonTournament, regenerateTournament } from "../api";
 import MovieCard from "../components/MovieCard";
 
 function roundLabel(round, totalRounds) {
@@ -141,6 +141,7 @@ export default function TournamentBracket() {
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState(null);
   const [winnerFlash, setWinnerFlash] = useState(null); // brief flash between matches
+  const [regenerating, setRegenerating] = useState(false);
 
   const loadTournament = useCallback(async () => {
     try {
@@ -250,6 +251,24 @@ export default function TournamentBracket() {
       setSubmitting(false);
     }
   }
+
+  async function handleRegenerate() {
+    setRegenerating(true);
+    setError(null);
+    try {
+      const updated = await regenerateTournament(id);
+      setTournament(updated);
+    } catch (err) {
+      setError(err.message);
+    } finally {
+      setRegenerating(false);
+    }
+  }
+
+  // Check if regeneration is available (AI-curated, no non-bye matches played)
+  const canRegenerate = tournament?.is_ai_curated &&
+    tournament?.status === "active" &&
+    !tournament?.matches?.some((m) => m.winner_movie_id && !m.is_bye);
 
   async function handleAbandon() {
     if (!confirm("Abandon this tournament? This cannot be undone.")) return;
@@ -388,9 +407,19 @@ export default function TournamentBracket() {
           </button>
           <span className="text-[#F5F0E8]/20">/</span>
         </div>
-        <h2 className="text-4xl md:text-6xl font-headline font-black uppercase tracking-tighter text-[#F5F0E8] leading-none mb-4">
+        <h2 className="text-4xl md:text-6xl font-headline font-black uppercase tracking-tighter text-[#F5F0E8] leading-none mb-2">
           {tournament.name}
         </h2>
+        {tournament.tagline && (
+          <p className="text-lg md:text-xl font-body text-[#E8A020]/80 italic mb-2">
+            {tournament.tagline}
+          </p>
+        )}
+        {tournament.theme_description && (
+          <p className="text-sm font-body text-[#F5F0E8]/50 mb-4 max-w-2xl leading-relaxed">
+            {tournament.theme_description}
+          </p>
+        )}
         <div className="flex items-center gap-6 flex-wrap">
           <span className="text-[10px] font-label uppercase tracking-[0.3em] text-[#6B6760]">
             {tournament.bracket_size} films
@@ -438,7 +467,7 @@ export default function TournamentBracket() {
         </div>
       )}
 
-      {/* Play Round Button */}
+      {/* Play Round Button + Regenerate */}
       {nextMatch && !isCompleted && !isAbandoned && (() => {
         const roundMatches = rounds.find((r) => r.round === nextMatch.round)?.matches || [];
         const remaining = roundMatches.filter((m) => !m.winner_movie_id).length;
@@ -446,13 +475,22 @@ export default function TournamentBracket() {
           ? `Play ${roundLabel(nextMatch.round, totalRounds)} (${remaining} matches)`
           : "Play Next Match";
         return (
-          <div className="mb-8">
+          <div className="mb-8 flex items-center gap-4 flex-wrap">
             <button
               onClick={() => setPlaying(true)}
               className="bg-[#E8A020] text-[#0F0E0D] font-headline font-black uppercase py-4 px-8 tracking-widest text-sm hover:shadow-[0_0_30px_rgba(232,160,32,0.4)] active:scale-[0.98] transition-all"
             >
               {label}
             </button>
+            {canRegenerate && (
+              <button
+                onClick={handleRegenerate}
+                disabled={regenerating}
+                className="border border-[#E8A020]/30 text-[#E8A020] font-headline font-bold uppercase py-4 px-6 tracking-widest text-xs hover:bg-[#E8A020]/10 transition-all disabled:opacity-40 disabled:cursor-not-allowed"
+              >
+                {regenerating ? "Regenerating..." : "Regenerate"}
+              </button>
+            )}
           </div>
         );
       })()}

--- a/frontend/src/pages/Tournaments.jsx
+++ b/frontend/src/pages/Tournaments.jsx
@@ -20,6 +20,7 @@ export default function Tournaments() {
   const [filterValue, setFilterValue] = useState("");
   const [availableGenres, setAvailableGenres] = useState([]);
   const [poolCount, setPoolCount] = useState(null);
+  const [aiCurated, setAiCurated] = useState(false);
 
   useEffect(() => {
     loadTournaments();
@@ -57,13 +58,14 @@ export default function Tournaments() {
   }
 
   async function handleCreate() {
-    if (!name.trim()) return;
+    if (!aiCurated && !name.trim()) return;
     setCreating(true);
     setError(null);
     try {
       const filterType = filterMode === "all" ? null : filterMode;
       const fv = filterMode === "all" ? null : filterValue;
-      const t = await createTournament(name.trim(), bracketSize, filterType, fv);
+      const tournamentName = name.trim() || "AI Tournament";
+      const t = await createTournament(tournamentName, bracketSize, filterType, fv, aiCurated);
       navigate(`/tournaments/${t.id}`);
     } catch (err) {
       setError(err.message);
@@ -118,6 +120,40 @@ export default function Tournaments() {
               placeholder="Horror Showdown"
               className="w-full max-w-md bg-[#0F0E0D] border border-[#F5F0E8]/10 text-[#F5F0E8] font-body px-4 py-3 placeholder:text-[#6B6760]/50 focus:border-[#E8A020]/50 focus:outline-none transition-colors"
             />
+          </div>
+
+          {/* Mode: Standard vs AI-Curated */}
+          <div className="mb-6">
+            <label className="text-[10px] font-label uppercase tracking-[0.3em] text-[#6B6760] block mb-2">
+              Curation Mode
+            </label>
+            <div className="flex gap-2">
+              <button
+                onClick={() => setAiCurated(false)}
+                className={
+                  !aiCurated
+                    ? "px-6 py-2 bg-[#E8A020] text-[#0F0E0D] font-label font-bold uppercase text-xs tracking-widest border border-[#E8A020]"
+                    : "px-6 py-2 bg-transparent text-[#F5F0E8]/60 font-label font-bold uppercase text-xs tracking-widest border border-[#F5F0E8]/10 hover:border-[#E8A020]/40 transition-colors"
+                }
+              >
+                Standard
+              </button>
+              <button
+                onClick={() => setAiCurated(true)}
+                className={
+                  aiCurated
+                    ? "px-6 py-2 bg-[#E8A020] text-[#0F0E0D] font-label font-bold uppercase text-xs tracking-widest border border-[#E8A020]"
+                    : "px-6 py-2 bg-transparent text-[#F5F0E8]/60 font-label font-bold uppercase text-xs tracking-widest border border-[#F5F0E8]/10 hover:border-[#E8A020]/40 transition-colors"
+                }
+              >
+                AI-Curated
+              </button>
+            </div>
+            {aiCurated && (
+              <p className="mt-2 text-sm font-body text-[#E8A020]/70">
+                AI will select films and create a themed bracket
+              </p>
+            )}
           </div>
 
           {/* Bracket Size */}
@@ -234,10 +270,10 @@ export default function Tournaments() {
           <div className="flex gap-3">
             <button
               onClick={handleCreate}
-              disabled={creating || !name.trim() || (filterMode !== "all" && !filterValue)}
+              disabled={creating || (!aiCurated && !name.trim()) || (filterMode !== "all" && !filterValue)}
               className="bg-[#E8A020] text-[#0F0E0D] font-headline font-black uppercase py-4 px-8 tracking-widest text-sm hover:shadow-[0_0_30px_rgba(232,160,32,0.4)] active:scale-[0.98] transition-all disabled:opacity-40 disabled:cursor-not-allowed"
             >
-              {creating ? "Creating..." : "Create & Seed"}
+              {creating ? (aiCurated ? "Curating your bracket..." : "Creating...") : "Create & Seed"}
             </button>
             <button
               onClick={() => {


### PR DESCRIPTION
## Summary
- **Switch all LLM calls from Anthropic API to OpenRouter/Requesty.ai**: New shared `backend/services/llm.py` client uses OpenRouter-compatible API format (`POST /v1/chat/completions` with Bearer auth). Configurable via `LLM_API_KEY`, `LLM_BASE_URL`, `LLM_MODEL` env vars (replaces `ANTHROPIC_API_KEY`).
- **AI-curated tournaments**: LLM selects films from candidate pool and generates themed bracket with name, tagline, and description. Frontend adds Standard/AI-Curated toggle, theme display in bracket header, and Regenerate button (up to 3 attempts, only before matches played).
- **Alembic migration 010**: Adds `tagline`, `theme_description`, `is_ai_curated`, `llm_response` columns to tournaments table (chains from 009).

## Changes
- `backend/config.py`: Replace `ANTHROPIC_API_KEY` with `LLM_API_KEY`, `LLM_BASE_URL`, `LLM_MODEL`
- `backend/services/llm.py`: New shared LLM client (OpenRouter-compatible)
- `backend/services/curator.py`: New AI tournament curation service
- `backend/services/suggest.py`: Refactored to use shared LLM client
- `backend/db_models.py`, `backend/schemas.py`: Add AI curation fields to Tournament
- `backend/routers/tournaments.py`: AI curation flow + regenerate endpoint
- Frontend: AI-Curated toggle, tagline/theme display, regenerate button
- CI: Add `LLM_API_KEY` env var

Supersedes #42 (which can't merge due to conflicts).

## Test plan
- [ ] Create a standard tournament -- verify no regression
- [ ] Create an AI-curated tournament with LLM_API_KEY set -- verify themed bracket
- [ ] Verify tagline and theme_description display in bracket header
- [ ] Click Regenerate -- verify bracket re-rolls with new theme
- [ ] Verify Regenerate disappears after a match is played
- [ ] Verify max 3 regenerations enforced
- [ ] Test AI suggestions still work via shared LLM client
- [ ] Run migration 010 on existing database

🤖 Generated with [Claude Code](https://claude.com/claude-code)