### PR TITLE
refactor: extract business logic from routers, remove dead code

### DIFF
--- a/backend/config.py
+++ b/backend/config.py
@@ -33,10 +33,6 @@ class Settings(BaseSettings):
     # Sentry
     SENTRY_DSN: str = ""
 
-    # ELO defaults
-    ELO_K_FACTOR: int = 32
-    ELO_DEFAULT_RATING: int = 1000
-
     model_config = {"env_file": ".env", "env_file_encoding": "utf-8"}
 
 

--- a/backend/models.py
+++ b/backend/models.py
@@ -1,7 +1,0 @@
-"""Backward-compatibility shim — import from db_models and schemas instead.
-
-This file will be removed once all references are migrated.
-"""
-
-from backend.db_models import *  # noqa: F401, F403
-from backend.schemas import *  # noqa: F401, F403

--- a/backend/routers/movies.py
+++ b/backend/routers/movies.py
@@ -1,74 +1,20 @@
-"""Movie pair generation endpoint — duel pair selection with quality band matching."""
+"""Movie pair generation endpoint."""
 
 from __future__ import annotations
 
 import base64
-import random
 from typing import Optional
 
 from fastapi import APIRouter, Depends, HTTPException, Query
-from sqlalchemy import select, func
 from sqlalchemy.ext.asyncio import AsyncSession
-from sqlalchemy.orm import joinedload
 
 from backend.db import get_db
-from backend.db_models import Movie, User, UserMovie
+from backend.db_models import User, UserMovie
 from backend.schemas import MovieWithStateSchema, MoviePairResponse
 from backend.routers.auth import get_current_user
+from backend.services.pair_selection import select_pair
 
 router = APIRouter(prefix="/api/movies", tags=["movies"])
-
-# ---------------------------------------------------------------------------
-# Quality band helpers
-# ---------------------------------------------------------------------------
-
-BAND_ORDER = ["elite", "strong", "mid", "weak", "poor"]
-
-
-def elo_to_band(elo: int | None) -> str:
-    if elo is None:
-        return "mid"
-    if elo >= 1300:
-        return "elite"
-    if elo >= 1100:
-        return "strong"
-    if elo >= 900:
-        return "mid"
-    if elo >= 700:
-        return "weak"
-    return "poor"
-
-
-def community_rating_to_band(rating: float | None) -> str:
-    if rating is None:
-        return "mid"
-    if rating >= 80:
-        return "elite"
-    if rating >= 65:
-        return "strong"
-    if rating >= 45:
-        return "mid"
-    if rating >= 25:
-        return "weak"
-    return "poor"
-
-
-def bands_adjacent(band_a: str, band_b: str) -> bool:
-    ia = BAND_ORDER.index(band_a)
-    ib = BAND_ORDER.index(band_b)
-    return abs(ia - ib) <= 1
-
-
-def _film_band(um: UserMovie) -> str:
-    """Determine quality band for a UserMovie.
-
-    Ranked films (battles >= 1) use ELO; unranked use community_rating.
-    """
-    if um.battles >= 1:
-        return elo_to_band(um.elo)
-    return community_rating_to_band(
-        float(um.movie.community_rating) if um.movie.community_rating is not None else None
-    )
 
 
 # ---------------------------------------------------------------------------
