### PR TITLE
feat: manual Trakt re-sync button

### DIFF
--- a/backend/routers/auth.py
+++ b/backend/routers/auth.py
@@ -2,7 +2,10 @@
 
 from __future__ import annotations
 
+import collections
+import logging
 import secrets
+import time
 import uuid
 from datetime import datetime, timedelta, timezone
 from urllib.parse import urlencode
@@ -10,18 +13,25 @@ from urllib.parse import urlencode
 import jwt
 from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException, Request, Response
 from fastapi.responses import RedirectResponse
-from sqlalchemy import select
+from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from backend.config import Settings, get_settings
 from backend.db import async_session_factory, get_db
-from backend.db_models import User
+from backend.db_models import User, UserMovie
 from backend.schemas import UserResponse
 from backend.services.pool import populate_movie_pool
 from backend.services.tmdb import backfill_posters
 from backend.services.trakt import TraktClient
 
+logger = logging.getLogger(__name__)
+
 router = APIRouter(tags=["auth"])
+
+# ── Simple in-memory rate limiter for sync endpoint ──────────────────
+_sync_timestamps: dict[str, list[float]] = collections.defaultdict(list)
+SYNC_RATE_LIMIT = 3  # max calls
+SYNC_RATE_WINDOW = 3600  # per hour (seconds)
 
 COOKIE_NAME = "filmduel_session"
 JWT_ALGORITHM = "HS256"
@@ -248,3 +258,70 @@ async def me(user: User = Depends(get_current_user)):
         trakt_username=user.trakt_username,
         created_at=user.created_at,
     )
+
+
+@router.post("/api/sync")
+async def sync_trakt(
+    background_tasks: BackgroundTasks,
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+):
+    """Trigger a manual Trakt re-sync, bypassing the 1-hour cooldown.
+
+    Rate limited to 3 calls per hour per user.
+    """
+    user_key = str(current_user.id)
+    now = time.monotonic()
+
+    # Prune old timestamps outside the window
+    _sync_timestamps[user_key] = [
+        ts for ts in _sync_timestamps[user_key] if now - ts < SYNC_RATE_WINDOW
+    ]
+    if len(_sync_timestamps[user_key]) >= SYNC_RATE_LIMIT:
+        raise HTTPException(
+            status_code=429,
+            detail="Sync rate limit exceeded. Try again later.",
+        )
+    _sync_timestamps[user_key].append(now)
+
+    # Count movies before sync so we can report new additions
+    before_count_result = await db.execute(
+        select(func.count()).select_from(UserMovie).where(
+            UserMovie.user_id == current_user.id
+        )
+    )
+    before_count = before_count_result.scalar() or 0
+
+    # Ensure fresh Trakt token
+    current_user = await ensure_fresh_token(current_user, db)
+
+    # Force sync (bypass cooldown by resetting last_seen_at)
+    current_user.last_seen_at = datetime.now(timezone.utc) - timedelta(hours=2)
+    await db.flush()
+
+    await populate_movie_pool(current_user, db)
+    await db.commit()
+
+    # Count movies after sync
+    after_count_result = await db.execute(
+        select(func.count()).select_from(UserMovie).where(
+            UserMovie.user_id == current_user.id
+        )
+    )
+    after_count = after_count_result.scalar() or 0
+    new_movies = max(0, after_count - before_count)
+
+    # Backfill posters in background
+    background_tasks.add_task(_backfill_posters_background)
+
+    logger.info(
+        "Manual sync for %s: %d new movies (total: %d)",
+        current_user.trakt_username,
+        new_movies,
+        after_count,
+    )
+
+    return {
+        "new_movies": new_movies,
+        "total_movies": after_count,
+    }

