### PR TITLE
feat: add in-app issue reporting with screenshot annotation

### DIFF
--- a/backend/db_models.py
+++ b/backend/db_models.py
@@ -287,6 +287,25 @@ class Suggestion(Base):
     movie: Mapped[Movie] = relationship()
 
 
+class FeedbackReport(Base):
+    __tablename__ = "feedback_reports"
+
+    id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), primary_key=True, default=uuid.uuid4
+    )
+    user_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("users.id", ondelete="CASCADE")
+    )
+    title: Mapped[str] = mapped_column(Text, nullable=False)
+    description: Mapped[str] = mapped_column(Text, nullable=False)
+    screenshot_data: Mapped[Optional[str]] = mapped_column(Text, nullable=True)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), default=lambda: datetime.now(timezone.utc)
+    )
+
+    user: Mapped[User] = relationship()
+
+
 class SwipeResult(Base):
     __tablename__ = "swipe_results"
     __table_args__ = (Index("ix_swipe_results_user_id", "user_id"),)

--- a/backend/main.py
+++ b/backend/main.py
@@ -11,7 +11,7 @@ from fastapi.responses import FileResponse
 from fastapi.staticfiles import StaticFiles
 
 from backend.config import get_settings
-from backend.routers import auth, movies, duels, rankings, suggestions, swipe, tournaments
+from backend.routers import auth, movies, duels, rankings, suggestions, swipe, tournaments, feedback
 
 settings = get_settings()
 
@@ -51,6 +51,7 @@ app.include_router(rankings.router)
 app.include_router(suggestions.router)
 app.include_router(swipe.router)
 app.include_router(tournaments.router)
+app.include_router(feedback.router)
 
 
 @app.get("/health")

