### PR TITLE
fix: tournament connection pool exhaustion

### DIFF
--- a/backend/routers/tournaments.py
+++ b/backend/routers/tournaments.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import uuid
 from typing import Optional
 
-from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException
+from fastapi import APIRouter, Depends, HTTPException
 from pydantic import BaseModel
 from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -26,7 +26,6 @@ from backend.services.tournament import (
     create_tournament_bracket,
     generate_seeded_bracket,
     get_filtered_ranked_films,
-    record_match_elo,
     record_match_winner,
     validate_match,
     _num_rounds,
@@ -447,11 +446,10 @@ async def submit_match_result_endpoint(
     tournament_id: uuid.UUID,
     match_id: uuid.UUID,
     body: MatchResult,
-    background_tasks: BackgroundTasks,
     current_user: User = Depends(get_current_user),
     db: AsyncSession = Depends(get_db),
 ):
-    """Submit a tournament match result. ELO updates happen in background."""
+    """Submit a tournament match result."""
     uid = current_user.id
     tournament = await _load_tournament(tournament_id, uid, db)
     winner_id = uuid.UUID(body.winner_movie_id)
@@ -461,8 +459,10 @@ async def submit_match_result_endpoint(
     except ValueError as e:
         raise HTTPException(status_code=400, detail=str(e))
 
-    await record_match_winner(db, tournament_id, tournament.bracket_size, match_id, winner_id)
-    background_tasks.add_task(record_match_elo, uid, match_id, winner_id, loser_id)
+    await record_match_winner(
+        db, tournament_id, tournament.bracket_size,
+        match_id, winner_id, loser_id, uid,
+    )
 
     tournament = await _load_tournament(tournament_id, uid, db)
     return _tournament_schema(tournament)

--- a/backend/services/tournament.py
+++ b/backend/services/tournament.py
@@ -227,15 +227,20 @@ async def record_match_winner(
     bracket_size: int,
     match_id: uuid.UUID,
     winner_id: uuid.UUID,
+    loser_id: uuid.UUID,
+    user_id: uuid.UUID,
 ) -> None:
-    """Fast path: set winner, propagate to next round, detect champion.
+    """Record match result: set winner, propagate, ELO update, duel record.
 
-    Only bracket-structural DB writes — no ELO, no duel records.
+    All on the caller's session — no background tasks, no connection pool issues.
+    Frontend does optimistic updates so the user doesn't wait.
     """
     now = datetime.now(timezone.utc)
 
-    match_stmt = select(TournamentMatch).where(TournamentMatch.id == match_id)
-    match_obj = (await db.execute(match_stmt)).scalar_one()
+    # Mark winner + propagate
+    match_obj = (await db.execute(
+        select(TournamentMatch).where(TournamentMatch.id == match_id)
+    )).scalar_one()
     match_obj.winner_movie_id = winner_id
     match_obj.played_at = now
 
@@ -264,58 +269,39 @@ async def record_match_winner(
         t.status = "completed"
         t.completed_at = now
 
+    # ELO update + duel record (same session, 2 extra queries)
+    um_w = (await db.execute(
+        select(UserMovie).where(UserMovie.user_id == user_id, UserMovie.movie_id == winner_id)
+    )).scalar_one()
+    um_l = (await db.execute(
+        select(UserMovie).where(UserMovie.user_id == user_id, UserMovie.movie_id == loser_id)
+    )).scalar_one()
+
+    w_elo = um_w.elo if um_w.elo is not None else get_initial_elo(um_w.seeded_elo)
+    l_elo = um_l.elo if um_l.elo is not None else get_initial_elo(um_l.seeded_elo)
+    new_w, new_l = update_elo(w_elo, l_elo, um_w.battles, um_l.battles)
+
+    um_w.elo = new_w
+    um_l.elo = new_l
+    um_w.battles += 1
+    um_l.battles += 1
+    um_w.last_dueled_at = now
+    um_l.last_dueled_at = now
+    um_w.updated_at = now
+    um_l.updated_at = now
+
+    duel = Duel(
+        user_id=user_id,
+        winner_movie_id=winner_id,
+        loser_movie_id=loser_id,
+        winner_elo_before=w_elo,
+        loser_elo_before=l_elo,
+        winner_elo_after=new_w,
+        loser_elo_after=new_l,
+        mode="tournament",
+    )
+    db.add(duel)
     await db.flush()
 
-
-async def record_match_elo(
-    user_id: uuid.UUID,
-    match_id: uuid.UUID,
-    winner_id: uuid.UUID,
-    loser_id: uuid.UUID,
-) -> None:
-    """Background: ELO update + duel record creation. Owns its own DB session."""
-    from backend.db import async_session_factory
-
-    try:
-        async with async_session_factory() as db:
-            um_w = (await db.execute(
-                select(UserMovie).where(UserMovie.user_id == user_id, UserMovie.movie_id == winner_id)
-            )).scalar_one()
-            um_l = (await db.execute(
-                select(UserMovie).where(UserMovie.user_id == user_id, UserMovie.movie_id == loser_id)
-            )).scalar_one()
-
-            w_elo = um_w.elo if um_w.elo is not None else get_initial_elo(um_w.seeded_elo)
-            l_elo = um_l.elo if um_l.elo is not None else get_initial_elo(um_l.seeded_elo)
-            new_w, new_l = update_elo(w_elo, l_elo, um_w.battles, um_l.battles)
-
-            now = datetime.now(timezone.utc)
-            um_w.elo = new_w
-            um_l.elo = new_l
-            um_w.battles += 1
-            um_l.battles += 1
-            um_w.last_dueled_at = now
-            um_l.last_dueled_at = now
-            um_w.updated_at = now
-            um_l.updated_at = now
-
-            duel = Duel(
-                user_id=user_id,
-                winner_movie_id=winner_id,
-                loser_movie_id=loser_id,
-                winner_elo_before=w_elo,
-                loser_elo_before=l_elo,
-                winner_elo_after=new_w,
-                loser_elo_after=new_l,
-                mode="tournament",
-            )
-            db.add(duel)
-
-            match_obj = (await db.execute(
-                select(TournamentMatch).where(TournamentMatch.id == match_id)
-            )).scalar_one()
-            match_obj.duel_id = duel.id
-
-            await db.commit()
-    except Exception:
-        logger.exception("Background ELO update failed for match %s", match_id)
+    match_obj.duel_id = duel.id
+    await db.flush()


### PR DESCRIPTION
## Summary
- Background ELO tasks each opened their own DB session
- Rapid match submissions (machine-gunning through bracket) exhausted QueuePool (5+10=15 connections)
- Fix: all work on the request session. No background tasks for tournament matches.
- Frontend optimistic updates mean user experience is still instant

🤖 Generated with [Claude Code](https://claude.com/claude-code)