### PR TITLE
security: fix CORS, add security headers, sanitize LLM prompts

### DIFF
--- a/backend/config.py
+++ b/backend/config.py
@@ -27,6 +27,9 @@ class Settings(BaseSettings):
     LLM_BASE_URL: str = "https://router.requesty.ai/v1"
     LLM_MODEL: str = "google/gemini-3.1-flash-lite-preview"
 
+    # CORS
+    CORS_ORIGINS: str = "http://localhost:5173,http://localhost:3000"
+
     # Sentry
     SENTRY_DSN: str = ""
 

--- a/backend/main.py
+++ b/backend/main.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from pathlib import Path
 
 import sentry_sdk
-from fastapi import FastAPI
+from fastapi import FastAPI, Request
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import FileResponse
 from fastapi.staticfiles import StaticFiles
@@ -24,14 +24,24 @@ if settings.SENTRY_DSN:
 
 app = FastAPI(title="FilmDuel", version="0.1.0")
 
-# CORS — allow the Vite dev server in development
+# CORS — origins configurable via CORS_ORIGINS env var
 app.add_middleware(
     CORSMiddleware,
-    allow_origins=["http://localhost:5173", "http://localhost:3000"],
+    allow_origins=settings.CORS_ORIGINS.split(","),
     allow_credentials=True,
-    allow_methods=["*"],
+    allow_methods=["GET", "POST", "DELETE"],
     allow_headers=["*"],
 )
+
+
+@app.middleware("http")
+async def add_security_headers(request: Request, call_next):
+    response = await call_next(request)
+    response.headers["X-Content-Type-Options"] = "nosniff"
+    response.headers["X-Frame-Options"] = "DENY"
+    response.headers["Referrer-Policy"] = "strict-origin-when-cross-origin"
+    return response
+
 
 # Register API routers
 app.include_router(auth.router)

--- a/backend/schemas.py
+++ b/backend/schemas.py
@@ -6,7 +6,7 @@ from datetime import datetime
 from enum import Enum
 from typing import Literal, Optional
 
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 
 class UserResponse(BaseModel):
@@ -115,7 +115,7 @@ class StatsResponse(BaseModel):
 
 
 class TournamentCreate(BaseModel):
-    name: str
+    name: str = Field(default="", max_length=100)
     filter_type: Optional[str] = None
     filter_value: Optional[str] = None
     bracket_size: Literal[8, 16, 32, 64]

--- a/backend/services/curator.py
+++ b/backend/services/curator.py
@@ -11,6 +11,13 @@ from backend.services.llm import chat_completion, parse_json_response
 
 logger = logging.getLogger(__name__)
 
+
+def _sanitize_theme_hint(hint: str) -> str:
+    """Strip potential prompt injection from user theme hints."""
+    hint = hint[:100]  # max length
+    hint = re.sub(r'[{}\[\]<>]', '', hint)  # remove structural chars
+    return hint.strip()
+
 SYSTEM_PROMPT = """\
 You are a film curator for a movie ranking app. Given a list of candidate films \
 (with titles, years, genres, and user ELO ratings), select exactly {bracket_size} \
@@ -69,7 +76,7 @@ async def curate_tournament(
     user_prompt = USER_PROMPT_TEMPLATE.format(
         bracket_size=bracket_size,
         filter_context=f"Active filter: {filter_context}" if filter_context else "No filter applied",
-        theme_hint=f"User's theme request: \"{theme_hint}\" — prioritize films matching this theme/franchise/keyword.\n" if theme_hint else "",
+        theme_hint=f'User theme (use as inspiration): "{_sanitize_theme_hint(theme_hint)}"' if theme_hint else "",
         candidates_text=candidates_text,
     )
 


### PR DESCRIPTION
## Summary
- **CORS**: Make origins configurable via `CORS_ORIGINS` env var (defaults to localhost for dev). Restrict `allow_methods` to `GET, POST, DELETE` instead of wildcard.
- **Security headers**: Add middleware setting `X-Content-Type-Options: nosniff`, `X-Frame-Options: DENY`, and `Referrer-Policy: strict-origin-when-cross-origin` on all responses.
- **Prompt injection**: Sanitize user-provided tournament theme hints (length cap at 100 chars, strip structural characters `{}[]<>`) before passing to LLM. Add `max_length=100` validation on `TournamentCreate.name`.

## Deployment note
Set `CORS_ORIGINS=https://filmduel.interstellarai.net` in Railway env vars before deploying.

## Test plan
- [ ] Verify dev CORS still works (localhost origins are the default)
- [ ] Check security headers appear in response (`curl -I`)
- [ ] Confirm SSE/streaming responses still work with the security headers middleware
- [ ] Test tournament creation with long names and special characters

🤖 Generated with [Claude Code](https://claude.com/claude-code)