### PR TITLE
feat: tournament name as AI theme hint

### DIFF
--- a/backend/routers/tournaments.py
+++ b/backend/routers/tournaments.py
@@ -291,6 +291,7 @@ async def create_tournament(
             candidates=candidates,
             bracket_size=body.bracket_size,
             filter_context=filter_context,
+            theme_hint=body.name.strip() if body.name else "",
         )
 
         # Validate returned film_ids are all in candidate list
@@ -312,6 +313,7 @@ async def create_tournament(
         ai_name = llm_result["name"]
         ai_tagline = llm_result.get("tagline")
         ai_theme_description = llm_result.get("theme_description")
+        llm_result["_theme_hint"] = body.name.strip() if body.name else ""
         ai_llm_response = llm_result
     else:
         seeded_films = user_movies[: body.bracket_size]
@@ -515,10 +517,13 @@ async def regenerate_tournament(
     if tournament.filter_type and tournament.filter_value:
         filter_context = f"{tournament.filter_type}: {tournament.filter_value}"
 
+    # Use original name as theme hint for regeneration
+    original_hint = tournament.llm_response.get("_theme_hint", "") if tournament.llm_response else ""
     llm_result = await curate_tournament(
         candidates=candidates,
         bracket_size=tournament.bracket_size,
         filter_context=filter_context,
+        theme_hint=original_hint,
     )
 
     # Validate returned film_ids

--- a/backend/services/curator.py
+++ b/backend/services/curator.py
@@ -29,7 +29,7 @@ Return ONLY valid JSON with no markdown formatting:
 USER_PROMPT_TEMPLATE = """\
 Bracket size: {bracket_size}
 {filter_context}
-
+{theme_hint}
 Candidate films:
 {candidates_text}
 """
@@ -39,6 +39,7 @@ async def curate_tournament(
     candidates: list[dict],
     bracket_size: int,
     filter_context: str = "",
+    theme_hint: str = "",
 ) -> dict:
     """Call LLM to select films and generate a theme.
 
@@ -68,6 +69,7 @@ async def curate_tournament(
     user_prompt = USER_PROMPT_TEMPLATE.format(
         bracket_size=bracket_size,
         filter_context=f"Active filter: {filter_context}" if filter_context else "No filter applied",
+        theme_hint=f"User's theme request: \"{theme_hint}\" — prioritize films matching this theme/franchise/keyword.\n" if theme_hint else "",
         candidates_text=candidates_text,
     )
 


### PR DESCRIPTION
## Summary
- User's name input passed to LLM as `theme_hint` parameter
- Prompt includes: "User's theme request: 'Marvel' — prioritize films matching this theme/franchise/keyword"
- Hint stored in `llm_response._theme_hint` so regeneration preserves it

## Test plan
- [ ] Create AI tournament with name "Marvel" — should select MCU films
- [ ] Create AI tournament with name "Nolan" — should select Christopher Nolan films
- [ ] Regenerate preserves the original theme hint

🤖 Generated with [Claude Code](https://claude.com/claude-code)