### PR TITLE
security: fix 6 high-severity vulnerabilities from audit

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,9 +13,13 @@ WORKDIR /app
 COPY backend/requirements.txt ./
 RUN pip install --no-cache-dir -r requirements.txt
 
+RUN useradd --create-home --shell /bin/bash appuser
+
 COPY alembic.ini ./
 COPY backend/ ./backend/
 COPY --from=frontend-build /app/frontend/dist ./frontend/dist
+
+USER appuser
 
 EXPOSE ${PORT:-8080}
 CMD ["sh", "-c", "alembic upgrade head && uvicorn backend.main:app --host 0.0.0.0 --port ${PORT:-8080}"]

--- a/backend/main.py
+++ b/backend/main.py
@@ -43,6 +43,14 @@ async def add_security_headers(request: Request, call_next):
     response.headers["X-Content-Type-Options"] = "nosniff"
     response.headers["X-Frame-Options"] = "DENY"
     response.headers["Referrer-Policy"] = "strict-origin-when-cross-origin"
+    response.headers["Strict-Transport-Security"] = "max-age=31536000; includeSubDomains"
+    response.headers["Content-Security-Policy"] = (
+        "default-src 'self'; "
+        "img-src 'self' https://image.tmdb.org data:; "
+        "script-src 'self'; "
+        "style-src 'self' 'unsafe-inline'; "
+        "connect-src 'self' https://*.sentry.io"
+    )
     return response
 
 

--- a/backend/routers/auth.py
+++ b/backend/routers/auth.py
@@ -35,13 +35,16 @@ SYNC_RATE_WINDOW = 3600  # per hour (seconds)
 
 COOKIE_NAME = "filmduel_session"
 JWT_ALGORITHM = "HS256"
-JWT_EXPIRY_HOURS = 72
+JWT_EXPIRY_HOURS = 4
 
 
 def create_jwt(user_id: str, settings: Settings) -> str:
     """Create a signed JWT for session management."""
     payload = {
         "sub": user_id,
+        "jti": secrets.token_hex(16),
+        "iss": "filmduel",
+        "aud": "filmduel",
         "exp": datetime.now(timezone.utc) + timedelta(hours=JWT_EXPIRY_HOURS),
         "iat": datetime.now(timezone.utc),
     }
@@ -55,7 +58,12 @@ def get_current_user_id(request: Request) -> str:
     if not token:
         raise HTTPException(status_code=401, detail="Not authenticated")
     try:
-        payload = jwt.decode(token, settings.SECRET_KEY, algorithms=[JWT_ALGORITHM])
+        payload = jwt.decode(
+            token, settings.SECRET_KEY,
+            algorithms=[JWT_ALGORITHM],
+            issuer="filmduel",
+            audience="filmduel",
+        )
         return payload["sub"]
     except jwt.ExpiredSignatureError:
         raise HTTPException(status_code=401, detail="Session expired")

--- a/backend/routers/duels.py
+++ b/backend/routers/duels.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import logging
 import uuid
 
