### PR TITLE
fix: LLM calls route through Requesty correctly

### DIFF
--- a/backend/config.py
+++ b/backend/config.py
@@ -25,7 +25,7 @@ class Settings(BaseSettings):
     # LLM (OpenRouter / Requesty.ai)
     LLM_API_KEY: str = ""
     LLM_BASE_URL: str = "https://router.requesty.ai/v1"
-    LLM_MODEL: str = "openrouter/google/gemini-2.5-flash-preview"
+    LLM_MODEL: str = "google/gemini-3.1-flash-lite-preview"
 
     # Sentry
     SENTRY_DSN: str = ""

--- a/backend/services/llm.py
+++ b/backend/services/llm.py
@@ -2,7 +2,6 @@
 
 import json
 import logging
-import os
 
 from backend.config import get_settings
 
@@ -22,15 +21,13 @@ async def chat_completion(
             "Set it in your environment or .env file to enable AI features."
         )
 
-    # LiteLLM uses env vars for API keys — set them before the call
-    os.environ["OPENROUTER_API_KEY"] = settings.LLM_API_KEY
-
     # Import here to avoid import-time side effects from litellm
     from litellm import acompletion
 
     response = await acompletion(
-        model=settings.LLM_MODEL,
+        model=f"openai/{settings.LLM_MODEL}",
         max_tokens=max_tokens,
+        api_key=settings.LLM_API_KEY,
         api_base=settings.LLM_BASE_URL,
         messages=[
             {"role": "system", "content": system},


### PR DESCRIPTION
## Summary
- LiteLLM `openrouter/` prefix ignored our `api_base` and hit OpenRouter directly
- Model `gemini-3.1-flash-lite-preview` exists on Requesty but the call never reached it
- Fix: use `openai/` prefix with explicit `api_key` + `api_base` for Requesty routing

## Test plan
- [ ] Create AI-curated tournament — should generate theme + bracket
- [ ] Visit Watch Next — suggestions should generate (if 20+ ranked films + candidates)

🤖 Generated with [Claude Code](https://claude.com/claude-code)