### PR TITLE
fix: increase LLM max_tokens — JSON was getting truncated

### DIFF
--- a/backend/services/curator.py
+++ b/backend/services/curator.py
@@ -72,7 +72,7 @@ async def curate_tournament(
     )
 
     try:
-        text_content = await chat_completion(system_prompt, user_prompt)
+        text_content = await chat_completion(system_prompt, user_prompt, max_tokens=2000)
     except ValueError as exc:
         # LLM_API_KEY not configured
         raise HTTPException(

--- a/backend/services/suggest.py
+++ b/backend/services/suggest.py
@@ -165,7 +165,7 @@ async def _call_llm(taste_profile: dict, candidates: list[dict]) -> list[dict]:
         )
     )
 
-    text_content = await chat_completion(system_prompt, user_message)
+    text_content = await chat_completion(system_prompt, user_message, max_tokens=1500)
     parsed = parse_json_response(text_content)
     return parsed["picks"]
 


### PR DESCRIPTION
## Summary
- Curator: 500 → 2000 tokens (16 UUIDs alone = ~300 chars)
- Suggestions: 500 → 1500 tokens (6 picks with reasons)
- Root cause: truncated JSON response from Gemini Flash

🤖 Generated with [Claude Code](https://claude.com/claude-code)