@@ -133,7 +79,10 @@ async def get_movie_pair(
     if last_pair_token:
         last_pair_ids = _decode_pair_token(last_pair_token)
 
-    pair = await _select_pair(db, uid, last_pair_ids)
+    try:
+        pair = await select_pair(db, uid, last_pair_ids)
+    except ValueError as e:
+        raise HTTPException(status_code=404, detail=str(e))
 
     movie_a, movie_b = pair
     schema_a = _user_movie_to_schema(movie_a)
@@ -145,139 +94,3 @@ async def get_movie_pair(
         movie_b=schema_b,
         next_pair_token=token,
     )
-
-
-# ---------------------------------------------------------------------------
-# Pair selection
-# ---------------------------------------------------------------------------
-
-
-async def _select_pair(
-    db: AsyncSession,
-    uid,
-    last_pair_ids: set[str] | None,
-) -> tuple[UserMovie, UserMovie]:
-    """Select a duel pair from seen films with quality band matching.
-
-    1. Pick anchor (film A) weighted by settlement: 1/(battles+1).
-    2. Determine anchor's band.
-    3. Filter candidates to same band, then adjacent, then full pool.
-    4. For ranked-vs-ranked: 70% close matches, 30% wide matches.
-    """
-
-    # All seen films
-    seen_stmt = (
-        select(UserMovie)
-        .options(joinedload(UserMovie.movie))
-        .where(
-            UserMovie.user_id == uid,
-            UserMovie.seen.is_(True),
-        )
-    )
-    seen_result = await db.execute(seen_stmt)
-    seen_films = list(seen_result.unique().scalars().all())
-
-    if len(seen_films) < 2:
-        raise HTTPException(
-            status_code=404,
-            detail="Need more seen films to duel. Swipe to classify some movies first!",
-        )
-
-    # Split into anchors (ranked, battles >= 1) and full pool
-    anchor_pool = [f for f in seen_films if f.battles >= 1 and f.elo is not None]
-
-    # Bootstrap: no anchors yet — pick two seen films by settlement weight
-    if len(anchor_pool) == 0:
-        return _pick_bootstrap_pair(seen_films, last_pair_ids)
-
-    # Normal: anchor + challenger from band-filtered pool
-    for _ in range(5):
-        anchor = _weighted_sample(anchor_pool)
-        anchor_band = elo_to_band(anchor.elo)
-
-        # Build candidate pool excluding anchor
-        all_candidates = [f for f in seen_films if f.movie_id != anchor.movie_id]
-        if not all_candidates:
-            break
-
-        # Band filter: same band first, then adjacent, then full pool
-        candidates = _band_filtered_candidates(anchor_band, all_candidates)
-
-        # Match distance variation for ranked-vs-ranked
-        challenger = _pick_challenger(anchor, candidates)
-
-        # Anti-repeat
-        pair_ids = {str(anchor.movie_id), str(challenger.movie_id)}
-        if last_pair_ids is None or pair_ids != last_pair_ids:
-            return anchor, challenger
-
-    # Fallback after retries
-    return anchor, challenger  # type: ignore
-
-
-def _band_filtered_candidates(
-    anchor_band: str,
-    candidates: list[UserMovie],
-) -> list[UserMovie]:
-    """Filter candidates by quality band: same > adjacent > all."""
-    # Same band
-    same = [f for f in candidates if _film_band(f) == anchor_band]
-    if same:
-        return same
-
-    # Adjacent bands (±1 step)
-    adjacent = [f for f in candidates if bands_adjacent(anchor_band, _film_band(f))]
-    if adjacent:
-        return adjacent
-
-    # Full pool fallback
-    return candidates
-
-
-def _pick_challenger(anchor: UserMovie, candidates: list[UserMovie]) -> UserMovie:
-    """Pick challenger with match distance variation for ranked-vs-ranked pairs.
-
-    - 70%: prefer close matches (ELO diff < 150), sample from top 10
-    - 30%: prefer wide matches (ELO diff > 300)
-    Falls back to settlement-weighted sample if filters produce nothing.
-    """
-    # Separate ranked candidates (both anchor and candidate have battles >= 1)
-    ranked = [f for f in candidates if f.battles >= 1 and f.elo is not None]
-
-    if ranked and anchor.elo is not None:
-        roll = random.random()
-        if roll < 0.70:
-            # Close match: sort by abs ELO diff, take top 10
-            ranked_sorted = sorted(ranked, key=lambda f: abs(f.elo - anchor.elo))
-            close = [f for f in ranked_sorted[:10] if abs(f.elo - anchor.elo) < 150]
-            if close:
-                return _weighted_sample(close)
-            # If no close matches in top 10, use top 10 anyway
-            return _weighted_sample(ranked_sorted[:10])
-        else:
-            # Wide match: ELO diff > 300
-            wide = [f for f in ranked if abs(f.elo - anchor.elo) > 300]
-            if wide:
-                return _weighted_sample(wide)
-
-    # Default: settlement-weighted from full candidate pool
-    return _weighted_sample(candidates)
-
-
-def _pick_bootstrap_pair(
-    seen_films: list[UserMovie],
-    last_pair_ids: set[str] | None,
-) -> tuple[UserMovie, UserMovie]:
-    """Bootstrap: pick two seen films when no anchors exist."""
-    for _ in range(5):
-        a, b = random.sample(seen_films, 2)
-        pair_ids = {str(a.movie_id), str(b.movie_id)}
-        if last_pair_ids is None or pair_ids != last_pair_ids:
-            return a, b
-    return a, b  # type: ignore
-
-
-def _weighted_sample(films: list[UserMovie]) -> UserMovie:
-    """Sample one film weighted by settlement: 1/(battles+1)."""
-    weights = [1.0 / (f.battles + 1) for f in films]
-    return random.choices(films, weights=weights, k=1)[0]

--- a/backend/routers/tournaments.py
+++ b/backend/routers/tournaments.py
@@ -21,9 +21,9 @@ from backend.schemas import (
     TournamentMatchSchema,
     TournamentSchema,
 )
-from backend.services.curator import curate_tournament
 from backend.services.tournament import (
     create_tournament_bracket,
+    curate_and_select_films,
     generate_seeded_bracket,
     get_filtered_ranked_films,
     record_match_winner,
@@ -184,42 +184,16 @@ async def create_tournament(
     ai_llm_response = None
 
     if body.ai_curated:
-        candidate_pool = user_movies[: body.bracket_size * 3]
-        candidates = [
-            {
-                "id": str(um.movie_id),
-                "title": um.movie.title,
-                "year": um.movie.year,
-                "genres": um.movie.genres or [],
-                "elo": um.elo,
-                "battles": um.battles,
-            }
-            for um in candidate_pool
-        ]
-
-        filter_context = ""
-        if body.filter_type and body.filter_value:
-            filter_context = f"{body.filter_type}: {body.filter_value}"
-
-        llm_result = await curate_tournament(
-            candidates=candidates,
-            bracket_size=body.bracket_size,
-            filter_context=filter_context,
-            theme_hint=body.name.strip() if body.name else "",
-        )
-
-        candidate_ids = {str(um.movie_id) for um in candidate_pool}
-        invalid_ids = set(llm_result["film_ids"]) - candidate_ids
-        if invalid_ids:
-            raise HTTPException(
-                status_code=500,
-                detail=f"AI selected films not in candidate pool: {invalid_ids}",
+        try:
+            seeded_films, llm_result = await curate_and_select_films(
+                user_movies=user_movies,
+                bracket_size=body.bracket_size,
+                filter_type=body.filter_type,
+                filter_value=body.filter_value,
+                theme_hint=body.name.strip() if body.name else "",
             )
-
-        film_id_set = set(llm_result["film_ids"])
-        selected_ums = [um for um in candidate_pool if str(um.movie_id) in film_id_set]
-        selected_ums.sort(key=lambda um: um.elo or 0, reverse=True)
-        seeded_films = selected_ums
+        except ValueError as e:
+            raise HTTPException(status_code=500, detail=str(e))
 
         ai_name = llm_result["name"]
         ai_tagline = llm_result.get("tagline")
@@ -284,43 +258,17 @@ async def regenerate_tournament(
     except ValueError:
         raise HTTPException(status_code=400, detail="Invalid decade format")
 
-    candidate_pool = user_movies[: tournament.bracket_size * 3]
-    candidates = [
-        {
-            "id": str(um.movie_id),
-            "title": um.movie.title,
-            "year": um.movie.year,
-            "genres": um.movie.genres or [],
-            "elo": um.elo,
-            "battles": um.battles,
-        }
-        for um in candidate_pool
-    ]
-
-    filter_context = ""
-    if tournament.filter_type and tournament.filter_value:
-        filter_context = f"{tournament.filter_type}: {tournament.filter_value}"
-
-    # Use original name as theme hint for regeneration
     original_hint = tournament.llm_response.get("_theme_hint", "") if tournament.llm_response else ""
-    llm_result = await curate_tournament(
-        candidates=candidates,
-        bracket_size=tournament.bracket_size,
-        filter_context=filter_context,
-        theme_hint=original_hint,
-    )
-
-    candidate_ids = {str(um.movie_id) for um in candidate_pool}
-    invalid_ids = set(llm_result["film_ids"]) - candidate_ids
-    if invalid_ids:
-        raise HTTPException(
-            status_code=500,
-            detail=f"AI selected films not in candidate pool: {invalid_ids}",
+    try:
+        selected_ums, llm_result = await curate_and_select_films(
+            user_movies=user_movies,
+            bracket_size=tournament.bracket_size,
+            filter_type=tournament.filter_type,
+            filter_value=tournament.filter_value,
+            theme_hint=original_hint,
         )
-
-    film_id_set = set(llm_result["film_ids"])
-    selected_ums = [um for um in candidate_pool if str(um.movie_id) in film_id_set]
-    selected_ums.sort(key=lambda um: um.elo or 0, reverse=True)
+    except ValueError as e:
+        raise HTTPException(status_code=500, detail=str(e))
 
     # Delete existing matches
     from sqlalchemy import delete

--- a/backend/services/elo.py
+++ b/backend/services/elo.py
@@ -77,23 +77,3 @@ def get_initial_elo(seeded_elo: int | None) -> int:
     otherwise falls back to the default 1000.
     """
     return seeded_elo if seeded_elo is not None else DEFAULT_ELO
-
-
-def outcome_to_scores(outcome: str) -> tuple[float, float]:
-    """Convert a duel outcome string to (score_a, score_b).
-
-    Outcomes:
-        a_wins  -> (1.0, 0.0)
-        b_wins  -> (0.0, 1.0)
-        a_only  -> (1.0, 0.0)  A seen, B not
-        b_only  -> (0.0, 1.0)  B seen, A not
-        neither -> (0.0, 0.0)  Both unseen, no ELO change
-    """
-    mapping = {
-        "a_wins": (1.0, 0.0),
-        "b_wins": (0.0, 1.0),
-        "a_only": (1.0, 0.0),
-        "b_only": (0.0, 1.0),
-        "neither": (0.0, 0.0),
-    }
-    return mapping[outcome]

--- a/backend/services/expand.py
+++ b/backend/services/expand.py
@@ -16,6 +16,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from backend.config import get_settings
 from backend.db import async_session_factory
 from backend.db_models import Movie, PoolExpansion, User, UserMovie
+from backend.services.pool import build_movie_upsert
 from backend.services.tmdb import backfill_posters, fetch_similar_films
 from backend.services.trakt import TraktClient
 
@@ -314,35 +315,7 @@ async def _upsert_film_from_trakt(
     if not trakt_id:
         return False
 
-    trakt_rating = movie_data.get("rating", 0)
-    community_rating = round(trakt_rating * 10, 1) if trakt_rating else None
-
-    stmt = insert(Movie.__table__).values(
-        trakt_id=trakt_id,
-        imdb_id=ids.get("imdb"),
-        tmdb_id=ids.get("tmdb"),
-        title=movie_data.get("title", "Unknown"),
-        year=movie_data.get("year"),
-        genres=movie_data.get("genres"),
-        overview=movie_data.get("overview"),
-        runtime=movie_data.get("runtime"),
-        community_rating=community_rating,
-        cached_at=now,
-    ).on_conflict_do_update(
-        index_elements=["trakt_id"],
-        set_={
-            "imdb_id": ids.get("imdb"),
-            "tmdb_id": ids.get("tmdb"),
-            "title": movie_data.get("title", "Unknown"),
-            "year": movie_data.get("year"),
-            "genres": movie_data.get("genres"),
-            "overview": movie_data.get("overview"),
-            "runtime": movie_data.get("runtime"),
-            "community_rating": community_rating,
-            "cached_at": now,
-        },
-    )
-    await db.execute(stmt)
+    await db.execute(build_movie_upsert(movie_data, now))
     await db.flush()
 
     # Get movie UUID

--- a/backend/services/pair_selection.py
+++ b/backend/services/pair_selection.py
@@ -1,0 +1,198 @@
+"""Duel pair selection algorithm with quality band matching."""
+
+from __future__ import annotations
+
+import random
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import joinedload
+
+from backend.db_models import UserMovie
+
+# ---------------------------------------------------------------------------
+# Quality band helpers
+# ---------------------------------------------------------------------------
+
+BAND_ORDER = ["elite", "strong", "mid", "weak", "poor"]
+
+
+def elo_to_band(elo: int | None) -> str:
+    if elo is None:
+        return "mid"
+    if elo >= 1300:
+        return "elite"
+    if elo >= 1100:
+        return "strong"
+    if elo >= 900:
+        return "mid"
+    if elo >= 700:
+        return "weak"
+    return "poor"
+
+
+def community_rating_to_band(rating: float | None) -> str:
+    if rating is None:
+        return "mid"
+    if rating >= 80:
+        return "elite"
+    if rating >= 65:
+        return "strong"
+    if rating >= 45:
+        return "mid"
+    if rating >= 25:
+        return "weak"
+    return "poor"
+
+
+def bands_adjacent(band_a: str, band_b: str) -> bool:
+    ia = BAND_ORDER.index(band_a)
+    ib = BAND_ORDER.index(band_b)
+    return abs(ia - ib) <= 1
+
+
+def _film_band(um: UserMovie) -> str:
+    """Determine quality band for a UserMovie.
+
+    Ranked films (battles >= 1) use ELO; unranked use community_rating.
+    """
+    if um.battles >= 1:
+        return elo_to_band(um.elo)
+    return community_rating_to_band(
+        float(um.movie.community_rating) if um.movie.community_rating is not None else None
+    )
+
+
+# ---------------------------------------------------------------------------
+# Pair selection
+# ---------------------------------------------------------------------------
+
+
+async def select_pair(
+    db: AsyncSession,
+    uid,
+    last_pair_ids: set[str] | None,
+) -> tuple[UserMovie, UserMovie]:
+    """Select a duel pair from seen films with quality band matching.
+
+    1. Pick anchor (film A) weighted by settlement: 1/(battles+1).
+    2. Determine anchor's band.
+    3. Filter candidates to same band, then adjacent, then full pool.
+    4. For ranked-vs-ranked: 70% close matches, 30% wide matches.
+
+    Raises ValueError if fewer than 2 seen films exist.
+    """
+
+    # All seen films
+    seen_stmt = (
+        select(UserMovie)
+        .options(joinedload(UserMovie.movie))
+        .where(
+            UserMovie.user_id == uid,
+            UserMovie.seen.is_(True),
+        )
+    )
+    seen_result = await db.execute(seen_stmt)
+    seen_films = list(seen_result.unique().scalars().all())
+
+    if len(seen_films) < 2:
+        raise ValueError("Need more seen films to duel. Swipe to classify some movies first!")
+
+    # Split into anchors (ranked, battles >= 1) and full pool
+    anchor_pool = [f for f in seen_films if f.battles >= 1 and f.elo is not None]
+
+    # Bootstrap: no anchors yet — pick two seen films by settlement weight
+    if len(anchor_pool) == 0:
+        return _pick_bootstrap_pair(seen_films, last_pair_ids)
+
+    # Normal: anchor + challenger from band-filtered pool
+    for _ in range(5):
+        anchor = _weighted_sample(anchor_pool)
+        anchor_band = elo_to_band(anchor.elo)
+
+        # Build candidate pool excluding anchor
+        all_candidates = [f for f in seen_films if f.movie_id != anchor.movie_id]
+        if not all_candidates:
+            break
+
+        # Band filter: same band first, then adjacent, then full pool
+        candidates = _band_filtered_candidates(anchor_band, all_candidates)
+
+        # Match distance variation for ranked-vs-ranked
+        challenger = _pick_challenger(anchor, candidates)
+
+        # Anti-repeat
+        pair_ids = {str(anchor.movie_id), str(challenger.movie_id)}
+        if last_pair_ids is None or pair_ids != last_pair_ids:
+            return anchor, challenger
+
+    # Fallback after retries
+    return anchor, challenger  # type: ignore
+
+
+def _band_filtered_candidates(
+    anchor_band: str,
+    candidates: list[UserMovie],
+) -> list[UserMovie]:
+    """Filter candidates by quality band: same > adjacent > all."""
+    # Same band
+    same = [f for f in candidates if _film_band(f) == anchor_band]
+    if same:
+        return same
+
+    # Adjacent bands (±1 step)
+    adjacent = [f for f in candidates if bands_adjacent(anchor_band, _film_band(f))]
+    if adjacent:
+        return adjacent
+
+    # Full pool fallback
+    return candidates
+
+
+def _pick_challenger(anchor: UserMovie, candidates: list[UserMovie]) -> UserMovie:
+    """Pick challenger with match distance variation for ranked-vs-ranked pairs.
+
+    - 70%: prefer close matches (ELO diff < 150), sample from top 10
+    - 30%: prefer wide matches (ELO diff > 300)
+    Falls back to settlement-weighted sample if filters produce nothing.
+    """
+    # Separate ranked candidates (both anchor and candidate have battles >= 1)
+    ranked = [f for f in candidates if f.battles >= 1 and f.elo is not None]
+
+    if ranked and anchor.elo is not None:
+        roll = random.random()
+        if roll < 0.70:
+            # Close match: sort by abs ELO diff, take top 10
+            ranked_sorted = sorted(ranked, key=lambda f: abs(f.elo - anchor.elo))
+            close = [f for f in ranked_sorted[:10] if abs(f.elo - anchor.elo) < 150]
+            if close:
+                return _weighted_sample(close)
+            # If no close matches in top 10, use top 10 anyway
+            return _weighted_sample(ranked_sorted[:10])
+        else:
+            # Wide match: ELO diff > 300
+            wide = [f for f in ranked if abs(f.elo - anchor.elo) > 300]
+            if wide:
+                return _weighted_sample(wide)
+
+    # Default: settlement-weighted from full candidate pool
+    return _weighted_sample(candidates)
+
+
+def _pick_bootstrap_pair(
+    seen_films: list[UserMovie],
+    last_pair_ids: set[str] | None,
+) -> tuple[UserMovie, UserMovie]:
+    """Bootstrap: pick two seen films when no anchors exist."""
+    for _ in range(5):
+        a, b = random.sample(seen_films, 2)
+        pair_ids = {str(a.movie_id), str(b.movie_id)}
+        if last_pair_ids is None or pair_ids != last_pair_ids:
+            return a, b
+    return a, b  # type: ignore
+
+
+def _weighted_sample(films: list[UserMovie]) -> UserMovie:
+    """Sample one film weighted by settlement: 1/(battles+1)."""
+    weights = [1.0 / (f.battles + 1) for f in films]
+    return random.choices(films, weights=weights, k=1)[0]

--- a/backend/services/pool.py
+++ b/backend/services/pool.py
@@ -19,6 +19,30 @@ logger = logging.getLogger(__name__)
 SYNC_COOLDOWN = timedelta(hours=1)
 
 
+def build_movie_upsert(movie_data: dict, now: datetime):
+    """Build a PostgreSQL INSERT...ON CONFLICT upsert for a Trakt movie dict."""
+    ids = movie_data.get("ids", {})
+    trakt_rating = movie_data.get("rating", 0)
+    community_rating = round(trakt_rating * 10, 1) if trakt_rating else None
+    values = dict(
+        trakt_id=ids["trakt"],
+        imdb_id=ids.get("imdb"),
+        tmdb_id=ids.get("tmdb"),
+        title=movie_data.get("title", "Unknown"),
+        year=movie_data.get("year"),
+        genres=movie_data.get("genres"),
+        overview=movie_data.get("overview"),
+        runtime=movie_data.get("runtime"),
+        community_rating=community_rating,
+        cached_at=now,
+    )
+    stmt = insert(Movie.__table__).values(**values).on_conflict_do_update(
+        index_elements=["trakt_id"],
+        set_={k: v for k, v in values.items() if k != "trakt_id"},
+    )
+    return stmt
+
+
 async def populate_movie_pool(user: User, db: AsyncSession) -> None:
     """Fetch movies from Trakt and populate the user's movie pool.
 
@@ -92,34 +116,7 @@ async def populate_movie_pool(user: User, db: AsyncSession) -> None:
 
     # Upsert movies into the movies table
     for movie_data in movie_pool.values():
-        ids = movie_data.get("ids", {})
-        trakt_rating = movie_data.get("rating", 0)
-        community_rating = round(trakt_rating * 10, 1) if trakt_rating else None
-        stmt = insert(Movie.__table__).values(
-            trakt_id=ids["trakt"],
-            imdb_id=ids.get("imdb"),
-            tmdb_id=ids.get("tmdb"),
-            title=movie_data.get("title", "Unknown"),
-            year=movie_data.get("year"),
-            genres=movie_data.get("genres"),
-            overview=movie_data.get("overview"),
-            runtime=movie_data.get("runtime"),
-            community_rating=community_rating,
-            cached_at=now,
-        ).on_conflict_do_update(
-            index_elements=["trakt_id"],
-            set_={
-                "imdb_id": ids.get("imdb"),
-                "tmdb_id": ids.get("tmdb"),
-                "title": movie_data.get("title", "Unknown"),
-                "year": movie_data.get("year"),
-                "genres": movie_data.get("genres"),
-                "overview": movie_data.get("overview"),
-                "runtime": movie_data.get("runtime"),
-                "community_rating": community_rating,
-                "cached_at": now,
-            },
-        )
+        stmt = build_movie_upsert(movie_data, now)
         await db.execute(stmt)
 
     await db.flush()

--- a/backend/services/tournament.py
+++ b/backend/services/tournament.py
@@ -12,9 +12,61 @@ from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from backend.db_models import Duel, Tournament, TournamentMatch, UserMovie
+from backend.services.curator import curate_tournament
 from backend.services.elo import get_initial_elo, update_elo
 
 logger = logging.getLogger(__name__)
+
+
+# ── AI curation orchestration ────────────────────────────────────────
+
+
+async def curate_and_select_films(
+    user_movies: list[UserMovie],
+    bracket_size: int,
+    filter_type: Optional[str],
+    filter_value: Optional[str],
+    theme_hint: str,
+) -> tuple[list[UserMovie], dict]:
+    """Build candidates, call LLM curation, validate and return selected films.
+
+    Returns (selected_user_movies_sorted_by_elo, llm_result_dict).
+    Raises ValueError if LLM returns IDs not in the candidate pool.
+    """
+    candidate_pool = user_movies[:bracket_size * 3]
+    candidates = [
+        {
+            "id": str(um.movie_id),
+            "title": um.movie.title,
+            "year": um.movie.year,
+            "genres": um.movie.genres or [],
+            "elo": um.elo,
+            "battles": um.battles,
+        }
+        for um in candidate_pool
+    ]
+
+    filter_context = ""
+    if filter_type and filter_value:
+        filter_context = f"{filter_type}: {filter_value}"
+
+    llm_result = await curate_tournament(
+        candidates=candidates,
+        bracket_size=bracket_size,
+        filter_context=filter_context,
+        theme_hint=theme_hint,
+    )
+
+    candidate_ids = {str(um.movie_id) for um in candidate_pool}
+    invalid_ids = set(llm_result["film_ids"]) - candidate_ids
+    if invalid_ids:
+        raise ValueError(f"AI selected films not in candidate pool: {invalid_ids}")
+
+    film_id_set = set(llm_result["film_ids"])
+    selected_ums = [um for um in candidate_pool if str(um.movie_id) in film_id_set]
+    selected_ums.sort(key=lambda um: um.elo or 0, reverse=True)
+
+    return selected_ums, llm_result
 
 
 # ── Pure helpers ──────────────────────────────────────────────────────

--- a/backend/tests/test_elo.py
+++ b/backend/tests/test_elo.py
@@ -5,7 +5,6 @@ from backend.services.elo import (
     expected_score,
     get_initial_elo,
     k_factor,
-    outcome_to_scores,
     trakt_rating_to_seeded_elo,
     update_elo,
 )
@@ -130,14 +129,4 @@ def test_get_initial_elo_with_seed():
 
 def test_get_initial_elo_without_seed():
     assert get_initial_elo(None) == 1000
-
-
-# --- outcome_to_scores ---
-
-
-def test_outcome_to_scores():
-    assert outcome_to_scores("a_wins") == (1.0, 0.0)
-    assert outcome_to_scores("b_wins") == (0.0, 1.0)
-    assert outcome_to_scores("neither") == (0.0, 0.0)
-
 

--- a/backend/tests/test_pair_selection.py
+++ b/backend/tests/test_pair_selection.py
@@ -7,7 +7,7 @@ from unittest.mock import MagicMock
 
 import pytest
 
-from backend.routers.movies import (
+from backend.services.pair_selection import (
     BAND_ORDER,
     _band_filtered_candidates,
     _film_band,


### PR DESCRIPTION
## Architectural Sweep

**Focus**: Extract business logic from router files into the service layer, consolidate duplicated code, and remove dead code — improving testability and maintainability without changing behavior.

### Assessment

The primary architectural concern was business logic leaking into router files — particularly `routers/tournaments.py` (491 lines) and `routers/movies.py` (284 lines), where complex orchestration and algorithmic logic lived alongside HTTP handling. A secondary concern was duplicated movie upsert patterns across `services/pool.py` and `services/expand.py` that were maintained separately. Three pieces of dead code (`models.py` shim, unused ELO config, unused `outcome_to_scores` function) added confusion without serving any purpose.

### Changes

- **`routers/tournaments.py` → `services/tournament.py`**: Extracted `curate_and_select_films()` — the AI curation orchestration that was duplicated verbatim between `create_tournament` and `regenerate_tournament` endpoints (~40 lines each). Router now calls the service and catches `ValueError`.
- **`routers/movies.py` → new `services/pair_selection.py`**: Moved 135 lines of pair selection algorithm (quality band matching, anchor/challenger selection, bootstrap logic) out of the router into a dedicated service module. Enables unit testing without HTTP/DB fixtures.
- **`services/pool.py` + `services/expand.py`**: Consolidated duplicated Trakt movie upsert logic into a shared `build_movie_upsert()` function in `pool.py`. Both call sites now use the single implementation — adding a column only requires one change.
- **Deleted `backend/models.py`**: Re-export shim with no remaining importers (migration was already complete).
- **Removed `ELO_K_FACTOR`/`ELO_DEFAULT_RATING` from `config.py`**: These were never read by `services/elo.py`, which uses its own constants.
- **Removed `outcome_to_scores()` from `services/elo.py`**: Unused function and its tests.

### Validation

- [x] Each change preserves existing behavior
- [x] No file appears in more than one change — all changes are independently revertible
- [x] Test imports updated (`test_pair_selection.py` now imports from `services/pair_selection`)
- [x] Net reduction: -61 lines (304 added, 365 removed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)