### PR TITLE
security: add rate limiting to all API endpoints

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -11,7 +11,11 @@ from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import FileResponse, JSONResponse
 from fastapi.staticfiles import StaticFiles
 
+from slowapi import _rate_limit_exceeded_handler
+from slowapi.errors import RateLimitExceeded
+
 from backend.config import get_settings
+from backend.rate_limit import limiter
 from backend.routers import auth, movies, duels, rankings, suggestions, swipe, tournaments, feedback
 
 logger = logging.getLogger(__name__)
@@ -26,6 +30,10 @@ if settings.SENTRY_DSN:
     )
 
 app = FastAPI(title="FilmDuel", version="0.1.0")
+
+# Rate limiting
+app.state.limiter = limiter
+app.add_exception_handler(RateLimitExceeded, _rate_limit_exceeded_handler)
 
 # CORS — origins configurable via CORS_ORIGINS env var
 app.add_middleware(

--- a/backend/rate_limit.py
+++ b/backend/rate_limit.py
@@ -1,0 +1,6 @@
+"""Rate limiting configuration using slowapi."""
+
+from slowapi import Limiter
+from slowapi.util import get_remote_address
+
+limiter = Limiter(key_func=get_remote_address)

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -10,4 +10,5 @@ greenlet>=3.0.0
 PyJWT>=2.8.0
 python-multipart>=0.0.6
 sentry-sdk[fastapi]>=2.0.0
+slowapi>=0.1.9
 litellm>=1.40.0

--- a/backend/routers/auth.py
+++ b/backend/routers/auth.py
@@ -12,6 +12,8 @@ from urllib.parse import urlencode
 
 import jwt
 from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException, Request, Response
+
+from backend.rate_limit import limiter
 from fastapi.responses import RedirectResponse
 from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -165,7 +167,8 @@ OAUTH_STATE_COOKIE = "filmduel_oauth_state"
 
 
 @router.get("/auth/login")
-async def login(settings: Settings = Depends(get_settings)):
+@limiter.limit("10/minute")
+async def login(request: Request, settings: Settings = Depends(get_settings)):
     """Redirect the user to Trakt's OAuth authorization page."""
     state = secrets.token_urlsafe(32)
     params = urlencode(
@@ -189,6 +192,7 @@ async def login(settings: Settings = Depends(get_settings)):
 
 
 @router.get("/auth/callback")
+@limiter.limit("10/minute")
 async def callback(
     code: str,
     request: Request,
@@ -258,7 +262,8 @@ async def callback(
 
 
 @router.post("/auth/logout")
-async def logout():
+@limiter.limit("10/minute")
+async def logout(request: Request):
     """Clear the session cookie."""
     response = Response(status_code=204)
     response.delete_cookie(COOKIE_NAME)

--- a/backend/routers/duels.py
+++ b/backend/routers/duels.py
@@ -5,8 +5,10 @@ from __future__ import annotations
 import logging
 import uuid
 
-from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException
+from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException, Request
 from sqlalchemy import select
+
+from backend.rate_limit import limiter
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from backend.db import async_session_factory, get_db
@@ -56,7 +58,9 @@ async def _sync_ratings_background(
 
 
 @router.post("", response_model=DuelResult)
+@limiter.limit("60/minute")
 async def submit_duel(
+    request: Request,
     body: DuelSubmit,
     background_tasks: BackgroundTasks,
     current_user: User = Depends(get_current_user),

--- a/backend/routers/suggestions.py
+++ b/backend/routers/suggestions.py
@@ -6,13 +6,14 @@ import logging
 import uuid
 from datetime import datetime, timedelta, timezone
 
-from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException, Query
+from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException, Query, Request
 from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import joinedload
 
 from backend.config import get_settings
 from backend.db import get_db
+from backend.rate_limit import limiter
 from backend.db_models import Movie, Suggestion, User, UserMovie
 from backend.routers.auth import get_current_user
 from backend.schemas import MediaType, MovieSchema, SuggestionSchema, SuggestionsResponse
@@ -95,7 +96,9 @@ async def _create_suggestions(
 
 
 @router.get("", response_model=SuggestionsResponse)
+@limiter.limit("10/minute")
 async def get_suggestions(
+    request: Request,
     current_user: User = Depends(get_current_user),
     db: AsyncSession = Depends(get_db),
     media_type: MediaType = Query(default="movie"),
@@ -141,7 +144,9 @@ async def get_suggestions(
 
 
 @router.post("/regenerate", response_model=SuggestionsResponse)
+@limiter.limit("3/minute")
 async def regenerate_suggestions(
+    request: Request,
     current_user: User = Depends(get_current_user),
     db: AsyncSession = Depends(get_db),
     media_type: MediaType = Query(default="movie"),

--- a/backend/routers/swipe.py
+++ b/backend/routers/swipe.py
@@ -6,12 +6,13 @@ import logging
 import uuid
 from datetime import datetime, timezone
 
-from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException, Query
+from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException, Query, Request
 from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from backend.db import get_db
 from backend.db_models import Movie, SwipeResult, User, UserMovie
+from backend.rate_limit import limiter
 from backend.routers.auth import get_current_user
 from backend.schemas import MediaType, SwipeCardSchema, SwipeResponse, SwipeSubmit
 from backend.services.expand import expand_pool
@@ -45,7 +46,9 @@ def _community_rating_range(band_index: int) -> tuple[float, float]:
 
 
 @router.get("/cards", response_model=list[SwipeCardSchema])
+@limiter.limit("20/minute")
 async def get_swipe_cards(
+    request: Request,
     current_user: User = Depends(get_current_user),
     db: AsyncSession = Depends(get_db),
     media_type: MediaType = Query(default="movie"),
@@ -158,7 +161,9 @@ async def get_swipe_cards(
 
 
 @router.post("/results", response_model=SwipeResponse)
+@limiter.limit("20/minute")
 async def submit_swipe_results(
+    request: Request,
     body: SwipeSubmit,
     background_tasks: BackgroundTasks,
     current_user: User = Depends(get_current_user),

--- a/backend/routers/tournaments.py
+++ b/backend/routers/tournaments.py
@@ -5,8 +5,10 @@ from __future__ import annotations
 import uuid
 from typing import Optional
 
-from fastapi import APIRouter, Depends, HTTPException, Query
+from fastapi import APIRouter, Depends, HTTPException, Query, Request
 from pydantic import BaseModel
+
+from backend.rate_limit import limiter
 from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import joinedload
@@ -159,7 +161,9 @@ async def get_pool_count(
 
 
 @router.post("", response_model=TournamentSchema)
+@limiter.limit("10/minute")
 async def create_tournament(
+    request: Request,
     body: TournamentCreate,
     current_user: User = Depends(get_current_user),
     db: AsyncSession = Depends(get_db),
@@ -231,8 +235,10 @@ async def create_tournament(
 
 
 @router.post("/{tournament_id}/regenerate", response_model=TournamentSchema)
+@limiter.limit("10/minute")
 async def regenerate_tournament(
     tournament_id: uuid.UUID,
+    request: Request,
     current_user: User = Depends(get_current_user),
     db: AsyncSession = Depends(get_db),
 ):


### PR DESCRIPTION
## Summary
- Adds `slowapi` library for IP-based rate limiting on all sensitive API endpoints
- Auth endpoints (login, callback, logout): 10 req/min
- Duel submission: 60 req/min
- Swipe cards/results: 20 req/min
- Suggestions get: 10 req/min, regenerate: 3 req/min
- Tournament create/regenerate: 10 req/min
- GET-only endpoints (health, SPA fallback, rankings, genres, etc.) are not rate limited

## Test plan
- [ ] Verify app starts without import errors
- [ ] Confirm rate limit headers appear in API responses
- [ ] Test that exceeding limits returns 429 status

🤖 Generated with [Claude Code](https://claude.com/claude-code)