### PR TITLE
fix: ensure all displayed movies have posters

### DIFF
--- a/backend/routers/suggestions.py
+++ b/backend/routers/suggestions.py
@@ -13,7 +13,7 @@ from sqlalchemy.orm import joinedload
 
 from backend.config import get_settings
 from backend.db import get_db
-from backend.db_models import Suggestion, User, UserMovie
+from backend.db_models import Movie, Suggestion, User, UserMovie
 from backend.routers.auth import get_current_user
 from backend.schemas import MovieSchema, SuggestionSchema, SuggestionsResponse
 from backend.services.suggest import generate_suggestions, has_enough_ranked
@@ -55,9 +55,11 @@ async def _get_active_suggestions(
     stmt = (
         select(Suggestion)
         .options(joinedload(Suggestion.movie))
+        .join(Suggestion.movie)
         .where(
             Suggestion.user_id == user_id,
             Suggestion.dismissed_at.is_(None),
+            Movie.poster_url.isnot(None),
         )
         .order_by(Suggestion.generated_at.desc())
     )

--- a/backend/services/expand.py
+++ b/backend/services/expand.py
@@ -16,7 +16,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from backend.config import get_settings
 from backend.db import async_session_factory
 from backend.db_models import Movie, PoolExpansion, User, UserMovie
-from backend.services.tmdb import fetch_similar_films
+from backend.services.tmdb import backfill_posters, fetch_similar_films
 from backend.services.trakt import TraktClient
 
 logger = logging.getLogger(__name__)
@@ -87,6 +87,11 @@ async def _expand_pool_inner(user_id: uuid.UUID) -> int:
             total_added += added
 
         await db.commit()
+
+    # Backfill poster URLs for newly added films (fresh session so commit is independent)
+    if total_added > 0:
+        async with async_session_factory() as poster_db:
+            await backfill_posters(poster_db)
 
     logger.info(
         "Pool expansion complete for user %s: %d films added", user_id, total_added

--- a/backend/services/suggest.py
+++ b/backend/services/suggest.py
@@ -91,17 +91,16 @@ async def _get_candidates(
     stmt = (
         select(UserMovie)
         .options(joinedload(UserMovie.movie))
+        .join(UserMovie.movie)
         .where(
             UserMovie.user_id == user_id,
             UserMovie.seen.is_(None),
+            Movie.poster_url.isnot(None),
         )
         .order_by(
-            # Prefer films with posters
-            Movie.poster_url.isnot(None).desc(),
-            # Then by community rating
+            # By community rating
             Movie.community_rating.desc().nulls_last(),
         )
-        .join(UserMovie.movie)
         .limit(CANDIDATE_LIMIT)
     )
     result = await db.execute(stmt)


### PR DESCRIPTION
## Summary
- Trigger `backfill_posters` after pool expansion completes, so newly added films get poster URLs from TMDB immediately
- Change suggestion candidate query to **require** `poster_url IS NOT NULL` instead of just preferring movies with posters
- Filter active suggestions to exclude movies whose poster hasn't been backfilled yet

## Test plan
- [ ] Expand pool for a user, verify new movies get poster URLs backfilled
- [ ] Generate suggestions, verify all returned movies have poster_url set
- [ ] Verify existing suggestions with missing posters are filtered from the response

🤖 Generated with [Claude Code](https://claude.com/claude-code)