### PR TITLE
fix: require 10+ seen films before dueling — better new user experience

### DIFF
--- a/backend/routers/swipe.py
+++ b/backend/routers/swipe.py
@@ -200,7 +200,7 @@ async def submit_swipe_results(
     )
     total_seen = (await db.execute(total_seen_stmt)).scalar() or 0
 
-    next_action = "duel" if total_seen >= 2 else "swipe"
+    next_action = "duel" if (total_seen >= 10 and seen_unranked >= 3) else "swipe"
 
     # Check if pool needs expansion
     unknown_stmt = (

--- a/backend/services/duel.py
+++ b/backend/services/duel.py
@@ -159,7 +159,15 @@ async def process_duel(
     )
     seen_unranked_result = await db.execute(seen_unranked_stmt)
     seen_unranked = seen_unranked_result.scalar_one()
-    next_action = "swipe" if seen_unranked < 3 else "duel"
+
+    total_seen_stmt = select(func.count()).where(
+        UserMovie.user_id == user_id,
+        UserMovie.seen.is_(True),
+    )
+    total_seen_result = await db.execute(total_seen_stmt)
+    total_seen = total_seen_result.scalar_one()
+
+    next_action = "swipe" if (seen_unranked < 3 or total_seen < 10) else "duel"
 
     return ProcessDuelResult(
         api_result=DuelResult(


### PR DESCRIPTION
## Summary
- **Duel endpoint** (`backend/services/duel.py`): Added `total_seen < 10` check alongside existing `seen_unranked < 3` — users now need both 10+ total seen films AND 3+ unranked films before being routed to duel
- **Swipe endpoint** (`backend/routers/swipe.py`): Updated threshold from `total_seen >= 2` to `total_seen >= 10 and seen_unranked >= 3` for consistent behavior
- Previously with only 2 seen films a user would be sent to duel, causing repetitive matchups against a tiny pool

## Test plan
- [ ] New user with <10 seen films should always get `next_action: "swipe"` from both `/api/swipe/results` and `/api/duels`
- [ ] User with 10+ seen films and 3+ unranked should get `next_action: "duel"`
- [ ] Frontend auto-continue loop in `Swipe.jsx` keeps loading cards when backend returns `next_action: "swipe"`

🤖 Generated with [Claude Code](https://claude.com/claude-code)