### PR TITLE
feat: use LiteLLM for LLM calls, switch to Gemini Flash

### DIFF
--- a/backend/config.py
+++ b/backend/config.py
@@ -25,7 +25,7 @@ class Settings(BaseSettings):
     # LLM (OpenRouter / Requesty.ai)
     LLM_API_KEY: str = ""
     LLM_BASE_URL: str = "https://router.requesty.ai/v1"
-    LLM_MODEL: str = "anthropic/claude-sonnet-4-20250514"
+    LLM_MODEL: str = "openrouter/google/gemini-2.5-flash-preview"
 
     # Sentry
     SENTRY_DSN: str = ""

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -10,3 +10,4 @@ greenlet>=3.0.0
 PyJWT>=2.8.0
 python-multipart>=0.0.6
 sentry-sdk[fastapi]>=2.0.0
+litellm>=1.40.0

--- a/backend/services/llm.py
+++ b/backend/services/llm.py
@@ -1,9 +1,9 @@
-"""Shared LLM client for AI features (uses OpenRouter/Requesty API)."""
+"""Shared LLM client for AI features (uses LiteLLM with Requesty/OpenRouter)."""
 
 import json
 import logging
+import os
 
-import httpx
 from backend.config import get_settings
 
 logger = logging.getLogger(__name__)
@@ -14,7 +14,7 @@ async def chat_completion(
     user_message: str,
     max_tokens: int = 500,
 ) -> str:
-    """Call the LLM via OpenRouter-compatible API. Returns the text response."""
+    """Call the LLM via LiteLLM. Returns the text response."""
     settings = get_settings()
     if not settings.LLM_API_KEY:
         raise ValueError(
@@ -22,26 +22,23 @@ async def chat_completion(
             "Set it in your environment or .env file to enable AI features."
         )
 
-    async with httpx.AsyncClient(timeout=30.0) as client:
-        resp = await client.post(
-            f"{settings.LLM_BASE_URL}/chat/completions",
-            headers={
-                "Authorization": f"Bearer {settings.LLM_API_KEY}",
-                "Content-Type": "application/json",
-            },
-            json={
-                "model": settings.LLM_MODEL,
-                "max_tokens": max_tokens,
-                "messages": [
-                    {"role": "system", "content": system},
-                    {"role": "user", "content": user_message},
-                ],
-            },
-        )
-        resp.raise_for_status()
+    # LiteLLM uses env vars for API keys — set them before the call
+    os.environ["OPENROUTER_API_KEY"] = settings.LLM_API_KEY
 
-    data = resp.json()
-    return data["choices"][0]["message"]["content"]
+    # Import here to avoid import-time side effects from litellm
+    from litellm import acompletion
+
+    response = await acompletion(
+        model=settings.LLM_MODEL,
+        max_tokens=max_tokens,
+        api_base=settings.LLM_BASE_URL,
+        messages=[
+            {"role": "system", "content": system},
+            {"role": "user", "content": user_message},
+        ],
+    )
+
+    return response.choices[0].message.content
 
 
 def parse_json_response(text: str) -> dict:


### PR DESCRIPTION
## Summary
- Replace raw httpx OpenRouter calls with LiteLLM `acompletion()`
- Default model changed to `google/gemini-2.5-flash-preview` (faster, cheaper)
- LiteLLM handles retries, error normalization, and provider-specific quirks
- Requesty.ai base URL preserved as default

## Test plan
- [ ] AI tournament creation works with Requesty key
- [ ] Suggestions generation works
- [ ] No import errors on startup

🤖 Generated with [Claude Code](https://claude.com/claude-code)