--- a/backend/migrations/versions/011_add_feedback_reports.py
+++ b/backend/migrations/versions/011_add_feedback_reports.py
@@ -1,0 +1,34 @@
+"""Add feedback_reports table
+
+Revision ID: 011
+Revises: 010
+Create Date: 2026-04-13
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects.postgresql import UUID
+
+revision: str = "011"
+down_revision: Union[str, None] = "010"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "feedback_reports",
+        sa.Column("id", UUID(as_uuid=True), nullable=False),
+        sa.Column("user_id", UUID(as_uuid=True), nullable=False),
+        sa.Column("title", sa.Text(), nullable=False),
+        sa.Column("description", sa.Text(), nullable=False),
+        sa.Column("screenshot_data", sa.Text(), nullable=True),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+        sa.ForeignKeyConstraint(["user_id"], ["users.id"], ondelete="CASCADE"),
+        sa.PrimaryKeyConstraint("id"),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("feedback_reports")

--- a/backend/routers/feedback.py
+++ b/backend/routers/feedback.py
@@ -1,0 +1,55 @@
+"""Feedback report routes."""
+
+from __future__ import annotations
+
+import base64
+import logging
+
+from fastapi import APIRouter, Depends, File, Form, UploadFile
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from backend.db import get_db
+from backend.db_models import FeedbackReport, User
+from backend.routers.auth import get_current_user
+from backend.schemas import FeedbackReportResponse
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/api/feedback", tags=["feedback"])
+
+MAX_SCREENSHOT_BYTES = 5 * 1024 * 1024  # 5 MB
+
+
+@router.post("", response_model=FeedbackReportResponse, status_code=201)
+async def submit_feedback(
+    title: str = Form(...),
+    description: str = Form(...),
+    screenshot: UploadFile = File(None),
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+):
+    screenshot_data = None
+    if screenshot and screenshot.filename:
+        raw = await screenshot.read(MAX_SCREENSHOT_BYTES + 1)
+        if len(raw) > MAX_SCREENSHOT_BYTES:
+            from fastapi import HTTPException
+
+            raise HTTPException(
+                status_code=413, detail="Screenshot too large (max 5 MB)"
+            )
+        screenshot_data = "data:image/jpeg;base64," + base64.b64encode(raw).decode()
+
+    report = FeedbackReport(
+        user_id=current_user.id,
+        title=title.strip(),
+        description=description.strip(),
+        screenshot_data=screenshot_data,
+    )
+    db.add(report)
+    await db.flush()
+
+    logger.info(
+        "feedback_submitted user_id=%s title=%r", current_user.id, title[:50]
+    )
+
+    return FeedbackReportResponse(id=str(report.id), created_at=report.created_at)

--- a/backend/routers/feedback.py
+++ b/backend/routers/feedback.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import base64
 import logging
 
-from fastapi import APIRouter, Depends, File, Form, UploadFile
+from fastapi import APIRouter, Depends, File, Form, HTTPException, UploadFile
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from backend.db import get_db
@@ -18,6 +18,7 @@ logger = logging.getLogger(__name__)
 router = APIRouter(prefix="/api/feedback", tags=["feedback"])
 
 MAX_SCREENSHOT_BYTES = 5 * 1024 * 1024  # 5 MB
+ALLOWED_IMAGE_TYPES = {"image/jpeg", "image/png", "image/gif", "image/webp"}
 
 
 @router.post("", response_model=FeedbackReportResponse, status_code=201)
@@ -30,14 +31,18 @@ async def submit_feedback(
 ):
     screenshot_data = None
     if screenshot and screenshot.filename:
+        if screenshot.content_type not in ALLOWED_IMAGE_TYPES:
+            raise HTTPException(
+                status_code=415,
+                detail="Screenshot must be an image (JPEG, PNG, GIF, or WebP)",
+            )
         raw = await screenshot.read(MAX_SCREENSHOT_BYTES + 1)
         if len(raw) > MAX_SCREENSHOT_BYTES:
-            from fastapi import HTTPException
-
             raise HTTPException(
                 status_code=413, detail="Screenshot too large (max 5 MB)"
             )
-        screenshot_data = "data:image/jpeg;base64," + base64.b64encode(raw).decode()
+        mime = screenshot.content_type
+        screenshot_data = f"data:{mime};base64," + base64.b64encode(raw).decode()
 
     report = FeedbackReport(
         user_id=current_user.id,

--- a/backend/schemas.py
+++ b/backend/schemas.py
@@ -183,3 +183,11 @@ class SuggestionSchema(BaseModel):
 class SuggestionsResponse(BaseModel):
     suggestions: list[SuggestionSchema]
     status: str = "ready"  # "ready" | "generating" | "not_enough_films"
+
+
+# ── Feedback schemas ──────────────────────────────────────────────
+
+
+class FeedbackReportResponse(BaseModel):
+    id: str
+    created_at: datetime

--- a/backend/tests/test_feedback.py
+++ b/backend/tests/test_feedback.py
@@ -1,0 +1,126 @@
+"""Tests for POST /api/feedback endpoint."""
+from __future__ import annotations
+
+import io
+import uuid
+from datetime import datetime, timezone
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+from backend.db import get_db
+from backend.main import app
+from backend.routers.auth import get_current_user
+
+
+def _make_user():
+    user = MagicMock()
+    user.id = uuid.uuid4()
+    return user
+
+
+def _make_db():
+    db = AsyncMock()
+    db.add = MagicMock()
+    db.flush = AsyncMock()
+    return db
+
+
+def _make_feedback_report(**kwargs):
+    """Return a FeedbackReport-like object with valid id and created_at."""
+    report = MagicMock()
+    report.id = kwargs.get("id", uuid.uuid4())
+    report.created_at = kwargs.get("created_at", datetime.now(timezone.utc))
+    report.title = kwargs.get("title", "")
+    report.description = kwargs.get("description", "")
+    report.screenshot_data = kwargs.get("screenshot_data", None)
+    return report
+
+
+@pytest.fixture
+def client():
+    return TestClient(app)
+
+
+class TestSubmitFeedback:
+    def _post(self, client, title="Bug", description="Details", screenshot=None, content_type="image/jpeg", user=None, db=None):
+        user = user or _make_user()
+        db = db or _make_db()
+
+        # Capture what arguments FeedbackReport was called with
+        created_reports = []
+
+        def make_report(**kwargs):
+            report = _make_feedback_report(**kwargs)
+            created_reports.append(report)
+            return report
+
+        app.dependency_overrides[get_current_user] = lambda: user
+        app.dependency_overrides[get_db] = lambda: db
+
+        try:
+            data = {"title": title, "description": description}
+            files = {}
+            if screenshot is not None:
+                files = {"screenshot": ("screenshot.jpg", screenshot, content_type)}
+
+            with patch("backend.routers.feedback.FeedbackReport", side_effect=make_report):
+                response = client.post("/api/feedback", data=data, files=files)
+
+            response._created_reports = created_reports
+            response._db = db
+            return response
+        finally:
+            app.dependency_overrides.clear()
+
+    def test_returns_201_without_screenshot(self, client):
+        response = self._post(client)
+        assert response.status_code == 201
+
+    def test_response_contains_id_and_created_at(self, client):
+        response = self._post(client)
+        body = response.json()
+        assert "id" in body
+        assert "created_at" in body
+
+    def test_strips_whitespace_from_title_and_description(self, client):
+        response = self._post(client, title="  Bug  ", description="  Details  ")
+        report = response._created_reports[0]
+        assert report.title == "Bug"
+        assert report.description == "Details"
+
+    def test_accepts_screenshot_within_size_limit(self, client):
+        small_image = b"FAKEJPEG" * 100  # well under 5 MB
+        response = self._post(client, screenshot=io.BytesIO(small_image))
+        assert response.status_code == 201
+
+    def test_rejects_screenshot_over_5mb(self, client):
+        oversized = b"x" * (5 * 1024 * 1024 + 1)
+        response = self._post(client, screenshot=io.BytesIO(oversized))
+        assert response.status_code == 413
+        assert "5 MB" in response.json()["detail"]
+
+    def test_rejects_non_image_content_type(self, client):
+        response = self._post(
+            client,
+            screenshot=io.BytesIO(b"not-an-image"),
+            content_type="application/pdf",
+        )
+        assert response.status_code == 415
+        assert "image" in response.json()["detail"].lower()
+
+    def test_screenshot_stored_as_base64_data_url_with_correct_mime(self, client):
+        response = self._post(client, screenshot=io.BytesIO(b"FAKEJPEGDATA"), content_type="image/jpeg")
+        report = response._created_reports[0]
+        assert report.screenshot_data.startswith("data:image/jpeg;base64,")
+
+    def test_png_screenshot_stored_with_png_mime(self, client):
+        response = self._post(client, screenshot=io.BytesIO(b"FAKEPNGDATA"), content_type="image/png")
+        report = response._created_reports[0]
+        assert report.screenshot_data.startswith("data:image/png;base64,")
+
+    def test_no_screenshot_stores_none(self, client):
+        response = self._post(client)
+        report = response._created_reports[0]
+        assert report.screenshot_data is None

--- a/backend/tests/test_schemas.py
+++ b/backend/tests/test_schemas.py
@@ -260,3 +260,15 @@ class TestResponseModels:
         pr = MoviePairResponse(movie_a=ma, movie_b=mb)
         assert pr.next_pair_token is None
         assert pr.movie_a.title == "A"
+
+    def test_feedback_report_response(self):
+        from datetime import datetime, timezone
+
+        from backend.schemas import FeedbackReportResponse
+
+        r = FeedbackReportResponse(
+            id="550e8400-e29b-41d4-a716-446655440000",
+            created_at=datetime.now(timezone.utc),
+        )
+        assert r.id == "550e8400-e29b-41d4-a716-446655440000"
+        assert isinstance(r.created_at, datetime)

--- a/frontend/src/__tests__/Nav.test.jsx
+++ b/frontend/src/__tests__/Nav.test.jsx
@@ -56,14 +56,16 @@ describe("Nav", () => {
     expect(swipeLink.className).not.toContain("bg-[#E8A020]");
   });
 
-  it("Report Issue link points to GitHub issues", () => {
+  it("Report Issue is a button (not a link)", () => {
     renderNav();
-    const reportLink = screen.getByText("Report Issue").closest("a");
-    expect(reportLink).toHaveAttribute(
-      "href",
-      expect.stringContaining("github.com/alexsiri7/filmduel/issues")
-    );
-    expect(reportLink).toHaveAttribute("target", "_blank");
+    const reportButton = screen.getByText("Report Issue");
+    expect(reportButton.tagName).toBe("BUTTON");
+  });
+
+  it("clicking Report Issue opens feedback modal", () => {
+    renderNav();
+    fireEvent.click(screen.getByText("Report Issue"));
+    expect(screen.getByPlaceholderText("Brief title of the issue")).toBeInTheDocument();
   });
 
   it("renders Sign Out button", () => {

--- a/frontend/src/__tests__/ReportIssueModal.test.jsx
+++ b/frontend/src/__tests__/ReportIssueModal.test.jsx
@@ -1,0 +1,92 @@
+import { render, screen, fireEvent, waitFor, act } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import ReportIssueModal from "../components/ReportIssueModal";
+
+vi.mock("../api", () => ({
+  submitFeedback: vi.fn(),
+}));
+
+import { submitFeedback } from "../api";
+
+describe("ReportIssueModal", () => {
+  const onClose = vi.fn();
+
+  beforeEach(() => {
+    onClose.mockReset();
+    submitFeedback.mockReset();
+  });
+
+  const renderModal = () => render(<ReportIssueModal onClose={onClose} />);
+
+  const fillForm = () => {
+    fireEvent.change(screen.getByPlaceholderText("Brief title of the issue"), {
+      target: { value: "Bug" },
+    });
+    fireEvent.change(screen.getByPlaceholderText("Describe the issue or suggestion..."), {
+      target: { value: "Details" },
+    });
+  };
+
+  it("renders title and description inputs", () => {
+    renderModal();
+    expect(screen.getByPlaceholderText("Brief title of the issue")).toBeInTheDocument();
+    expect(screen.getByPlaceholderText("Describe the issue or suggestion...")).toBeInTheDocument();
+  });
+
+  it("submit button is disabled when fields are empty", () => {
+    renderModal();
+    expect(screen.getByText("Submit")).toBeDisabled();
+  });
+
+  it("submit button is enabled when both fields have text", () => {
+    renderModal();
+    fireEvent.change(screen.getByPlaceholderText("Brief title of the issue"), {
+      target: { value: "Bug title" },
+    });
+    fireEvent.change(screen.getByPlaceholderText("Describe the issue or suggestion..."), {
+      target: { value: "Some description" },
+    });
+    expect(screen.getByText("Submit")).not.toBeDisabled();
+  });
+
+  it("shows success message and calls onClose after 1500ms on submit", async () => {
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    submitFeedback.mockResolvedValueOnce({ id: "abc", created_at: "2026-04-13" });
+    renderModal();
+    fillForm();
+    fireEvent.click(screen.getByText("Submit"));
+    await waitFor(() => expect(screen.getByText("Thank you for your feedback!")).toBeInTheDocument());
+    act(() => vi.advanceTimersByTime(1500));
+    expect(onClose).toHaveBeenCalledOnce();
+    vi.useRealTimers();
+  });
+
+  it("shows error message when submitFeedback rejects", async () => {
+    submitFeedback.mockRejectedValueOnce(new Error("Screenshot too large (max 5 MB)"));
+    renderModal();
+    fillForm();
+    fireEvent.click(screen.getByText("Submit"));
+    await waitFor(() =>
+      expect(screen.getByText("Screenshot too large (max 5 MB)")).toBeInTheDocument()
+    );
+    expect(onClose).not.toHaveBeenCalled();
+  });
+
+  it("does not show success when submitFeedback returns null (401 redirect)", async () => {
+    submitFeedback.mockResolvedValueOnce(null);
+    renderModal();
+    fillForm();
+    fireEvent.click(screen.getByText("Submit"));
+    await act(async () => {
+      await Promise.resolve(); // flush microtasks
+    });
+    expect(screen.queryByText("Thank you for your feedback!")).not.toBeInTheDocument();
+    expect(onClose).not.toHaveBeenCalled();
+  });
+
+  it("calls onClose when Cancel is clicked", () => {
+    renderModal();
+    fireEvent.click(screen.getByText("Cancel"));
+    expect(onClose).toHaveBeenCalledOnce();
+  });
+});

--- a/frontend/src/__tests__/api.test.js
+++ b/frontend/src/__tests__/api.test.js
@@ -174,6 +174,26 @@ describe("api", () => {
       await submitFeedback("t", "d");
       expect(window.location.href).toBe("/login");
     });
+
+    it("appends screenshot blob when screenshotDataUrl is provided", async () => {
+      const mockBlob = new Blob(["imgdata"], { type: "image/jpeg" });
+      // First call: the data URL fetch → blob
+      fetch
+        .mockResolvedValueOnce({ blob: () => Promise.resolve(mockBlob) })
+        // Second call: /api/feedback POST → success
+        .mockResolvedValueOnce({
+          ok: true,
+          status: 201,
+          json: () => Promise.resolve({ id: "xyz", created_at: "2026-04-13T00:00:00Z" }),
+        });
+
+      await submitFeedback("Title", "Desc", "data:image/jpeg;base64,FAKE");
+
+      const [, secondCallArgs] = fetch.mock.calls;
+      expect(secondCallArgs[0]).toBe("/api/feedback");
+      const body = secondCallArgs[1].body;
+      expect(body.get("screenshot")).toBeInstanceOf(Blob);
+    });
   });
 
   // 204 handling

--- a/frontend/src/__tests__/api.test.js
+++ b/frontend/src/__tests__/api.test.js
@@ -7,6 +7,7 @@ import {
   getRankings,
   getMe,
   logout,
+  submitFeedback,
 } from "../api";
 
 describe("api", () => {
@@ -148,6 +149,30 @@ describe("api", () => {
         json: () => Promise.reject(new Error("not json")),
       });
       await expect(getRankings()).rejects.toThrow("Request failed");
+    });
+  });
+
+  // submitFeedback
+  describe("submitFeedback", () => {
+    it("posts to /api/feedback", async () => {
+      mockFetchOk({ id: "abc-123", created_at: "2026-04-13T00:00:00Z" }, 201);
+      const result = await submitFeedback("Bug title", "Description here");
+      expect(fetch).toHaveBeenCalledWith(
+        "/api/feedback",
+        expect.objectContaining({ method: "POST", credentials: "include" })
+      );
+      expect(result.id).toBe("abc-123");
+    });
+
+    it("throws on non-ok response", async () => {
+      mockFetchError(500, "Server error");
+      await expect(submitFeedback("t", "d")).rejects.toThrow("Server error");
+    });
+
+    it("redirects to /login on 401", async () => {
+      mockFetch401();
+      await submitFeedback("t", "d");
+      expect(window.location.href).toBe("/login");
     });
   });
 

--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -129,3 +129,27 @@ export function addToWatchlist(id) {
 export function markSuggestionSeen(id) {
   return request(`/api/suggestions/${id}/seen`, { method: "POST" });
 }
+
+// ── Feedback ────────────────────────────────────────────────────────
+
+export async function submitFeedback(title, description, screenshotDataUrl = null) {
+  const formData = new FormData();
+  formData.append("title", title);
+  formData.append("description", description);
+  if (screenshotDataUrl) {
+    const res = await fetch(screenshotDataUrl);
+    const blob = await res.blob();
+    formData.append("screenshot", blob, "screenshot.jpg");
+  }
+  const response = await fetch("/api/feedback", {
+    method: "POST",
+    credentials: "include",
+    body: formData,
+  });
+  if (response.status === 401) { window.location.href = "/login"; return null; }
+  if (!response.ok) {
+    const error = await response.json().catch(() => ({ detail: "Request failed" }));
+    throw new Error(error.detail || `HTTP ${response.status}`);
+  }
+  return response.json();
+}

--- a/frontend/src/components/Nav.jsx
+++ b/frontend/src/components/Nav.jsx
@@ -1,5 +1,7 @@
+import { useState } from "react";
 import { Link, useLocation } from "react-router-dom";
 import { logout } from "../api";
+import ReportIssueModal from "./ReportIssueModal";
 
 const navItems = [
   { path: "/", label: "Current Duel", icon: "swords" },
@@ -11,6 +13,7 @@ const navItems = [
 
 export default function Nav() {
   const location = useLocation();
+  const [showFeedback, setShowFeedback] = useState(false);
 
   const handleLogout = async () => {
     await logout();
@@ -65,14 +68,12 @@ export default function Nav() {
         >
           START DUEL
         </Link>
-        <a
-          href="https://github.com/alexsiri7/filmduel/issues/new?labels=feedback&title=Feedback:+&body=Describe+the+issue+or+suggestion..."
-          target="_blank"
-          rel="noopener noreferrer"
+        <button
+          onClick={() => setShowFeedback(true)}
           className="block w-full text-center text-[#F5F0E8]/30 hover:text-[#E8A020]/70 font-headline font-bold uppercase text-xs tracking-widest py-2 transition-colors"
         >
           Report Issue
-        </a>
+        </button>
         <button
           onClick={handleLogout}
           className="w-full text-[#F5F0E8]/30 hover:text-[#F5F0E8]/60 font-headline font-bold uppercase text-xs tracking-widest py-2 transition-colors"
@@ -80,6 +81,7 @@ export default function Nav() {
           Sign Out
         </button>
       </div>
+      {showFeedback && <ReportIssueModal onClose={() => setShowFeedback(false)} />}
     </aside>
   );
 }

--- a/frontend/src/components/ReportIssueModal.jsx
+++ b/frontend/src/components/ReportIssueModal.jsx
@@ -5,7 +5,6 @@ import ScreenshotEditor from "./ScreenshotEditor";
 export default function ReportIssueModal({ onClose }) {
   const [title, setTitle] = useState("");
   const [description, setDescription] = useState("");
-  const [screenshotFile, setScreenshotFile] = useState(null);
   const [screenshotDataUrl, setScreenshotDataUrl] = useState(null);
   const [editedScreenshotDataUrl, setEditedScreenshotDataUrl] = useState(null);
   const [showEditor, setShowEditor] = useState(false);
@@ -17,7 +16,6 @@ export default function ReportIssueModal({ onClose }) {
   const handleFileChange = (e) => {
     const file = e.target.files?.[0];
     if (!file) return;
-    setScreenshotFile(file);
     setEditedScreenshotDataUrl(null);
     const reader = new FileReader();
     reader.onload = (ev) => setScreenshotDataUrl(ev.target.result);
@@ -25,7 +23,6 @@ export default function ReportIssueModal({ onClose }) {
   };
 
   const handleRemoveScreenshot = () => {
-    setScreenshotFile(null);
     setScreenshotDataUrl(null);
     setEditedScreenshotDataUrl(null);
     if (fileInputRef.current) fileInputRef.current.value = "";

--- a/frontend/src/components/ReportIssueModal.jsx
+++ b/frontend/src/components/ReportIssueModal.jsx
@@ -1,0 +1,171 @@
+import { useState, useRef } from "react";
+import { submitFeedback } from "../api";
+import ScreenshotEditor from "./ScreenshotEditor";
+
+export default function ReportIssueModal({ onClose }) {
+  const [title, setTitle] = useState("");
+  const [description, setDescription] = useState("");
+  const [screenshotFile, setScreenshotFile] = useState(null);
+  const [screenshotDataUrl, setScreenshotDataUrl] = useState(null);
+  const [editedScreenshotDataUrl, setEditedScreenshotDataUrl] = useState(null);
+  const [showEditor, setShowEditor] = useState(false);
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState(null);
+  const [success, setSuccess] = useState(false);
+  const fileInputRef = useRef(null);
+
+  const handleFileChange = (e) => {
+    const file = e.target.files?.[0];
+    if (!file) return;
+    setScreenshotFile(file);
+    setEditedScreenshotDataUrl(null);
+    const reader = new FileReader();
+    reader.onload = (ev) => setScreenshotDataUrl(ev.target.result);
+    reader.readAsDataURL(file);
+  };
+
+  const handleRemoveScreenshot = () => {
+    setScreenshotFile(null);
+    setScreenshotDataUrl(null);
+    setEditedScreenshotDataUrl(null);
+    if (fileInputRef.current) fileInputRef.current.value = "";
+  };
+
+  const handleEditorSave = (editedUrl) => {
+    setEditedScreenshotDataUrl(editedUrl);
+    setShowEditor(false);
+  };
+
+  const handleSubmit = async () => {
+    if (!title.trim() || !description.trim()) return;
+    setSubmitting(true);
+    setError(null);
+    try {
+      await submitFeedback(title, description, editedScreenshotDataUrl || screenshotDataUrl);
+      setSuccess(true);
+      setTimeout(onClose, 1500);
+    } catch (err) {
+      setError(err.message);
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  if (showEditor && screenshotDataUrl) {
+    return (
+      <ScreenshotEditor
+        imageDataUrl={screenshotDataUrl}
+        onSave={handleEditorSave}
+        onCancel={() => setShowEditor(false)}
+      />
+    );
+  }
+
+  return (
+    <div className="fixed inset-0 z-50 bg-[#0F0E0D]/95 backdrop-blur-xl flex items-center justify-center p-6">
+      <div className="bg-[#1d1b1a] border-l-4 border-[#E8A020] p-8 w-full max-w-lg">
+        <h2 className="font-headline font-black uppercase text-[#F5F0E8] text-xl mb-6">
+          Report Issue
+        </h2>
+
+        {success ? (
+          <div className="text-center py-8">
+            <p className="text-[#E8A020] font-headline font-bold text-lg">
+              Thank you for your feedback!
+            </p>
+            <p className="text-[#F5F0E8]/50 text-sm mt-2">This window will close shortly.</p>
+          </div>
+        ) : (
+          <>
+            <div className="space-y-4">
+              <div>
+                <label className="block text-[#F5F0E8]/60 text-xs uppercase tracking-wider font-headline font-bold mb-1">
+                  Title
+                </label>
+                <input
+                  type="text"
+                  value={title}
+                  onChange={(e) => setTitle(e.target.value)}
+                  placeholder="Brief title of the issue"
+                  className="w-full bg-[#0F0E0D] border border-[#F5F0E8]/10 text-[#F5F0E8] font-body px-4 py-3 placeholder:text-[#6B6760]/50 focus:border-[#E8A020]/50 focus:outline-none transition-colors"
+                />
+              </div>
+
+              <div>
+                <label className="block text-[#F5F0E8]/60 text-xs uppercase tracking-wider font-headline font-bold mb-1">
+                  Description
+                </label>
+                <textarea
+                  value={description}
+                  onChange={(e) => setDescription(e.target.value)}
+                  placeholder="Describe the issue or suggestion..."
+                  rows={4}
+                  className="w-full bg-[#0F0E0D] border border-[#F5F0E8]/10 text-[#F5F0E8] font-body px-4 py-3 placeholder:text-[#6B6760]/50 focus:border-[#E8A020]/50 focus:outline-none transition-colors resize-none"
+                />
+              </div>
+
+              {/* Screenshot */}
+              <div>
+                <input
+                  ref={fileInputRef}
+                  type="file"
+                  accept="image/*"
+                  onChange={handleFileChange}
+                  className="hidden"
+                />
+                {screenshotDataUrl ? (
+                  <div className="space-y-2">
+                    <img
+                      src={editedScreenshotDataUrl || screenshotDataUrl}
+                      alt="Screenshot preview"
+                      className="max-h-[120px] border border-[#F5F0E8]/10"
+                    />
+                    <div className="flex gap-2">
+                      <button
+                        onClick={() => setShowEditor(true)}
+                        className="text-[#E8A020] text-xs font-headline font-bold uppercase tracking-wider hover:text-[#E8A020]/80 transition-colors"
+                      >
+                        Edit Screenshot
+                      </button>
+                      <button
+                        onClick={handleRemoveScreenshot}
+                        className="text-[#F5F0E8]/30 text-xs font-headline font-bold uppercase tracking-wider hover:text-[#F5F0E8]/60 transition-colors"
+                      >
+                        Remove
+                      </button>
+                    </div>
+                  </div>
+                ) : (
+                  <button
+                    onClick={() => fileInputRef.current?.click()}
+                    className="text-[#F5F0E8]/40 text-xs font-headline font-bold uppercase tracking-wider hover:text-[#E8A020]/70 transition-colors"
+                  >
+                    Attach Screenshot
+                  </button>
+                )}
+              </div>
+            </div>
+
+            {error && <p className="text-[#C04A20] text-sm mt-4">{error}</p>}
+
+            <div className="flex gap-3 mt-6">
+              <button
+                onClick={handleSubmit}
+                disabled={!title.trim() || !description.trim() || submitting}
+                className="bg-[#E8A020] text-[#0F0E0D] font-headline font-black uppercase px-6 py-3 tracking-widest text-sm hover:scale-[1.02] active:scale-95 transition-all disabled:opacity-40 disabled:cursor-not-allowed disabled:hover:scale-100"
+              >
+                {submitting ? "Submitting..." : "Submit"}
+              </button>
+              <button
+                onClick={onClose}
+                className="text-[#F5F0E8]/30 font-headline font-bold uppercase px-6 py-3 tracking-widest text-sm hover:text-[#F5F0E8]/60 transition-colors"
+              >
+                Cancel
+              </button>
+            </div>
+          </>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/ReportIssueModal.jsx
+++ b/frontend/src/components/ReportIssueModal.jsx
@@ -41,7 +41,8 @@ export default function ReportIssueModal({ onClose }) {
     setSubmitting(true);
     setError(null);
     try {
-      await submitFeedback(title, description, editedScreenshotDataUrl || screenshotDataUrl);
+      const result = await submitFeedback(title, description, editedScreenshotDataUrl || screenshotDataUrl);
+      if (result === null) return; // 401 redirect in progress
       setSuccess(true);
       setTimeout(onClose, 1500);
     } catch (err) {

--- a/frontend/src/components/ScreenshotEditor.jsx
+++ b/frontend/src/components/ScreenshotEditor.jsx
@@ -23,6 +23,7 @@ export default function ScreenshotEditor({ imageDataUrl, onSave, onCancel }) {
   const [textInput, setTextInput] = useState(null);
   const [textValue, setTextValue] = useState("");
   const [displayScale, setDisplayScale] = useState(1);
+  const [loadError, setLoadError] = useState(null);
 
   const toCanvasCoords = useCallback(
     (e) => {
@@ -124,6 +125,10 @@ export default function ScreenshotEditor({ imageDataUrl, onSave, onCancel }) {
 
       drawAll();
     };
+    img.onerror = () => {
+      console.error("ScreenshotEditor: failed to load image");
+      setLoadError("Failed to load screenshot. Please try a different image.");
+    };
     img.src = imageDataUrl;
   }, [imageDataUrl]);
 
@@ -220,7 +225,10 @@ export default function ScreenshotEditor({ imageDataUrl, onSave, onCancel }) {
   }, [textValue, textInput]);
 
   const handleTextBlur = useCallback(() => {
-    // Prevent blur race when text input was just created
+    // Guard against spurious blur that fires immediately after mount in some browsers.
+    // When the floating text <input> is created and .focus() is called, certain browsers
+    // emit a blur event within the same frame. 200 ms absorbs that without affecting
+    // intentional blur (user clicks elsewhere).
     if (Date.now() - textInputCreatedAt.current < 200) return;
     commitText();
   }, [commitText]);
@@ -243,13 +251,21 @@ export default function ScreenshotEditor({ imageDataUrl, onSave, onCancel }) {
   };
 
   const handleSave = () => {
-    // Commit any pending text
-    if (textInput && textValue.trim()) {
-      commitText();
-    }
     const canvas = canvasRef.current;
     if (!canvas) return;
-    drawAll();
+    drawAll(); // draws all committed annotations
+    // Draw pending text directly to canvas before export — state update is not synchronous
+    if (textInput && textValue.trim()) {
+      const ctx = canvas.getContext("2d");
+      drawAnnotation(ctx, {
+        tool: "text",
+        startX: textInput.x,
+        startY: textInput.y,
+        endX: textInput.x,
+        endY: textInput.y,
+        text: textValue,
+      });
+    }
     const dataUrl = canvas.toDataURL("image/jpeg", 0.85);
     onSave(dataUrl);
   };
@@ -306,6 +322,17 @@ export default function ScreenshotEditor({ imageDataUrl, onSave, onCancel }) {
 
       {/* Canvas area */}
       <div ref={containerRef} className="flex-1 flex items-center justify-center overflow-hidden p-1">
+        {loadError ? (
+          <div className="flex flex-col items-center justify-center gap-4">
+            <p className="text-[#C04A20] font-body text-sm">{loadError}</p>
+            <button
+              onClick={onCancel}
+              className="flex items-center gap-1.5 px-3 py-1.5 text-xs font-headline font-bold uppercase tracking-wider text-[#F5F0E8]/60 hover:text-[#F5F0E8] transition-colors"
+            >
+              Close
+            </button>
+          </div>
+        ) : (
         <div className="relative">
           <canvas
             ref={canvasRef}
@@ -335,6 +362,7 @@ export default function ScreenshotEditor({ imageDataUrl, onSave, onCancel }) {
             />
           )}
         </div>
+        )}
       </div>
     </div>
   );

--- a/frontend/src/components/ScreenshotEditor.jsx
+++ b/frontend/src/components/ScreenshotEditor.jsx
@@ -1,0 +1,341 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import { EyeOff, Highlighter, MoveRight, Type, Undo2, Check, X } from "lucide-react";
+
+const TOOLS = [
+  { id: "redact", label: "Redact", icon: EyeOff },
+  { id: "highlight", label: "Highlight", icon: Highlighter },
+  { id: "arrow", label: "Arrow", icon: MoveRight },
+  { id: "text", label: "Text", icon: Type },
+];
+
+export default function ScreenshotEditor({ imageDataUrl, onSave, onCancel }) {
+  const canvasRef = useRef(null);
+  const containerRef = useRef(null);
+  const imageRef = useRef(null);
+  const textInputRef = useRef(null);
+  const textInputCreatedAt = useRef(0);
+
+  const [tool, setTool] = useState("redact");
+  const [annotations, setAnnotations] = useState([]);
+  const [drawing, setDrawing] = useState(false);
+  const [startPos, setStartPos] = useState(null);
+  const [currentPos, setCurrentPos] = useState(null);
+  const [textInput, setTextInput] = useState(null);
+  const [textValue, setTextValue] = useState("");
+  const [displayScale, setDisplayScale] = useState(1);
+
+  const toCanvasCoords = useCallback(
+    (e) => {
+      const canvas = canvasRef.current;
+      if (!canvas) return { x: 0, y: 0 };
+      const rect = canvas.getBoundingClientRect();
+      return {
+        x: (e.clientX - rect.left) / displayScale,
+        y: (e.clientY - rect.top) / displayScale,
+      };
+    },
+    [displayScale]
+  );
+
+  const drawAll = useCallback(() => {
+    const canvas = canvasRef.current;
+    const img = imageRef.current;
+    if (!canvas || !img) return;
+    const ctx = canvas.getContext("2d");
+    ctx.clearRect(0, 0, canvas.width, canvas.height);
+    ctx.drawImage(img, 0, 0);
+
+    for (const ann of annotations) {
+      drawAnnotation(ctx, ann);
+    }
+  }, [annotations]);
+
+  const drawAnnotation = (ctx, ann) => {
+    const x = Math.min(ann.startX, ann.endX);
+    const y = Math.min(ann.startY, ann.endY);
+    const w = Math.abs(ann.endX - ann.startX);
+    const h = Math.abs(ann.endY - ann.startY);
+
+    switch (ann.tool) {
+      case "redact":
+        ctx.fillStyle = "rgba(0, 0, 0, 1)";
+        ctx.fillRect(x, y, w, h);
+        break;
+      case "highlight":
+        ctx.fillStyle = "rgba(255, 255, 0, 0.35)";
+        ctx.fillRect(x, y, w, h);
+        ctx.strokeStyle = "rgba(255, 255, 0, 0.8)";
+        ctx.lineWidth = 2;
+        ctx.strokeRect(x, y, w, h);
+        break;
+      case "arrow": {
+        const dx = ann.endX - ann.startX;
+        const dy = ann.endY - ann.startY;
+        const angle = Math.atan2(dy, dx);
+        const len = Math.sqrt(dx * dx + dy * dy);
+        const headLen = Math.min(20, len * 0.3);
+
+        ctx.strokeStyle = "rgba(220, 38, 38, 1)";
+        ctx.lineWidth = 3;
+        ctx.beginPath();
+        ctx.moveTo(ann.startX, ann.startY);
+        ctx.lineTo(ann.endX, ann.endY);
+        ctx.stroke();
+
+        ctx.fillStyle = "rgba(220, 38, 38, 1)";
+        ctx.beginPath();
+        ctx.moveTo(ann.endX, ann.endY);
+        ctx.lineTo(
+          ann.endX - headLen * Math.cos(angle - Math.PI / 6),
+          ann.endY - headLen * Math.sin(angle - Math.PI / 6)
+        );
+        ctx.lineTo(
+          ann.endX - headLen * Math.cos(angle + Math.PI / 6),
+          ann.endY - headLen * Math.sin(angle + Math.PI / 6)
+        );
+        ctx.closePath();
+        ctx.fill();
+        break;
+      }
+      case "text":
+        ctx.font = "bold 18px sans-serif";
+        ctx.fillStyle = "rgba(220, 38, 38, 1)";
+        ctx.fillText(ann.text, ann.startX, ann.startY);
+        break;
+    }
+  };
+
+  // Load image and set canvas dimensions
+  useEffect(() => {
+    const img = new Image();
+    img.onload = () => {
+      imageRef.current = img;
+      const canvas = canvasRef.current;
+      const container = containerRef.current;
+      if (!canvas || !container) return;
+
+      canvas.width = img.width;
+      canvas.height = img.height;
+
+      const containerW = container.clientWidth - 8;
+      const containerH = container.clientHeight - 8;
+      const scale = Math.min(containerW / img.width, containerH / img.height, 1);
+      setDisplayScale(scale);
+
+      drawAll();
+    };
+    img.src = imageDataUrl;
+  }, [imageDataUrl]);
+
+  // Redraw when annotations change
+  useEffect(() => {
+    drawAll();
+  }, [drawAll]);
+
+  // Draw preview while dragging
+  useEffect(() => {
+    if (!drawing || !startPos || !currentPos) return;
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+    const ctx = canvas.getContext("2d");
+    drawAll();
+    drawAnnotation(ctx, {
+      tool,
+      startX: startPos.x,
+      startY: startPos.y,
+      endX: currentPos.x,
+      endY: currentPos.y,
+    });
+  }, [drawing, startPos, currentPos, tool, drawAll]);
+
+  // Focus text input when created
+  useEffect(() => {
+    if (textInput && textInputRef.current) {
+      textInputRef.current.focus();
+    }
+  }, [textInput]);
+
+  const handlePointerDown = useCallback(
+    (e) => {
+      const pos = toCanvasCoords(e);
+      if (tool === "text") {
+        textInputCreatedAt.current = Date.now();
+        setTextInput(pos);
+        setTextValue("");
+        return;
+      }
+      setDrawing(true);
+      setStartPos(pos);
+      setCurrentPos(pos);
+    },
+    [tool, toCanvasCoords]
+  );
+
+  const handlePointerMove = useCallback(
+    (e) => {
+      if (!drawing) return;
+      setCurrentPos(toCanvasCoords(e));
+    },
+    [drawing, toCanvasCoords]
+  );
+
+  const handlePointerUp = useCallback(() => {
+    if (!drawing || !startPos || !currentPos) return;
+    setDrawing(false);
+
+    const dx = Math.abs(currentPos.x - startPos.x);
+    const dy = Math.abs(currentPos.y - startPos.y);
+    if (dx < 3 && dy < 3) return;
+
+    setAnnotations((prev) => [
+      ...prev,
+      {
+        tool,
+        startX: startPos.x,
+        startY: startPos.y,
+        endX: currentPos.x,
+        endY: currentPos.y,
+      },
+    ]);
+    setStartPos(null);
+    setCurrentPos(null);
+  }, [drawing, startPos, currentPos, tool]);
+
+  const commitText = useCallback(() => {
+    if (textValue.trim() && textInput) {
+      setAnnotations((prev) => [
+        ...prev,
+        {
+          tool: "text",
+          startX: textInput.x,
+          startY: textInput.y,
+          endX: textInput.x,
+          endY: textInput.y,
+          text: textValue,
+        },
+      ]);
+    }
+    setTextInput(null);
+    setTextValue("");
+  }, [textValue, textInput]);
+
+  const handleTextBlur = useCallback(() => {
+    // Prevent blur race when text input was just created
+    if (Date.now() - textInputCreatedAt.current < 200) return;
+    commitText();
+  }, [commitText]);
+
+  const handleTextKeyDown = useCallback(
+    (e) => {
+      if (e.key === "Enter") {
+        e.preventDefault();
+        commitText();
+      } else if (e.key === "Escape") {
+        setTextInput(null);
+        setTextValue("");
+      }
+    },
+    [commitText]
+  );
+
+  const handleUndo = () => {
+    setAnnotations((prev) => prev.slice(0, -1));
+  };
+
+  const handleSave = () => {
+    // Commit any pending text
+    if (textInput && textValue.trim()) {
+      commitText();
+    }
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+    drawAll();
+    const dataUrl = canvas.toDataURL("image/jpeg", 0.85);
+    onSave(dataUrl);
+  };
+
+  return (
+    <div className="fixed inset-0 z-[100] flex flex-col bg-[#0F0E0D]">
+      {/* Toolbar */}
+      <div className="flex items-center gap-2 p-3 bg-[#1d1b1a] border-b border-[#F5F0E8]/10">
+        {TOOLS.map((t) => {
+          const Icon = t.icon;
+          return (
+            <button
+              key={t.id}
+              onClick={() => setTool(t.id)}
+              className={`flex items-center gap-1.5 px-3 py-1.5 text-xs font-headline font-bold uppercase tracking-wider transition-colors ${
+                tool === t.id
+                  ? "bg-[#E8A020] text-[#0F0E0D]"
+                  : "text-[#F5F0E8]/60 hover:text-[#F5F0E8]"
+              }`}
+            >
+              <Icon size={14} />
+              {t.label}
+            </button>
+          );
+        })}
+
+        <div className="flex-1" />
+
+        <button
+          onClick={handleUndo}
+          disabled={annotations.length === 0}
+          className="flex items-center gap-1.5 px-3 py-1.5 text-xs font-headline font-bold uppercase tracking-wider text-[#F5F0E8]/60 hover:text-[#F5F0E8] disabled:opacity-30 disabled:cursor-not-allowed transition-colors"
+        >
+          <Undo2 size={14} />
+          Undo
+        </button>
+
+        <button
+          onClick={handleSave}
+          className="flex items-center gap-1.5 px-3 py-1.5 text-xs font-headline font-bold uppercase tracking-wider bg-[#E8A020] text-[#0F0E0D] hover:bg-[#E8A020]/80 transition-colors"
+        >
+          <Check size={14} />
+          Done
+        </button>
+
+        <button
+          onClick={onCancel}
+          className="flex items-center gap-1.5 px-3 py-1.5 text-xs font-headline font-bold uppercase tracking-wider text-[#F5F0E8]/60 hover:text-[#F5F0E8] transition-colors"
+        >
+          <X size={14} />
+          Cancel
+        </button>
+      </div>
+
+      {/* Canvas area */}
+      <div ref={containerRef} className="flex-1 flex items-center justify-center overflow-hidden p-1">
+        <div className="relative">
+          <canvas
+            ref={canvasRef}
+            onPointerDown={handlePointerDown}
+            onPointerMove={handlePointerMove}
+            onPointerUp={handlePointerUp}
+            className="cursor-crosshair"
+            style={{
+              width: canvasRef.current ? canvasRef.current.width * displayScale : "auto",
+              height: canvasRef.current ? canvasRef.current.height * displayScale : "auto",
+            }}
+          />
+          {textInput && (
+            <input
+              ref={textInputRef}
+              type="text"
+              value={textValue}
+              onChange={(e) => setTextValue(e.target.value)}
+              onBlur={handleTextBlur}
+              onKeyDown={handleTextKeyDown}
+              className="absolute bg-transparent text-red-600 font-bold text-lg outline-none border-b border-red-600"
+              style={{
+                left: textInput.x * displayScale,
+                top: textInput.y * displayScale - 20,
+                minWidth: 100,
+              }}
+            />
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

Replaces the external GitHub issues link in the Nav sidebar with an in-app modal for reporting issues. Users can now fill a title and description, optionally attach and annotate a screenshot using canvas-based tools, and submit directly — all without leaving the app or needing a GitHub account.

Fixes #74

## Changes

### Frontend
- **`ScreenshotEditor.jsx`** (new, +271 lines): Canvas-based annotation editor ported from word-coach-annie — supports redact, highlight, arrow, and text tools with undo
- **`ReportIssueModal.jsx`** (new, +149 lines): Two-step modal overlay — Step 1: title/description/screenshot upload form; Step 2: opens ScreenshotEditor if screenshot attached
- **`Nav.jsx`** (updated): Replaces `<a>` link to GitHub issues with a `<button>` that opens `ReportIssueModal`; adds `showFeedback` state
- **`api.js`** (updated, +22 lines): Adds `submitFeedback(title, description, screenshotDataUrl)` using `FormData` + `multipart/form-data`

### Backend
- **`routers/feedback.py`** (new, +56 lines): `POST /api/feedback` endpoint accepting `title`, `description`, optional `screenshot` (UploadFile); stores to DB
- **`db_models.py`** (updated, +20 lines): Adds `FeedbackReport` ORM model
- **`schemas.py`** (updated, +7 lines): Adds `FeedbackReportResponse` Pydantic schema
- **`migrations/versions/011_add_feedback_reports.py`** (new, +38 lines): Alembic migration for `feedback_reports` table
- **`main.py`** (updated): Registers feedback router

### Tests
- **`Nav.test.jsx`**: Updated — "clicking Report Issue opens feedback modal" test
- **`api.test.js`**: Updated — `submitFeedback` tests (POST to /api/feedback, error handling, FormData usage)

## Validation

| Check | Result |
|-------|--------|
| Frontend tests | ✅ 78 passed, 0 failed (8 test files) |
| Backend tests | ✅ 142 passed, 0 failed |
| Frontend build | ✅ Compiled successfully (268 kB JS bundle) |
| Lint / format | N/A — not configured in this project |