### PR TITLE
feat: add Trakt/IMDB links and Trakt rating to rankings

### DIFF
--- a/backend/routers/rankings.py
+++ b/backend/routers/rankings.py
@@ -13,6 +13,7 @@ from backend.db import get_db
 from backend.db_models import User, UserMovie
 from backend.schemas import MovieSchema, RankedMovie, RankingsResponse, StatsResponse
 from backend.routers.auth import get_current_user
+from backend.services.elo import elo_to_trakt_rating
 from backend.services.rankings import (
     export_rankings_csv,
     get_user_rankings,
@@ -39,6 +40,7 @@ def _build_ranked_movie(um: UserMovie, rank: int) -> RankedMovie:
         ),
         elo=um.elo,
         battles=um.battles,
+        trakt_rating=elo_to_trakt_rating(um.elo),
     )
 
 

--- a/backend/schemas.py
+++ b/backend/schemas.py
@@ -70,6 +70,7 @@ class RankedMovie(BaseModel):
     movie: MovieSchema
     elo: int = 1000
     battles: int = 0
+    trakt_rating: Optional[int] = None  # computed from ELO (1-10 scale)
 
 
 class RankingsResponse(BaseModel):

--- a/frontend/src/pages/Rankings.jsx
+++ b/frontend/src/pages/Rankings.jsx
@@ -151,6 +151,20 @@ export default function Rankings() {
                     </div>
                     <div className="flex flex-col">
                       <span className="text-[10px] font-label uppercase tracking-widest text-[#6B6760]">
+                        Rating
+                      </span>
+                      <span
+                        className={`font-headline font-bold ${
+                          isFirst
+                            ? "text-lg text-[#F5F0E8]"
+                            : "text-md text-[#F5F0E8]/60"
+                        }`}
+                      >
+                        {r.trakt_rating != null ? `${r.trakt_rating}/10` : "—"}
+                      </span>
+                    </div>
+                    <div className="flex flex-col">
+                      <span className="text-[10px] font-label uppercase tracking-widest text-[#6B6760]">
                         Battles
                       </span>
                       <span
@@ -163,6 +177,28 @@ export default function Rankings() {
                         {r.battles}
                       </span>
                     </div>
+                  </div>
+                  <div className="flex gap-3 mt-1">
+                    {r.movie.trakt_id && (
+                      <a
+                        href={`https://trakt.tv/search/trakt/${r.movie.trakt_id}?id_type=movie`}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="text-[10px] font-label uppercase tracking-widest text-[#F5F0E8]/30 hover:text-[#E8A020] transition-colors"
+                      >
+                        Trakt
+                      </a>
+                    )}
+                    {r.movie.imdb_id && (
+                      <a
+                        href={`https://www.imdb.com/title/${r.movie.imdb_id}/`}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="text-[10px] font-label uppercase tracking-widest text-[#F5F0E8]/30 hover:text-[#E8A020] transition-colors"
+                      >
+                        IMDB
+                      </a>
+                    )}
                   </div>
                 </div>
               </div>


### PR DESCRIPTION
## Summary
- Added `trakt_rating` field (1-10 scale, computed from ELO) to `RankedMovie` schema and populated it in the rankings router using existing `elo_to_trakt_rating` helper
- Rankings page now displays a "Rating" column (X/10) alongside ELO and Battles
- Each ranked movie row includes subtle Trakt and IMDB links that light up gold on hover

## Test plan
- [ ] Load rankings page and verify Rating column shows values 1-10
- [ ] Click Trakt link — opens correct Trakt search page for the movie
- [ ] Click IMDB link — opens correct IMDB title page
- [ ] Verify links only appear when trakt_id / imdb_id are present
- [ ] Check mobile layout still looks clean with the extra column

🤖 Generated with [Claude Code](https://claude.com/claude-code)