### PR TITLE
fix: swipe 'load more' resets card state properly

### DIFF
--- a/frontend/src/pages/Swipe.jsx
+++ b/frontend/src/pages/Swipe.jsx
@@ -20,9 +20,14 @@ export default function Swipe() {
     setCurrentIndex(0);
     setResults([]);
     setSummary(null);
+    setCardKey(0);
     try {
       const data = await fetchSwipeCards();
-      setCards(data || []);
+      if (!data || data.length === 0) {
+        setCards([]);
+      } else {
+        setCards(data);
+      }
     } catch (err) {
       setError(err.message);
       setCards([]);


### PR DESCRIPTION
## Summary
- Reset cardKey when loading new cards (ensures SwipeCard re-mounts)
- Explicit empty array handling for API response

🤖 Generated with [Claude Code](https://claude.com/claude-code)