### PR TITLE
feat: add Trakt personalized recommendations to pool sources

### DIFF
--- a/backend/services/expand.py
+++ b/backend/services/expand.py
@@ -65,21 +65,28 @@ async def _expand_pool_inner(user_id: uuid.UUID) -> int:
             (row.source, row.source_key) for row in result.all()
         }
 
-        # Source A: TMDB similar films from top-ranked movies
+        # Source A: Trakt personalized recommendations (highest quality)
+        if total_added < TARGET_ADDED:
+            added = await _expand_from_recommendations(
+                db, user_id, user, settings, recent_keys, now
+            )
+            total_added += added
+
+        # Source B: TMDB similar films from top-ranked movies
         if total_added < TARGET_ADDED:
             added = await _expand_from_similar(
                 db, user_id, settings, recent_keys, now
             )
             total_added += added
 
-        # Source B: Trakt anticipated
+        # Source C: Trakt anticipated
         if total_added < TARGET_ADDED and ("anticipated", None) not in recent_keys:
             added = await _expand_from_anticipated(
                 db, user_id, user, settings, recent_keys, now
             )
             total_added += added
 
-        # Source C: Deeper popular pages
+        # Source D: Deeper popular pages
         if total_added < TARGET_ADDED:
             added = await _expand_from_popular_pages(
                 db, user_id, user, settings, recent_keys, now
@@ -92,6 +99,45 @@ async def _expand_pool_inner(user_id: uuid.UUID) -> int:
         "Pool expansion complete for user %s: %d films added", user_id, total_added
     )
     return total_added
+
+
+async def _expand_from_recommendations(
+    db: AsyncSession,
+    user_id: uuid.UUID,
+    user: User,
+    settings,
+    recent_keys: set[tuple[str, str | None]],
+    now: datetime,
+) -> int:
+    """Source A: Trakt personalized recommendations."""
+    if ("trakt_recommendations", "default") in recent_keys:
+        return 0
+
+    client = TraktClient(
+        client_id=settings.TRAKT_CLIENT_ID,
+        access_token=user.trakt_access_token,
+    )
+    try:
+        recs = await client.get_recommendations(limit=100)
+    except Exception:
+        logger.exception("Failed to fetch Trakt recommendations")
+        return 0
+
+    added = 0
+    for movie in recs:
+        ok = await _upsert_film_from_trakt(db, user_id, movie, now)
+        if ok:
+            added += 1
+
+    db.add(PoolExpansion(
+        user_id=user_id,
+        source="trakt_recommendations",
+        source_key="default",
+        films_added=added,
+        ran_at=now,
+    ))
+    await db.flush()
+    return added
 
 
 async def _expand_from_similar(

--- a/backend/services/pool.py
+++ b/backend/services/pool.py
@@ -50,6 +50,11 @@ async def populate_movie_pool(user: User, db: AsyncSession) -> None:
         logger.exception("Failed to fetch trending movies")
         trending = []
     try:
+        recommended = await client.get_recommendations(limit=100)
+    except Exception:
+        logger.exception("Failed to fetch recommendations")
+        recommended = []
+    try:
         watched = await client.get_user_watched(user.trakt_user_id)
     except Exception:
         logger.exception("Failed to fetch watch history for %s", user.trakt_user_id)
@@ -70,7 +75,7 @@ async def populate_movie_pool(user: User, db: AsyncSession) -> None:
     movie_pool: dict[int, dict] = {}
     seen_trakt_ids: set[int] = set()
 
-    for movie in popular + trending:
+    for movie in popular + trending + recommended:
         trakt_id = movie["ids"]["trakt"]
         if trakt_id not in movie_pool:
             movie_pool[trakt_id] = movie

--- a/backend/services/trakt.py
+++ b/backend/services/trakt.py
@@ -138,6 +138,16 @@ class TraktClient:
             )
             resp.raise_for_status()
 
+    async def get_recommendations(self, limit: int = 100) -> list[dict]:
+        """Get personalized movie recommendations for the authenticated user."""
+        async with self._client() as client:
+            resp = await client.get(
+                "/recommendations/movies",
+                params={"limit": limit, "extended": "full", "ignore_collected": "true"},
+            )
+            resp.raise_for_status()
+            return resp.json()
+
     async def add_to_watchlist(self, trakt_id: int) -> None:
         """Add a movie to the user's Trakt watchlist."""
         async with self._client() as client:


### PR DESCRIPTION
## Summary
- Added `get_recommendations()` method to `TraktClient` using `/recommendations/movies` endpoint (authenticated, personalized)
- Integrated recommendations into initial pool import (`pool.py`) alongside popular/trending — films added with `seen=None`
- Added `_expand_from_recommendations` as the first expansion source in `expand.py` (before TMDB similar) since personalized recs are highest quality
- All three sources respect existing patterns: try/except guards, cooldown tracking via `PoolExpansion`, and standard upsert logic

## Test plan
- [ ] Verify authenticated Trakt user gets recommendation-sourced films in their pool after login
- [ ] Verify expansion runs recommendations before TMDB similar
- [ ] Verify cooldown prevents re-fetching recommendations within 7 days
- [ ] Verify graceful fallback when recommendations endpoint fails (e.g., no auth token)

🤖 Generated with [Claude Code](https://claude.com/claude-code)