### PR TITLE
fix: swipe shows random films, not same top-rated ones

### DIFF
--- a/backend/routers/swipe.py
+++ b/backend/routers/swipe.py
@@ -76,9 +76,9 @@ async def get_swipe_cards(
     )
 
     if median_elo is None:
-        # No ranked films yet — prioritize popular/trending (high community_rating)
+        # No ranked films yet — pick randomly from rated films
         stmt = base.where(Movie.community_rating.isnot(None)).order_by(
-            Movie.community_rating.desc(), func.random()
+            func.random()
         ).limit(10)
         result = await db.execute(stmt)
         rows = result.all()


### PR DESCRIPTION
## Summary
- Removed deterministic `community_rating DESC` ordering from swipe card selection for new users (no ranked films yet)
- Changed to pure `func.random()` so each swipe session shows a different random selection from the unknown pool
- Previously, users without ELO history always saw the same highest-rated films every session

## Test plan
- [ ] New user opens swipe view — should see different films each session
- [ ] Existing user with rankings still gets band-weighted selection (unchanged)
- [ ] Backfill logic still works when fewer than 10 rated films available

🤖 Generated with [Claude Code](https://claude.com/claude-code)