### PR TITLE
fix: always register SPA catch-all route to prevent 404 on root

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ WORKDIR /app/frontend
 COPY frontend/package.json frontend/package-lock.json* ./
 RUN npm install
 COPY frontend/ ./
-RUN npm run build
+RUN npm run build && test -d dist
 
 # Stage 2: Python backend + built frontend
 FROM python:3.12-slim

--- a/backend/main.py
+++ b/backend/main.py
@@ -63,13 +63,17 @@ async def health():
 
 STATIC_DIR = Path(__file__).resolve().parent.parent / "frontend" / "dist"
 
-if STATIC_DIR.is_dir():
+if (STATIC_DIR / "assets").is_dir():
     app.mount("/assets", StaticFiles(directory=STATIC_DIR / "assets"), name="assets")
 
-    @app.get("/{full_path:path}")
-    async def spa_fallback(full_path: str):
-        """Serve the SPA index.html for any non-API route."""
-        file_path = (STATIC_DIR / full_path).resolve()
-        if file_path.is_file() and str(file_path).startswith(str(STATIC_DIR.resolve())):
-            return FileResponse(file_path)
-        return FileResponse(STATIC_DIR / "index.html")
+
+@app.get("/{full_path:path}")
+async def spa_fallback(full_path: str):
+    """Serve the SPA index.html for any non-API route."""
+    if not STATIC_DIR.is_dir():
+        from fastapi.responses import JSONResponse
+        return JSONResponse({"detail": "Frontend not available"}, status_code=503)
+    file_path = (STATIC_DIR / full_path).resolve()
+    if file_path.is_file() and str(file_path).startswith(str(STATIC_DIR.resolve())):
+        return FileResponse(file_path)
+    return FileResponse(STATIC_DIR / "index.html")

--- a/backend/main.py
+++ b/backend/main.py
@@ -2,16 +2,19 @@
 
 from __future__ import annotations
 
+import logging
 from pathlib import Path
 
 import sentry_sdk
 from fastapi import FastAPI, Request
 from fastapi.middleware.cors import CORSMiddleware
-from fastapi.responses import FileResponse
+from fastapi.responses import FileResponse, JSONResponse
 from fastapi.staticfiles import StaticFiles
 
 from backend.config import get_settings
 from backend.routers import auth, movies, duels, rankings, suggestions, swipe, tournaments, feedback
+
+logger = logging.getLogger(__name__)
 
 settings = get_settings()
 
@@ -71,7 +74,7 @@ if (STATIC_DIR / "assets").is_dir():
 async def spa_fallback(full_path: str):
     """Serve the SPA index.html for any non-API route."""
     if not STATIC_DIR.is_dir():
-        from fastapi.responses import JSONResponse
+        logger.warning("frontend/dist not found at %s — returning 503", STATIC_DIR)
         return JSONResponse({"detail": "Frontend not available"}, status_code=503)
     file_path = (STATIC_DIR / full_path).resolve()
     if file_path.is_file() and str(file_path).startswith(str(STATIC_DIR.resolve())):

--- a/backend/tests/test_spa.py
+++ b/backend/tests/test_spa.py
@@ -1,0 +1,66 @@
+"""Tests for the SPA catch-all route (spa_fallback)."""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+from fastapi.testclient import TestClient
+
+import backend.main as main_module
+from backend.main import app
+
+client = TestClient(app)
+
+
+def test_root_returns_503_when_dist_missing(tmp_path):
+    """Route must be registered even when frontend/dist doesn't exist."""
+    missing = tmp_path / "nonexistent"
+    with patch.object(main_module, "STATIC_DIR", missing):
+        response = client.get("/")
+    assert response.status_code == 503
+    assert response.json() == {"detail": "Frontend not available"}
+
+
+def test_spa_fallback_returns_503_for_unknown_path_when_dist_missing(tmp_path):
+    """Any SPA route must return 503 when dist is missing, not 404."""
+    missing = tmp_path / "nonexistent"
+    with patch.object(main_module, "STATIC_DIR", missing):
+        response = client.get("/some/deep/route")
+    assert response.status_code == 503
+    assert response.json() == {"detail": "Frontend not available"}
+
+
+def test_spa_fallback_serves_index_html_for_spa_route(tmp_path):
+    """Non-file SPA routes (e.g. /login) must serve index.html."""
+    dist = tmp_path / "dist"
+    dist.mkdir()
+    (dist / "index.html").write_text("<html>app</html>")
+    with patch.object(main_module, "STATIC_DIR", dist):
+        response = client.get("/login")
+    assert response.status_code == 200
+
+
+def test_spa_fallback_serves_static_file_when_it_exists(tmp_path):
+    """Requests for existing static files must return the file directly."""
+    dist = tmp_path / "dist"
+    dist.mkdir()
+    (dist / "index.html").write_text("<html>app</html>")
+    static_file = dist / "favicon.ico"
+    static_file.write_bytes(b"\x00")
+    with patch.object(main_module, "STATIC_DIR", dist):
+        response = client.get("/favicon.ico")
+    assert response.status_code == 200
+
+
+def test_path_traversal_is_blocked(tmp_path):
+    """Path traversal attempts must not serve files outside frontend/dist."""
+    dist = tmp_path / "dist"
+    dist.mkdir()
+    (dist / "index.html").write_text("<html>app</html>")
+    sensitive = tmp_path / "secret.txt"
+    sensitive.write_text("SECRET")
+
+    with patch.object(main_module, "STATIC_DIR", dist):
+        response = client.get("/../secret.txt")
+    assert response.status_code == 200
+    assert "SECRET" not in response.text


### PR DESCRIPTION
## Summary

- Decouples SPA catch-all route registration from the `frontend/dist` directory existence check
- The `/{full_path:path}` route is now always registered so FastAPI never returns 404 for the root path
- If `frontend/dist` is missing at runtime, the handler returns HTTP 503 instead of an unhandled 404
- Adds `test -d dist` in the Dockerfile to fail the build immediately if Vite doesn't produce output

## Root Cause

`backend/main.py` conditionally registered the SPA catch-all route inside `if STATIC_DIR.is_dir()`. When `frontend/dist` was absent (e.g. stale image, build artifact missing), no route matched `/` and FastAPI returned 404. The `/health` endpoint was unaffected, masking the failure from Railway's health check.

## Changes

| File | Change |
|------|--------|
| `backend/main.py` | Move `@app.get("/{full_path:path}")` outside the directory guard; return 503 when dist is missing |
| `Dockerfile` | Add `&& test -d dist` after `npm run build` to fail fast on missing build output |

## Validation

- Backend tests: 152 passed, 0 failed
- Frontend tests: 86 passed, 0 failed  
- Frontend build: successful (dist/index.html, assets CSS + JS)
- All checks passed on first run with no modifications

Fixes #76