--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -53,6 +53,8 @@ export function submitSwipeResults(results) {
 
 export function logout() { return request("/auth/logout", { method: "POST" }); }
 
+export function syncTrakt() { return request("/api/sync", { method: "POST" }); }
+
 // ── Tournaments ──────────────────────────────────────────────────────
 
 export function getTournaments() {

--- a/frontend/src/pages/Rankings.jsx
+++ b/frontend/src/pages/Rankings.jsx
@@ -1,5 +1,5 @@
 import { useState, useEffect } from "react";
-import { getRankings, fetchStats } from "../api";
+import { getRankings, fetchStats, syncTrakt } from "../api";
 
 const GENRE_FILTERS = ["All", "Drama", "Horror", "Sci-fi", "Thriller", "Comedy"];
 
@@ -9,6 +9,7 @@ export default function Rankings() {
   const [loading, setLoading] = useState(true);
   const [activeFilter, setActiveFilter] = useState("All");
   const [total, setTotal] = useState(0);
+  const [syncState, setSyncState] = useState("idle"); // idle | syncing | done | error
 
   useEffect(() => {
     async function load() {
@@ -45,9 +46,55 @@ export default function Rankings() {
     <div className="min-h-screen bg-[#0F0E0D] p-6 md:p-12 pb-32">
       {/* Header */}
       <header className="mb-12">
-        <h2 className="text-5xl md:text-7xl font-headline font-black uppercase tracking-tighter text-[#F5F0E8] mb-8 leading-none">
-          Your <span className="text-[#E8A020]">rankings</span>
-        </h2>
+        <div className="flex items-start justify-between mb-8 gap-4">
+          <h2 className="text-5xl md:text-7xl font-headline font-black uppercase tracking-tighter text-[#F5F0E8] leading-none">
+            Your <span className="text-[#E8A020]">rankings</span>
+          </h2>
+          <button
+            onClick={async () => {
+              if (syncState === "syncing") return;
+              setSyncState("syncing");
+              try {
+                const result = await syncTrakt();
+                setSyncState("done");
+                if (result?.new_movies > 0) {
+                  // Reload rankings to reflect new data
+                  const genre = activeFilter === "All" ? null : activeFilter;
+                  const [rankData, statsData] = await Promise.all([
+                    getRankings(50, 0, genre),
+                    fetchStats(),
+                  ]);
+                  setRankings(rankData.rankings);
+                  setTotal(rankData.total);
+                  setStats(statsData);
+                }
+                setTimeout(() => setSyncState("idle"), 3000);
+              } catch (err) {
+                console.error("Sync failed:", err);
+                setSyncState("error");
+                setTimeout(() => setSyncState("idle"), 3000);
+              }
+            }}
+            disabled={syncState === "syncing"}
+            className={`shrink-0 mt-2 px-4 py-2 font-label font-bold uppercase text-xs tracking-widest border transition-all ${
+              syncState === "syncing"
+                ? "border-[#E8A020]/30 text-[#E8A020]/50 cursor-wait"
+                : syncState === "done"
+                ? "border-green-500/50 text-green-400"
+                : syncState === "error"
+                ? "border-red-500/50 text-red-400"
+                : "border-[#F5F0E8]/10 text-[#F5F0E8]/60 hover:border-[#E8A020]/40 hover:text-[#E8A020]"
+            }`}
+          >
+            {syncState === "syncing"
+              ? "Syncing..."
+              : syncState === "done"
+              ? "Synced!"
+              : syncState === "error"
+              ? "Failed"
+              : "Sync Trakt"}
+          </button>
+        </div>
 
         {/* Filter Pills */}
         <div className="flex items-center gap-3 flex-wrap">


### PR DESCRIPTION
## Summary
- Adds `POST /api/sync` endpoint that triggers a full Trakt re-sync, bypassing the 1-hour cooldown
- Rate limited to 3 calls/hour per user (in-memory tracker)
- Ensures fresh Trakt OAuth token before syncing, returns count of new movies found
- Adds "Sync Trakt" button to Rankings page header with syncing/done/error visual states
- Auto-reloads rankings data when new movies are discovered

## Test plan
- [ ] Click "Sync Trakt" on Rankings page, verify it shows "Syncing..." then "Synced!"
- [ ] Verify new movies from Trakt appear after sync without re-login
- [ ] Click sync 4 times rapidly, verify 4th attempt returns 429
- [ ] Verify button resets to idle state after 3 seconds

🤖 Generated with [Claude Code](https://claude.com/claude-code)