-from fastapi import APIRouter, BackgroundTasks, Depends
+from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -61,6 +61,23 @@ async def submit_duel(
     movie_b_id = uuid.UUID(body.movie_b_id)
     outcome = body.outcome.value
     mode = body.mode
+
+    # Prevent self-duels
+    if movie_a_id == movie_b_id:
+        raise HTTPException(status_code=400, detail="Cannot duel a movie against itself")
+
+    # For competitive outcomes, verify both movies are in the user's seen pool
+    if outcome in ("a_wins", "b_wins"):
+        from backend.db_models import UserMovie
+        for mid in (movie_a_id, movie_b_id):
+            stmt = select(UserMovie).where(
+                UserMovie.user_id == uid,
+                UserMovie.movie_id == mid,
+                UserMovie.seen.is_(True),
+            )
+            um_check = await db.execute(stmt)
+            if not um_check.scalar_one_or_none():
+                raise HTTPException(status_code=400, detail="Movie not in your seen pool")
 
     result = await process_duel(db, uid, movie_a_id, movie_b_id, outcome, mode)
 

--- a/backend/routers/feedback.py
+++ b/backend/routers/feedback.py
@@ -20,6 +20,25 @@ router = APIRouter(prefix="/api/feedback", tags=["feedback"])
 MAX_SCREENSHOT_BYTES = 5 * 1024 * 1024  # 5 MB
 ALLOWED_IMAGE_TYPES = {"image/jpeg", "image/png", "image/gif", "image/webp"}
 
+# Magic bytes for allowed image types
+_IMAGE_SIGNATURES = {
+    b'\x89PNG\r\n\x1a\n': "image/png",
+    b'\xff\xd8\xff': "image/jpeg",
+    b'GIF87a': "image/gif",
+    b'GIF89a': "image/gif",
+    b'RIFF': "image/webp",  # WebP starts with RIFF....WEBP
+}
+
+
+def _detect_image_type(data: bytes) -> str | None:
+    """Detect image type from magic bytes. Returns MIME type or None."""
+    for sig, mime in _IMAGE_SIGNATURES.items():
+        if data[:len(sig)] == sig:
+            if mime == "image/webp" and data[8:12] != b'WEBP':
+                continue
+            return mime
+    return None
+
 
 @router.post("", response_model=FeedbackReportResponse, status_code=201)
 async def submit_feedback(
@@ -31,17 +50,17 @@ async def submit_feedback(
 ):
     screenshot_data = None
     if screenshot and screenshot.filename:
-        if screenshot.content_type not in ALLOWED_IMAGE_TYPES:
-            raise HTTPException(
-                status_code=415,
-                detail="Screenshot must be an image (JPEG, PNG, GIF, or WebP)",
-            )
         raw = await screenshot.read(MAX_SCREENSHOT_BYTES + 1)
         if len(raw) > MAX_SCREENSHOT_BYTES:
             raise HTTPException(
                 status_code=413, detail="Screenshot too large (max 5 MB)"
             )
-        mime = screenshot.content_type
+        mime = _detect_image_type(raw)
+        if not mime:
+            raise HTTPException(
+                status_code=415,
+                detail="Screenshot must be a valid image (JPEG, PNG, GIF, or WebP)",
+            )
         screenshot_data = f"data:{mime};base64," + base64.b64encode(raw).decode()
 
     report = FeedbackReport(

--- a/backend/services/duel.py
+++ b/backend/services/duel.py
@@ -28,12 +28,15 @@ class ProcessDuelResult:
 
 
 async def get_or_create_user_movie(
-    db: AsyncSession, user_id: uuid.UUID, movie_id: uuid.UUID
+    db: AsyncSession, user_id: uuid.UUID, movie_id: uuid.UUID,
+    *, for_update: bool = False,
 ) -> UserMovie:
     """Fetch an existing UserMovie or create a new one."""
     stmt = select(UserMovie).where(
         UserMovie.user_id == user_id, UserMovie.movie_id == movie_id
     )
+    if for_update:
+        stmt = stmt.with_for_update()
     result = await db.execute(stmt)
     um = result.scalar_one_or_none()
     if not um:
@@ -57,8 +60,8 @@ async def process_duel(
     FastAPI dependency).  Returns a ``DuelResult`` ready to send to the client.
     """
     # ── Fetch / create user_movies ──────────────────────────────────
-    um_a = await get_or_create_user_movie(db, user_id, movie_a_id)
-    um_b = await get_or_create_user_movie(db, user_id, movie_b_id)
+    um_a = await get_or_create_user_movie(db, user_id, movie_a_id, for_update=True)
+    um_b = await get_or_create_user_movie(db, user_id, movie_b_id, for_update=True)
 
     um_a_seen_was_none = um_a.seen is None
     um_b_seen_was_none = um_b.seen is None

--- a/backend/services/tournament.py
+++ b/backend/services/tournament.py
@@ -237,10 +237,12 @@ async def record_match_winner(
     """
     now = datetime.now(timezone.utc)
 
-    # Mark winner + propagate
+    # Mark winner + propagate (lock row to prevent double-submit)
     match_obj = (await db.execute(
-        select(TournamentMatch).where(TournamentMatch.id == match_id)
+        select(TournamentMatch).where(TournamentMatch.id == match_id).with_for_update()
     )).scalar_one()
+    if match_obj.winner_movie_id is not None:
+        raise ValueError("Match already played")
     match_obj.winner_movie_id = winner_id
     match_obj.played_at = now
 
@@ -271,10 +273,14 @@ async def record_match_winner(
 
     # ELO update + duel record (same session, 2 extra queries)
     um_w = (await db.execute(
-        select(UserMovie).where(UserMovie.user_id == user_id, UserMovie.movie_id == winner_id)
+        select(UserMovie).where(
+            UserMovie.user_id == user_id, UserMovie.movie_id == winner_id
+        ).with_for_update()
     )).scalar_one()
     um_l = (await db.execute(
-        select(UserMovie).where(UserMovie.user_id == user_id, UserMovie.movie_id == loser_id)
+        select(UserMovie).where(
+            UserMovie.user_id == user_id, UserMovie.movie_id == loser_id
+        ).with_for_update()
     )).scalar_one()
 
     w_elo = um_w.elo if um_w.elo is not None else get_initial_elo(um_w.seeded_elo)

--- a/backend/tests/test_auth.py
+++ b/backend/tests/test_auth.py
@@ -44,18 +44,30 @@ class TestCreateJWT:
     def test_round_trip_decode(self):
         user_id = "550e8400-e29b-41d4-a716-446655440000"
         token = create_jwt(user_id, SETTINGS)
-        payload = pyjwt.decode(token, SETTINGS.SECRET_KEY, algorithms=[JWT_ALGORITHM])
+        payload = pyjwt.decode(
+            token, SETTINGS.SECRET_KEY, algorithms=[JWT_ALGORITHM],
+            issuer="filmduel", audience="filmduel",
+        )
         assert payload["sub"] == user_id
+        assert payload["iss"] == "filmduel"
+        assert payload["aud"] == "filmduel"
+        assert "jti" in payload
 
     def test_payload_has_exp_and_iat(self):
         token = create_jwt("user-1", SETTINGS)
-        payload = pyjwt.decode(token, SETTINGS.SECRET_KEY, algorithms=[JWT_ALGORITHM])
+        payload = pyjwt.decode(
+            token, SETTINGS.SECRET_KEY, algorithms=[JWT_ALGORITHM],
+            issuer="filmduel", audience="filmduel",
+        )
         assert "exp" in payload
         assert "iat" in payload
 
     def test_expiry_is_in_future(self):
         token = create_jwt("user-1", SETTINGS)
-        payload = pyjwt.decode(token, SETTINGS.SECRET_KEY, algorithms=[JWT_ALGORITHM])
+        payload = pyjwt.decode(
+            token, SETTINGS.SECRET_KEY, algorithms=[JWT_ALGORITHM],
+            issuer="filmduel", audience="filmduel",
+        )
         exp = datetime.fromtimestamp(payload["exp"], tz=timezone.utc)
         now = datetime.now(timezone.utc)
         # Should expire roughly JWT_EXPIRY_HOURS from now (allow 5 min tolerance)
@@ -105,6 +117,8 @@ class TestGetCurrentUserId:
         # Create a token that expired an hour ago
         payload = {
             "sub": "user-1",
+            "iss": "filmduel",
+            "aud": "filmduel",
             "exp": datetime.now(timezone.utc) - timedelta(hours=1),
             "iat": datetime.now(timezone.utc) - timedelta(hours=2),
         }
@@ -138,6 +152,8 @@ class TestGetCurrentUserId:
         """Token without 'sub' claim should raise 401 (KeyError caught as InvalidTokenError)."""
         monkeypatch.setattr("backend.routers.auth.get_settings", lambda: SETTINGS)
         payload = {
+            "iss": "filmduel",
+            "aud": "filmduel",
             "exp": datetime.now(timezone.utc) + timedelta(hours=1),
             "iat": datetime.now(timezone.utc),
             # no "sub"

--- a/backend/tests/test_feedback.py
+++ b/backend/tests/test_feedback.py
@@ -91,7 +91,7 @@ class TestSubmitFeedback:
         assert report.description == "Details"
 
     def test_accepts_screenshot_within_size_limit(self, client):
-        small_image = b"FAKEJPEG" * 100  # well under 5 MB
+        small_image = b'\xff\xd8\xff' + b'\x00' * 100  # valid JPEG magic bytes
         response = self._post(client, screenshot=io.BytesIO(small_image))
         assert response.status_code == 201
 
@@ -111,12 +111,14 @@ class TestSubmitFeedback:
         assert "image" in response.json()["detail"].lower()
 
     def test_screenshot_stored_as_base64_data_url_with_correct_mime(self, client):
-        response = self._post(client, screenshot=io.BytesIO(b"FAKEJPEGDATA"), content_type="image/jpeg")
+        jpeg_data = b'\xff\xd8\xff' + b'\x00' * 10  # valid JPEG magic bytes
+        response = self._post(client, screenshot=io.BytesIO(jpeg_data), content_type="image/jpeg")
         report = response._created_reports[0]
         assert report.screenshot_data.startswith("data:image/jpeg;base64,")
 
     def test_png_screenshot_stored_with_png_mime(self, client):
-        response = self._post(client, screenshot=io.BytesIO(b"FAKEPNGDATA"), content_type="image/png")
+        png_data = b'\x89PNG\r\n\x1a\n' + b'\x00' * 10  # valid PNG magic bytes
+        response = self._post(client, screenshot=io.BytesIO(png_data), content_type="image/png")
         report = response._created_reports[0]
         assert report.screenshot_data.startswith("data:image/png;base64,")
 


### PR DESCRIPTION
## Summary

Comprehensive security audit identified 27 findings (4 HIGH, 13 MEDIUM, 10 LOW). This PR fixes all HIGH findings and several MEDIUM ones:

- **SEC-001/002**: Race condition on ELO updates — added `SELECT ... FOR UPDATE` row-level locking on UserMovie during duel and tournament ELO mutations
- **SEC-003**: Tournament match double-submit — added `FOR UPDATE` lock on TournamentMatch + null-check guard preventing duplicate winner assignment
- **SEC-004/024**: JWT hardening — reduced expiry from 72h → 4h, added `jti` (unique token ID), `iss`/`aud` claims with validation
- **SEC-005**: Self-duel prevention — reject duels where `movie_a_id == movie_b_id`
- **SEC-006**: Duel movie validation — verify both movies exist in user's seen pool before processing
- **SEC-009/010**: Added HSTS and Content-Security-Policy response headers
- **SEC-011**: Docker container now runs as non-root `appuser`
- **SEC-015**: Screenshot upload validates magic bytes instead of trusting client Content-Type

### Remaining findings (MEDIUM/LOW) tracked as separate issues.

## Test plan
- [x] Existing tests updated to match new JWT claims (iss/aud/jti)
- [x] Feedback tests updated to use real image magic bytes
- [ ] Verify ELO locking under concurrent load
- [ ] Confirm CSP doesn't break frontend asset loading

🤖 Generated with [Claude Code](https://claude.com/claude-code)