### PR TITLE
refactor: extract duel service layer

### DIFF
--- a/backend/routers/duels.py
+++ b/backend/routers/duels.py
@@ -4,17 +4,16 @@ from __future__ import annotations
 
 import logging
 import uuid
-from datetime import datetime, timezone
 
-from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException
-from sqlalchemy import func, select
+from fastapi import APIRouter, BackgroundTasks, Depends
+from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from backend.db import async_session_factory, get_db
-from backend.db_models import Duel, Movie, User, UserMovie
+from backend.db_models import Movie, User
 from backend.schemas import DuelSubmit, DuelResult
 from backend.routers.auth import get_current_user
-from backend.services.elo import get_initial_elo, update_elo
+from backend.services.duel import process_duel
 from backend.services.sync import sync_post_duel
 
 logger = logging.getLogger(__name__)
@@ -29,6 +28,7 @@ async def _sync_ratings_background(
     movie_b_id: uuid.UUID,
     new_elo_b: int,
 ) -> None:
+    """Fire-and-forget Trakt rating sync after a duel with a winner."""
     async with async_session_factory() as session:
         user_stmt = select(User.trakt_access_token).where(User.id == user_id)
         result = await session.execute(user_stmt)
@@ -49,105 +49,6 @@ async def _sync_ratings_background(
         await sync_post_duel(access_token, movie_ratings)
 
 
-async def _persist_duel_background(
-    user_id: uuid.UUID,
-    movie_a_id: uuid.UUID,
-    movie_b_id: uuid.UUID,
-    outcome: str,
-    mode: str,
-    new_elo_a: int | None,
-    new_elo_b: int | None,
-    pair_type: str,
-    elo_a_before: int | None,
-    elo_b_before: int | None,
-    um_a_seen_was_none: bool,
-    um_b_seen_was_none: bool,
-) -> None:
-    """Persist ELO updates, duel record, and user_movie mutations in a background task."""
-    try:
-        async with async_session_factory() as session:
-            async with session.begin():
-                # Fetch or create user_movies
-                for mid in (movie_a_id, movie_b_id):
-                    stmt = select(UserMovie).where(
-                        UserMovie.user_id == user_id, UserMovie.movie_id == mid
-                    )
-                    result = await session.execute(stmt)
-                    um = result.scalar_one_or_none()
-                    if not um:
-                        um = UserMovie(user_id=user_id, movie_id=mid)
-                        session.add(um)
-                        await session.flush()
-
-                # Re-fetch both for updates
-                stmt_a = select(UserMovie).where(
-                    UserMovie.user_id == user_id, UserMovie.movie_id == movie_a_id
-                )
-                stmt_b = select(UserMovie).where(
-                    UserMovie.user_id == user_id, UserMovie.movie_id == movie_b_id
-                )
-                um_a = (await session.execute(stmt_a)).scalar_one()
-                um_b = (await session.execute(stmt_b)).scalar_one()
-
-                now = datetime.now(timezone.utc)
-
-                if outcome in ("a_wins", "b_wins"):
-                    um_a.seen = True
-                    um_b.seen = True
-                    um_a.elo = new_elo_a
-                    um_b.elo = new_elo_b
-                    um_a.battles += 1
-                    um_b.battles += 1
-                    um_a.last_dueled_at = now
-                    um_b.last_dueled_at = now
-                    um_a.updated_at = now
-                    um_b.updated_at = now
-                elif outcome == "a_only":
-                    if um_a_seen_was_none:
-                        um_a.seen = True
-                    um_b.seen = False
-                    um_a.updated_at = now
-                    um_b.updated_at = now
-                elif outcome == "b_only":
-                    if um_b_seen_was_none:
-                        um_b.seen = True
-                    um_a.seen = False
-                    um_a.updated_at = now
-                    um_b.updated_at = now
-                elif outcome == "neither":
-                    um_a.seen = False
-                    um_b.seen = False
-                    um_a.updated_at = now
-                    um_b.updated_at = now
-
-                # Build duel record
-                winner_id = loser_id = None
-                w_elo_before = l_elo_before = w_elo_after = l_elo_after = None
-                if outcome == "a_wins":
-                    winner_id, loser_id = movie_a_id, movie_b_id
-                    w_elo_before, l_elo_before = elo_a_before, elo_b_before
-                    w_elo_after, l_elo_after = new_elo_a, new_elo_b
-                elif outcome == "b_wins":
-                    winner_id, loser_id = movie_b_id, movie_a_id
-                    w_elo_before, l_elo_before = elo_b_before, elo_a_before
-                    w_elo_after, l_elo_after = new_elo_b, new_elo_a
-
-                duel = Duel(
-                    user_id=user_id,
-                    winner_movie_id=winner_id,
-                    loser_movie_id=loser_id,
-                    winner_elo_before=w_elo_before,
-                    loser_elo_before=l_elo_before,
-                    winner_elo_after=w_elo_after,
-                    loser_elo_after=l_elo_after,
-                    mode=mode,
-                    pair_type=pair_type,
-                )
-                session.add(duel)
-    except Exception:
-        logger.exception("Failed to persist duel for user %s", user_id)
-
-
 @router.post("", response_model=DuelResult)
 async def submit_duel(
     body: DuelSubmit,
@@ -161,85 +62,17 @@ async def submit_duel(
     outcome = body.outcome.value
     mode = body.mode
 
-    # ── Read current state (fast queries, no mutations) ──────────────
-    async def get_or_create_user_movie(mid: uuid.UUID) -> UserMovie:
-        stmt = select(UserMovie).where(
-            UserMovie.user_id == uid, UserMovie.movie_id == mid
-        )
-        result = await db.execute(stmt)
-        um = result.scalar_one_or_none()
-        if not um:
-            um = UserMovie(user_id=uid, movie_id=mid)
-            db.add(um)
-            await db.flush()
-        return um
+    result = await process_duel(db, uid, movie_a_id, movie_b_id, outcome, mode)
 
-    um_a = await get_or_create_user_movie(movie_a_id)
-    um_b = await get_or_create_user_movie(movie_b_id)
-
-    # Snapshot state needed by the background task
-    um_a_seen_was_none = um_a.seen is None
-    um_b_seen_was_none = um_b.seen is None
-
-    # Compute pair_type before battles are incremented
-    if um_a.battles >= 1 and um_b.battles >= 1:
-        pair_type = "ranked_vs_ranked"
-    elif um_a.battles == 0 or um_b.battles == 0:
-        pair_type = "ranked_vs_unranked"
-    else:
-        pair_type = "unknown"
-
-    # ── ELO math (pure CPU, no I/O) ─────────────────────────────────
-    new_elo_a: int | None = um_a.elo
-    new_elo_b: int | None = um_b.elo
-    delta_a = 0
-    delta_b = 0
-    elo_a_before: int | None = None
-    elo_b_before: int | None = None
-
-    if outcome in ("a_wins", "b_wins"):
-        elo_a_before = um_a.elo if um_a.elo is not None else get_initial_elo(um_a.seeded_elo)
-        elo_b_before = um_b.elo if um_b.elo is not None else get_initial_elo(um_b.seeded_elo)
-
-        if outcome == "a_wins":
-            new_elo_a, new_elo_b = update_elo(
-                elo_a_before, elo_b_before, um_a.battles, um_b.battles
-            )
-        else:  # b_wins
-            new_elo_b, new_elo_a = update_elo(
-                elo_b_before, elo_a_before, um_b.battles, um_a.battles
-            )
-
-        delta_a = new_elo_a - elo_a_before
-        delta_b = new_elo_b - elo_b_before
-
-    # ── next_action (fast count query, before background task) ───────
-    seen_unranked_stmt = select(func.count()).where(
-        UserMovie.user_id == uid,
-        UserMovie.seen.is_(True),
-        UserMovie.battles == 0,
-    )
-    seen_unranked_result = await db.execute(seen_unranked_stmt)
-    seen_unranked = seen_unranked_result.scalar_one()
-    next_action = "swipe" if seen_unranked < 3 else "duel"
-
-    # ── Fire background tasks (DB persist + Trakt sync) ──────────────
-    background_tasks.add_task(
-        _persist_duel_background,
-        uid, movie_a_id, movie_b_id, outcome, mode,
-        new_elo_a, new_elo_b, pair_type,
-        elo_a_before, elo_b_before,
-        um_a_seen_was_none, um_b_seen_was_none,
-    )
-
+    # Trakt sync in background (fire-and-forget)
     if outcome in ("a_wins", "b_wins"):
         background_tasks.add_task(
-            _sync_ratings_background, uid, movie_a_id, new_elo_a, movie_b_id, new_elo_b,
+            _sync_ratings_background,
+            uid,
+            movie_a_id,
+            result.new_elo_a,
+            movie_b_id,
+            result.new_elo_b,
         )
 
-    return DuelResult(
-        outcome=body.outcome,
-        movie_a_elo_delta=delta_a,
-        movie_b_elo_delta=delta_b,
-        next_action=next_action,
-    )
+    return result.api_result

--- a/backend/services/duel.py
+++ b/backend/services/duel.py
@@ -1,0 +1,173 @@
+"""Duel business logic — ELO updates, user_movie mutations, duel records.
+
+Extracted from the router so the core logic is testable and not duplicated
+between the inline handler and a background task.
+"""
+
+from __future__ import annotations
+
+import uuid
+from dataclasses import dataclass
+from datetime import datetime, timezone
+
+from sqlalchemy import func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from backend.db_models import Duel, UserMovie
+from backend.schemas import DuelOutcome, DuelResult
+from backend.services.elo import get_initial_elo, update_elo
+
+
+@dataclass
+class ProcessDuelResult:
+    """Internal result carrying both the API response and data needed by background tasks."""
+
+    api_result: DuelResult
+    new_elo_a: int | None
+    new_elo_b: int | None
+
+
+async def get_or_create_user_movie(
+    db: AsyncSession, user_id: uuid.UUID, movie_id: uuid.UUID
+) -> UserMovie:
+    """Fetch an existing UserMovie or create a new one."""
+    stmt = select(UserMovie).where(
+        UserMovie.user_id == user_id, UserMovie.movie_id == movie_id
+    )
+    result = await db.execute(stmt)
+    um = result.scalar_one_or_none()
+    if not um:
+        um = UserMovie(user_id=user_id, movie_id=movie_id)
+        db.add(um)
+        await db.flush()
+    return um
+
+
+async def process_duel(
+    db: AsyncSession,
+    user_id: uuid.UUID,
+    movie_a_id: uuid.UUID,
+    movie_b_id: uuid.UUID,
+    outcome: str,
+    mode: str,
+) -> ProcessDuelResult:
+    """Run the full duel pipeline: ELO math, DB mutations, duel record.
+
+    All writes happen on the provided session (committed by the caller /
+    FastAPI dependency).  Returns a ``DuelResult`` ready to send to the client.
+    """
+    # ── Fetch / create user_movies ──────────────────────────────────
+    um_a = await get_or_create_user_movie(db, user_id, movie_a_id)
+    um_b = await get_or_create_user_movie(db, user_id, movie_b_id)
+
+    um_a_seen_was_none = um_a.seen is None
+    um_b_seen_was_none = um_b.seen is None
+
+    # ── Pair type (before battles are incremented) ──────────────────
+    if um_a.battles >= 1 and um_b.battles >= 1:
+        pair_type = "ranked_vs_ranked"
+    elif um_a.battles == 0 or um_b.battles == 0:
+        pair_type = "ranked_vs_unranked"
+    else:
+        pair_type = "unknown"
+
+    # ── ELO math (pure CPU, no I/O) ────────────────────────────────
+    new_elo_a: int | None = um_a.elo
+    new_elo_b: int | None = um_b.elo
+    delta_a = 0
+    delta_b = 0
+    elo_a_before: int | None = None
+    elo_b_before: int | None = None
+
+    now = datetime.now(timezone.utc)
+
+    if outcome in ("a_wins", "b_wins"):
+        elo_a_before = um_a.elo if um_a.elo is not None else get_initial_elo(um_a.seeded_elo)
+        elo_b_before = um_b.elo if um_b.elo is not None else get_initial_elo(um_b.seeded_elo)
+
+        if outcome == "a_wins":
+            new_elo_a, new_elo_b = update_elo(
+                elo_a_before, elo_b_before, um_a.battles, um_b.battles
+            )
+        else:  # b_wins
+            new_elo_b, new_elo_a = update_elo(
+                elo_b_before, elo_a_before, um_b.battles, um_a.battles
+            )
+
+        delta_a = new_elo_a - elo_a_before
+        delta_b = new_elo_b - elo_b_before
+
+        # Mutate user_movies
+        um_a.seen = True
+        um_b.seen = True
+        um_a.elo = new_elo_a
+        um_b.elo = new_elo_b
+        um_a.battles += 1
+        um_b.battles += 1
+        um_a.last_dueled_at = now
+        um_b.last_dueled_at = now
+        um_a.updated_at = now
+        um_b.updated_at = now
+    elif outcome == "a_only":
+        if um_a_seen_was_none:
+            um_a.seen = True
+        um_b.seen = False
+        um_a.updated_at = now
+        um_b.updated_at = now
+    elif outcome == "b_only":
+        if um_b_seen_was_none:
+            um_b.seen = True
+        um_a.seen = False
+        um_a.updated_at = now
+        um_b.updated_at = now
+    elif outcome == "neither":
+        um_a.seen = False
+        um_b.seen = False
+        um_a.updated_at = now
+        um_b.updated_at = now
+
+    # ── Duel record ─────────────────────────────────────────────────
+    winner_id = loser_id = None
+    w_elo_before = l_elo_before = w_elo_after = l_elo_after = None
+    if outcome == "a_wins":
+        winner_id, loser_id = movie_a_id, movie_b_id
+        w_elo_before, l_elo_before = elo_a_before, elo_b_before
+        w_elo_after, l_elo_after = new_elo_a, new_elo_b
+    elif outcome == "b_wins":
+        winner_id, loser_id = movie_b_id, movie_a_id
+        w_elo_before, l_elo_before = elo_b_before, elo_a_before
+        w_elo_after, l_elo_after = new_elo_b, new_elo_a
+
+    duel = Duel(
+        user_id=user_id,
+        winner_movie_id=winner_id,
+        loser_movie_id=loser_id,
+        winner_elo_before=w_elo_before,
+        loser_elo_before=l_elo_before,
+        winner_elo_after=w_elo_after,
+        loser_elo_after=l_elo_after,
+        mode=mode,
+        pair_type=pair_type,
+    )
+    db.add(duel)
+
+    # ── next_action ─────────────────────────────────────────────────
+    seen_unranked_stmt = select(func.count()).where(
+        UserMovie.user_id == user_id,
+        UserMovie.seen.is_(True),
+        UserMovie.battles == 0,
+    )
+    seen_unranked_result = await db.execute(seen_unranked_stmt)
+    seen_unranked = seen_unranked_result.scalar_one()
+    next_action = "swipe" if seen_unranked < 3 else "duel"
+
+    return ProcessDuelResult(
+        api_result=DuelResult(
+            outcome=DuelOutcome(outcome),
+            movie_a_elo_delta=delta_a,
+            movie_b_elo_delta=delta_b,
+            next_action=next_action,
+        ),
+        new_elo_a=new_elo_a,
+        new_elo_b=new_elo_b,
+    )

--- a/backend/tests/test_duel_service.py
+++ b/backend/tests/test_duel_service.py
@@ -1,0 +1,333 @@
+"""Tests for the duel service layer."""
+
+from __future__ import annotations
+
+import uuid
+from datetime import datetime, timezone
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from backend.services.duel import get_or_create_user_movie, process_duel
+
+
+def _make_user_movie(
+    user_id: uuid.UUID,
+    movie_id: uuid.UUID,
+    elo: int | None = None,
+    seeded_elo: int | None = None,
+    battles: int = 0,
+    seen: bool | None = None,
+) -> MagicMock:
+    """Build a mock UserMovie with sensible defaults."""
+    um = MagicMock()
+    um.user_id = user_id
+    um.movie_id = movie_id
+    um.elo = elo
+    um.seeded_elo = seeded_elo
+    um.battles = battles
+    um.seen = seen
+    um.last_dueled_at = None
+    um.updated_at = datetime.now(timezone.utc)
+    return um
+
+
+# ---------------------------------------------------------------------------
+# get_or_create_user_movie
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_get_or_create_existing():
+    """Returns existing UserMovie without creating a new one."""
+    uid = uuid.uuid4()
+    mid = uuid.uuid4()
+    existing = _make_user_movie(uid, mid)
+
+    mock_result = MagicMock()
+    mock_result.scalar_one_or_none.return_value = existing
+
+    db = AsyncMock()
+    db.execute.return_value = mock_result
+
+    um = await get_or_create_user_movie(db, uid, mid)
+    assert um is existing
+    db.add.assert_not_called()
+    db.flush.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_get_or_create_new():
+    """Creates a new UserMovie when none exists."""
+    uid = uuid.uuid4()
+    mid = uuid.uuid4()
+
+    mock_result = MagicMock()
+    mock_result.scalar_one_or_none.return_value = None
+
+    db = AsyncMock()
+    db.execute.return_value = mock_result
+
+    um = await get_or_create_user_movie(db, uid, mid)
+    assert um.user_id == uid
+    assert um.movie_id == mid
+    db.add.assert_called_once()
+    db.flush.assert_awaited_once()
+
+
+# ---------------------------------------------------------------------------
+# process_duel — a_wins
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_process_duel_a_wins_elo():
+    """Winner gets ELO increase, loser gets decrease for a_wins."""
+    uid = uuid.uuid4()
+    mid_a = uuid.uuid4()
+    mid_b = uuid.uuid4()
+
+    um_a = _make_user_movie(uid, mid_a, elo=1000, battles=5)
+    um_b = _make_user_movie(uid, mid_b, elo=1000, battles=5)
+
+    call_count = 0
+
+    async def fake_execute(stmt):
+        nonlocal call_count
+        call_count += 1
+        result = MagicMock()
+        # First two calls: get_or_create for um_a and um_b
+        if call_count == 1:
+            result.scalar_one_or_none.return_value = um_a
+            return result
+        elif call_count == 2:
+            result.scalar_one_or_none.return_value = um_b
+            return result
+        else:
+            # seen_unranked count query
+            result.scalar_one.return_value = 5
+            return result
+
+    db = AsyncMock()
+    db.execute = fake_execute
+
+    result = await process_duel(db, uid, mid_a, mid_b, "a_wins", "discovery")
+
+    assert result.api_result.movie_a_elo_delta > 0, "Winner A should gain ELO"
+    assert result.api_result.movie_b_elo_delta < 0, "Loser B should lose ELO"
+    assert um_a.battles == 6
+    assert um_b.battles == 6
+    assert um_a.seen is True
+    assert um_b.seen is True
+
+
+# ---------------------------------------------------------------------------
+# process_duel — b_wins
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_process_duel_b_wins_elo():
+    """Winner gets ELO increase, loser gets decrease for b_wins."""
+    uid = uuid.uuid4()
+    mid_a = uuid.uuid4()
+    mid_b = uuid.uuid4()
+
+    um_a = _make_user_movie(uid, mid_a, elo=1000, battles=5)
+    um_b = _make_user_movie(uid, mid_b, elo=1000, battles=5)
+
+    call_count = 0
+
+    async def fake_execute(stmt):
+        nonlocal call_count
+        call_count += 1
+        result = MagicMock()
+        if call_count == 1:
+            result.scalar_one_or_none.return_value = um_a
+            return result
+        elif call_count == 2:
+            result.scalar_one_or_none.return_value = um_b
+            return result
+        else:
+            result.scalar_one.return_value = 5
+            return result
+
+    db = AsyncMock()
+    db.execute = fake_execute
+
+    result = await process_duel(db, uid, mid_a, mid_b, "b_wins", "discovery")
+
+    assert result.api_result.movie_b_elo_delta > 0, "Winner B should gain ELO"
+    assert result.api_result.movie_a_elo_delta < 0, "Loser A should lose ELO"
+    assert um_a.battles == 6
+    assert um_b.battles == 6
+
+
+# ---------------------------------------------------------------------------
+# Duel record creation
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_process_duel_creates_duel_record():
+    """A Duel ORM object is added to the session."""
+    uid = uuid.uuid4()
+    mid_a = uuid.uuid4()
+    mid_b = uuid.uuid4()
+
+    um_a = _make_user_movie(uid, mid_a, elo=1000, battles=3)
+    um_b = _make_user_movie(uid, mid_b, elo=1000, battles=3)
+
+    call_count = 0
+
+    async def fake_execute(stmt):
+        nonlocal call_count
+        call_count += 1
+        result = MagicMock()
+        if call_count == 1:
+            result.scalar_one_or_none.return_value = um_a
+            return result
+        elif call_count == 2:
+            result.scalar_one_or_none.return_value = um_b
+            return result
+        else:
+            result.scalar_one.return_value = 5
+            return result
+
+    db = AsyncMock()
+    db.execute = fake_execute
+
+    await process_duel(db, uid, mid_a, mid_b, "a_wins", "ranked")
+
+    # db.add is called for the Duel record
+    assert db.add.called
+    # Find the Duel object among add calls
+    from backend.db_models import Duel
+
+    duel_adds = [
+        call.args[0]
+        for call in db.add.call_args_list
+        if isinstance(call.args[0], Duel)
+    ]
+    assert len(duel_adds) == 1
+    duel = duel_adds[0]
+    assert duel.user_id == uid
+    assert duel.winner_movie_id == mid_a
+    assert duel.loser_movie_id == mid_b
+    assert duel.mode == "ranked"
+
+
+# ---------------------------------------------------------------------------
+# next_action = "swipe" when seen_unranked < 3
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_next_action_swipe_when_few_seen_unranked():
+    """next_action should be 'swipe' when seen_unranked count < 3."""
+    uid = uuid.uuid4()
+    mid_a = uuid.uuid4()
+    mid_b = uuid.uuid4()
+
+    um_a = _make_user_movie(uid, mid_a, elo=1000, battles=2)
+    um_b = _make_user_movie(uid, mid_b, elo=1000, battles=2)
+
+    call_count = 0
+
+    async def fake_execute(stmt):
+        nonlocal call_count
+        call_count += 1
+        result = MagicMock()
+        if call_count == 1:
+            result.scalar_one_or_none.return_value = um_a
+            return result
+        elif call_count == 2:
+            result.scalar_one_or_none.return_value = um_b
+            return result
+        else:
+            # Return seen_unranked count of 2 (< 3)
+            result.scalar_one.return_value = 2
+            return result
+
+    db = AsyncMock()
+    db.execute = fake_execute
+
+    result = await process_duel(db, uid, mid_a, mid_b, "a_wins", "discovery")
+    assert result.api_result.next_action == "swipe"
+
+
+@pytest.mark.asyncio
+async def test_next_action_duel_when_enough_seen_unranked():
+    """next_action should be 'duel' when seen_unranked count >= 3."""
+    uid = uuid.uuid4()
+    mid_a = uuid.uuid4()
+    mid_b = uuid.uuid4()
+
+    um_a = _make_user_movie(uid, mid_a, elo=1000, battles=2)
+    um_b = _make_user_movie(uid, mid_b, elo=1000, battles=2)
+
+    call_count = 0
+
+    async def fake_execute(stmt):
+        nonlocal call_count
+        call_count += 1
+        result = MagicMock()
+        if call_count == 1:
+            result.scalar_one_or_none.return_value = um_a
+            return result
+        elif call_count == 2:
+            result.scalar_one_or_none.return_value = um_b
+            return result
+        else:
+            result.scalar_one.return_value = 10
+            return result
+
+    db = AsyncMock()
+    db.execute = fake_execute
+
+    result = await process_duel(db, uid, mid_a, mid_b, "a_wins", "discovery")
+    assert result.api_result.next_action == "duel"
+
+
+# ---------------------------------------------------------------------------
+# Seeded ELO fallback
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_process_duel_uses_seeded_elo_when_no_elo():
+    """When elo is None, initial ELO should come from seeded_elo."""
+    uid = uuid.uuid4()
+    mid_a = uuid.uuid4()
+    mid_b = uuid.uuid4()
+
+    um_a = _make_user_movie(uid, mid_a, elo=None, seeded_elo=1200, battles=0)
+    um_b = _make_user_movie(uid, mid_b, elo=None, seeded_elo=800, battles=0)
+
+    call_count = 0
+
+    async def fake_execute(stmt):
+        nonlocal call_count
+        call_count += 1
+        result = MagicMock()
+        if call_count == 1:
+            result.scalar_one_or_none.return_value = um_a
+            return result
+        elif call_count == 2:
+            result.scalar_one_or_none.return_value = um_b
+            return result
+        else:
+            result.scalar_one.return_value = 5
+            return result
+
+    db = AsyncMock()
+    db.execute = fake_execute
+
+    result = await process_duel(db, uid, mid_a, mid_b, "a_wins", "discovery")
+
+    # A (1200) beats B (800) — A should gain less since heavily favored
+    assert result.api_result.movie_a_elo_delta > 0
+    assert result.api_result.movie_b_elo_delta < 0
+    # ELO values should be based on seeded_elo, not default 1000
+    assert result.new_elo_a > 1200
+    assert result.new_elo_b < 800


### PR DESCRIPTION
## Summary
- Extract duel business logic (ELO computation, user_movie mutations, duel record creation) from `backend/routers/duels.py` into `backend/services/duel.py`
- Eliminate duplicated logic between the inline handler and `_persist_duel_background` — the background persist function is removed entirely
- DB writes now happen on the request session (committed by FastAPI's `get_db` dependency), removing the separate background-task session
- Trakt sync remains as a fire-and-forget background task in the router

## Test plan
- [x] 8 new unit tests in `backend/tests/test_duel_service.py` covering:
  - get_or_create_user_movie (existing and new)
  - a_wins / b_wins ELO deltas (winner gains, loser loses)
  - Duel record creation with correct fields
  - next_action returns "swipe" when seen_unranked < 3
  - next_action returns "duel" when seen_unranked >= 3
  - Seeded ELO fallback when elo is None
- [x] All 55 existing tests pass
- [x] Frontend vite build succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)