### PR TITLE
fix: swipe only shows films with posters

### DIFF
--- a/backend/routers/swipe.py
+++ b/backend/routers/swipe.py
@@ -60,7 +60,7 @@ async def get_swipe_cards(
     result = await db.execute(median_stmt)
     median_elo = result.scalar_one_or_none()
 
-    # Base query: unknown films for this user
+    # Base query: unknown films for this user (must have poster)
     base = (
         select(
             Movie.id,
@@ -72,7 +72,7 @@ async def get_swipe_cards(
             Movie.community_rating,
         )
         .join(UserMovie, UserMovie.movie_id == Movie.id)
-        .where(UserMovie.user_id == uid, UserMovie.seen.is_(None))
+        .where(UserMovie.user_id == uid, UserMovie.seen.is_(None), Movie.poster_url.isnot(None))
     )
 
     if median_elo is None:


### PR DESCRIPTION
## Summary
- Filter out movies with null `poster_url` from the swipe cards base query
- Prevents blank placeholder cards from appearing in the swipe view

## Test plan
- [ ] Open swipe view and verify all cards display poster images
- [ ] Confirm no blank/placeholder cards appear

🤖 Generated with [Claude Code](https://claude.com/claude-code)