### PR TITLE
feat: add TV show support alongside movie dueling

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # FilmDuel
 
-Rank your movies through head-to-head duels. Powered by ELO ratings, Trakt integration, and TMDB posters.
+Rank your movies and TV shows through head-to-head duels. Powered by ELO ratings, Trakt integration, and TMDB posters.
 
 ## Stack
 

--- a/backend/db_models.py
+++ b/backend/db_models.py
@@ -50,11 +50,17 @@ class User(Base):
 
 class Movie(Base):
     __tablename__ = "movies"
+    __table_args__ = (
+        UniqueConstraint("trakt_id", "media_type", name="uq_movies_trakt_id_media_type"),
+    )
 
     id: Mapped[uuid.UUID] = mapped_column(
         UUID(as_uuid=True), primary_key=True, default=uuid.uuid4
     )
-    trakt_id: Mapped[int] = mapped_column(Integer, unique=True, nullable=False)
+    trakt_id: Mapped[int] = mapped_column(Integer, nullable=False)
+    media_type: Mapped[str] = mapped_column(
+        Text, nullable=False, server_default="movie", index=True
+    )
     imdb_id: Mapped[Optional[str]] = mapped_column(Text, nullable=True)
     tmdb_id: Mapped[Optional[int]] = mapped_column(Integer, nullable=True)
     title: Mapped[str] = mapped_column(Text, nullable=False)

--- a/backend/migrations/versions/012_add_media_type.py
+++ b/backend/migrations/versions/012_add_media_type.py
@@ -1,0 +1,44 @@
+"""Add media_type column to movies table for TV show support
+
+Revision ID: 012
+Revises: 011
+Create Date: 2026-04-13
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+revision: str = "012"
+down_revision: Union[str, None] = "011"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    # Add media_type column with server_default so existing rows get 'movie'
+    op.add_column(
+        "movies",
+        sa.Column(
+            "media_type",
+            sa.Text(),
+            nullable=False,
+            server_default="movie",
+        ),
+    )
+    op.create_index("ix_movies_media_type", "movies", ["media_type"])
+
+    # Drop the old unique constraint on trakt_id alone
+    op.drop_constraint("movies_trakt_id_key", "movies", type_="unique")
+
+    # Add composite unique constraint on (trakt_id, media_type)
+    op.create_unique_constraint(
+        "uq_movies_trakt_id_media_type", "movies", ["trakt_id", "media_type"]
+    )
+
+
+def downgrade() -> None:
+    op.drop_constraint("uq_movies_trakt_id_media_type", "movies", type_="unique")
+    op.create_unique_constraint("movies_trakt_id_key", "movies", ["trakt_id"])
+    op.drop_index("ix_movies_media_type", table_name="movies")
+    op.drop_column("movies", "media_type")

--- a/backend/routers/duels.py
+++ b/backend/routers/duels.py
@@ -35,18 +35,21 @@ async def _sync_ratings_background(
         access_token = result.scalar_one_or_none()
         if not access_token:
             return
-        movies_stmt = select(Movie.id, Movie.trakt_id).where(
+        movies_stmt = select(Movie.id, Movie.trakt_id, Movie.media_type).where(
             Movie.id.in_([movie_a_id, movie_b_id])
         )
         result = await session.execute(movies_stmt)
-        trakt_map = {row.id: row.trakt_id for row in result.all()}
+        rows = result.all()
+        trakt_map = {row.id: row.trakt_id for row in rows}
+        # Both movies in a duel are the same media_type
+        media_type = rows[0].media_type if rows else "movie"
     movie_ratings = []
     if movie_a_id in trakt_map:
         movie_ratings.append((trakt_map[movie_a_id], new_elo_a))
     if movie_b_id in trakt_map:
         movie_ratings.append((trakt_map[movie_b_id], new_elo_b))
     if movie_ratings:
-        await sync_post_duel(access_token, movie_ratings)
+        await sync_post_duel(access_token, movie_ratings, media_type)
 
 
 @router.post("", response_model=DuelResult)

--- a/backend/routers/duels.py
+++ b/backend/routers/duels.py
@@ -29,27 +29,30 @@ async def _sync_ratings_background(
     new_elo_b: int,
 ) -> None:
     """Fire-and-forget Trakt rating sync after a duel with a winner."""
-    async with async_session_factory() as session:
-        user_stmt = select(User.trakt_access_token).where(User.id == user_id)
-        result = await session.execute(user_stmt)
-        access_token = result.scalar_one_or_none()
-        if not access_token:
-            return
-        movies_stmt = select(Movie.id, Movie.trakt_id, Movie.media_type).where(
-            Movie.id.in_([movie_a_id, movie_b_id])
-        )
-        result = await session.execute(movies_stmt)
-        rows = result.all()
-        trakt_map = {row.id: row.trakt_id for row in rows}
-        # Both movies in a duel are the same media_type
-        media_type = rows[0].media_type if rows else "movie"
-    movie_ratings = []
-    if movie_a_id in trakt_map:
-        movie_ratings.append((trakt_map[movie_a_id], new_elo_a))
-    if movie_b_id in trakt_map:
-        movie_ratings.append((trakt_map[movie_b_id], new_elo_b))
-    if movie_ratings:
-        await sync_post_duel(access_token, movie_ratings, media_type)
+    try:
+        async with async_session_factory() as session:
+            user_stmt = select(User.trakt_access_token).where(User.id == user_id)
+            result = await session.execute(user_stmt)
+            access_token = result.scalar_one_or_none()
+            if not access_token:
+                return
+            movies_stmt = select(Movie.id, Movie.trakt_id, Movie.media_type).where(
+                Movie.id.in_([movie_a_id, movie_b_id])
+            )
+            result = await session.execute(movies_stmt)
+            rows = result.all()
+            trakt_map = {row.id: row.trakt_id for row in rows}
+            # Both movies in a duel are the same media_type
+            media_type = rows[0].media_type if rows else "movie"
+        movie_ratings = []
+        if movie_a_id in trakt_map:
+            movie_ratings.append((trakt_map[movie_a_id], new_elo_a))
+        if movie_b_id in trakt_map:
+            movie_ratings.append((trakt_map[movie_b_id], new_elo_b))
+        if movie_ratings:
+            await sync_post_duel(access_token, movie_ratings, media_type)
+    except Exception:
+        logger.exception("Background rating sync failed for user %s", user_id)
 
 
 @router.post("", response_model=DuelResult)

--- a/backend/routers/movies.py
+++ b/backend/routers/movies.py
@@ -88,6 +88,7 @@ def _user_movie_to_schema(um: UserMovie) -> MovieWithStateSchema:
         poster_url=movie.poster_url,
         overview=movie.overview,
         genres=movie.genres,
+        media_type=movie.media_type,
         seen=um.seen,
         elo=um.elo,
         battles=um.battles,
@@ -119,6 +120,7 @@ def _decode_pair_token(token: str) -> set[str] | None:
 async def get_movie_pair(
     mode: str = Query(default="discovery"),
     last_pair_token: Optional[str] = Query(default=None),
+    media_type: str = Query(default="movie"),
     current_user: User = Depends(get_current_user),
     db: AsyncSession = Depends(get_db),
 ):
@@ -133,7 +135,7 @@ async def get_movie_pair(
     if last_pair_token:
         last_pair_ids = _decode_pair_token(last_pair_token)
 
-    pair = await _select_pair(db, uid, last_pair_ids)
+    pair = await _select_pair(db, uid, last_pair_ids, media_type)
 
     movie_a, movie_b = pair
     schema_a = _user_movie_to_schema(movie_a)
@@ -156,6 +158,7 @@ async def _select_pair(
     db: AsyncSession,
     uid,
     last_pair_ids: set[str] | None,
+    media_type: str = "movie",
 ) -> tuple[UserMovie, UserMovie]:
     """Select a duel pair from seen films with quality band matching.
 
@@ -165,13 +168,15 @@ async def _select_pair(
     4. For ranked-vs-ranked: 70% close matches, 30% wide matches.
     """
 
-    # All seen films
+    # All seen films of the requested media_type
     seen_stmt = (
         select(UserMovie)
         .options(joinedload(UserMovie.movie))
+        .join(Movie, UserMovie.movie_id == Movie.id)
         .where(
             UserMovie.user_id == uid,
             UserMovie.seen.is_(True),
+            Movie.media_type == media_type,
         )
     )
     seen_result = await db.execute(seen_stmt)

--- a/backend/routers/movies.py
+++ b/backend/routers/movies.py
@@ -13,7 +13,7 @@ from sqlalchemy.orm import joinedload
 
 from backend.db import get_db
 from backend.db_models import Movie, User, UserMovie
-from backend.schemas import MovieWithStateSchema, MoviePairResponse
+from backend.schemas import MediaType, MovieWithStateSchema, MoviePairResponse
 from backend.routers.auth import get_current_user
 
 router = APIRouter(prefix="/api/movies", tags=["movies"])
@@ -120,7 +120,7 @@ def _decode_pair_token(token: str) -> set[str] | None:
 async def get_movie_pair(
     mode: str = Query(default="discovery"),
     last_pair_token: Optional[str] = Query(default=None),
-    media_type: str = Query(default="movie"),
+    media_type: MediaType = Query(default="movie"),
     current_user: User = Depends(get_current_user),
     db: AsyncSession = Depends(get_db),
 ):

--- a/backend/routers/rankings.py
+++ b/backend/routers/rankings.py
@@ -37,6 +37,7 @@ def _build_ranked_movie(um: UserMovie, rank: int) -> RankedMovie:
             poster_url=movie.poster_url,
             overview=movie.overview,
             genres=movie.genres,
+            media_type=movie.media_type,
         ),
         elo=um.elo,
         battles=um.battles,
@@ -52,10 +53,12 @@ async def get_rankings(
     offset: int = Query(default=0, ge=0),
     genre: Optional[str] = Query(default=None),
     decade: Optional[str] = Query(default=None),
+    media_type: str = Query(default="movie"),
 ):
-    """Return the user's ranked movies sorted by ELO descending."""
+    """Return the user's ranked movies/shows sorted by ELO descending."""
     user_movies, total = await get_user_rankings(
-        db, current_user.id, genre=genre, decade=decade, limit=limit, offset=offset
+        db, current_user.id, genre=genre, decade=decade, limit=limit, offset=offset,
+        media_type=media_type,
     )
     rankings = [
         _build_ranked_movie(um, rank=offset + i + 1)
@@ -68,9 +71,10 @@ async def get_rankings(
 async def get_stats(
     current_user: User = Depends(get_current_user),
     db: AsyncSession = Depends(get_db),
+    media_type: str = Query(default="movie"),
 ):
     """Return aggregate stats for the user's rankings."""
-    stats = await get_user_stats(db, current_user.id)
+    stats = await get_user_stats(db, current_user.id, media_type=media_type)
 
     if stats["highest_rated"] is None:
         return StatsResponse(
@@ -99,9 +103,10 @@ async def get_stats(
 async def export_csv(
     current_user: User = Depends(get_current_user),
     db: AsyncSession = Depends(get_db),
+    media_type: str = Query(default="movie"),
 ):
     """Export rankings as a Letterboxd-compatible CSV."""
-    csv_content = await export_rankings_csv(db, current_user.id)
+    csv_content = await export_rankings_csv(db, current_user.id, media_type=media_type)
     output = io.StringIO(csv_content)
     return StreamingResponse(
         output,

--- a/backend/routers/rankings.py
+++ b/backend/routers/rankings.py
@@ -11,7 +11,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from backend.db import get_db
 from backend.db_models import User, UserMovie
-from backend.schemas import MovieSchema, RankedMovie, RankingsResponse, StatsResponse
+from backend.schemas import MediaType, MovieSchema, RankedMovie, RankingsResponse, StatsResponse
 from backend.routers.auth import get_current_user
 from backend.services.elo import elo_to_trakt_rating
 from backend.services.rankings import (
@@ -53,7 +53,7 @@ async def get_rankings(
     offset: int = Query(default=0, ge=0),
     genre: Optional[str] = Query(default=None),
     decade: Optional[str] = Query(default=None),
-    media_type: str = Query(default="movie"),
+    media_type: MediaType = Query(default="movie"),
 ):
     """Return the user's ranked movies/shows sorted by ELO descending."""
     user_movies, total = await get_user_rankings(
@@ -71,7 +71,7 @@ async def get_rankings(
 async def get_stats(
     current_user: User = Depends(get_current_user),
     db: AsyncSession = Depends(get_db),
-    media_type: str = Query(default="movie"),
+    media_type: MediaType = Query(default="movie"),
 ):
     """Return aggregate stats for the user's rankings."""
     stats = await get_user_stats(db, current_user.id, media_type=media_type)
@@ -103,7 +103,7 @@ async def get_stats(
 async def export_csv(
     current_user: User = Depends(get_current_user),
     db: AsyncSession = Depends(get_db),
-    media_type: str = Query(default="movie"),
+    media_type: MediaType = Query(default="movie"),
 ):
     """Export rankings as a Letterboxd-compatible CSV."""
     csv_content = await export_rankings_csv(db, current_user.id, media_type=media_type)

--- a/backend/routers/suggestions.py
+++ b/backend/routers/suggestions.py
@@ -40,6 +40,7 @@ def _build_suggestion_schema(s: Suggestion) -> SuggestionSchema:
             year=m.year,
             poster_url=m.poster_url,
             overview=m.overview,
+            media_type=m.media_type,
         ),
         reason=s.reason,
         generated_at=s.generated_at,
@@ -49,9 +50,9 @@ def _build_suggestion_schema(s: Suggestion) -> SuggestionSchema:
 
 
 async def _get_active_suggestions(
-    user_id: uuid.UUID, db: AsyncSession
+    user_id: uuid.UUID, db: AsyncSession, media_type: str = "movie"
 ) -> list[Suggestion]:
-    """Get non-dismissed suggestions for a user."""
+    """Get non-dismissed suggestions for a user, filtered by media_type."""
     stmt = (
         select(Suggestion)
         .options(joinedload(Suggestion.movie))
@@ -60,6 +61,7 @@ async def _get_active_suggestions(
             Suggestion.user_id == user_id,
             Suggestion.dismissed_at.is_(None),
             Movie.poster_url.isnot(None),
+            Movie.media_type == media_type,
         )
         .order_by(Suggestion.generated_at.desc())
     )
@@ -68,10 +70,10 @@ async def _get_active_suggestions(
 
 
 async def _create_suggestions(
-    user_id: uuid.UUID, db: AsyncSession
+    user_id: uuid.UUID, db: AsyncSession, media_type: str = "movie"
 ) -> list[Suggestion]:
     """Generate new suggestions via AI and persist them."""
-    picks = await generate_suggestions(user_id, db)
+    picks = await generate_suggestions(user_id, db, media_type=media_type)
     if not picks:
         return []
 
@@ -89,23 +91,24 @@ async def _create_suggestions(
     await db.flush()
 
     # Reload with movie relationships
-    return await _get_active_suggestions(user_id, db)
+    return await _get_active_suggestions(user_id, db, media_type)
 
 
 @router.get("", response_model=SuggestionsResponse)
 async def get_suggestions(
     current_user: User = Depends(get_current_user),
     db: AsyncSession = Depends(get_db),
+    media_type: str = "movie",
 ):
     """Return current suggestions. Generate if stale (>24h) or missing."""
     uid = current_user.id
 
     # Check if user has enough ranked films
-    if not await has_enough_ranked(uid, db):
+    if not await has_enough_ranked(uid, db, media_type=media_type):
         return SuggestionsResponse(suggestions=[], status="not_enough_films")
 
     # Check existing non-dismissed suggestions
-    active = await _get_active_suggestions(uid, db)
+    active = await _get_active_suggestions(uid, db, media_type)
 
     if active:
         # Check freshness
@@ -119,7 +122,7 @@ async def get_suggestions(
 
     # Stale or none — generate new
     try:
-        new_suggestions = await _create_suggestions(uid, db)
+        new_suggestions = await _create_suggestions(uid, db, media_type)
         if not new_suggestions:
             return SuggestionsResponse(suggestions=[], status="no_candidates")
         return SuggestionsResponse(
@@ -141,11 +144,12 @@ async def get_suggestions(
 async def regenerate_suggestions(
     current_user: User = Depends(get_current_user),
     db: AsyncSession = Depends(get_db),
+    media_type: str = "movie",
 ):
     """Force regeneration. Rate-limited: 3 per day."""
     uid = current_user.id
 
-    if not await has_enough_ranked(uid, db):
+    if not await has_enough_ranked(uid, db, media_type=media_type):
         return SuggestionsResponse(suggestions=[], status="not_enough_films")
 
     # Count regenerations in last 24h (by counting distinct generated_at timestamps)
@@ -167,13 +171,13 @@ async def regenerate_suggestions(
         )
 
     # Dismiss all existing suggestions
-    active = await _get_active_suggestions(uid, db)
+    active = await _get_active_suggestions(uid, db, media_type)
     now = datetime.now(timezone.utc)
     for s in active:
         s.dismissed_at = now
 
     try:
-        new_suggestions = await _create_suggestions(uid, db)
+        new_suggestions = await _create_suggestions(uid, db, media_type)
         if not new_suggestions:
             return SuggestionsResponse(suggestions=[], status="not_enough_films")
         return SuggestionsResponse(

--- a/backend/routers/suggestions.py
+++ b/backend/routers/suggestions.py
@@ -6,7 +6,7 @@ import logging
 import uuid
 from datetime import datetime, timedelta, timezone
 
-from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException
+from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException, Query
 from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import joinedload
@@ -15,7 +15,7 @@ from backend.config import get_settings
 from backend.db import get_db
 from backend.db_models import Movie, Suggestion, User, UserMovie
 from backend.routers.auth import get_current_user
-from backend.schemas import MovieSchema, SuggestionSchema, SuggestionsResponse
+from backend.schemas import MediaType, MovieSchema, SuggestionSchema, SuggestionsResponse
 from backend.services.suggest import generate_suggestions, has_enough_ranked
 from backend.services.trakt import TraktClient
 
@@ -98,7 +98,7 @@ async def _create_suggestions(
 async def get_suggestions(
     current_user: User = Depends(get_current_user),
     db: AsyncSession = Depends(get_db),
-    media_type: str = "movie",
+    media_type: MediaType = Query(default="movie"),
 ):
     """Return current suggestions. Generate if stale (>24h) or missing."""
     uid = current_user.id
@@ -144,7 +144,7 @@ async def get_suggestions(
 async def regenerate_suggestions(
     current_user: User = Depends(get_current_user),
     db: AsyncSession = Depends(get_db),
-    media_type: str = "movie",
+    media_type: MediaType = Query(default="movie"),
 ):
     """Force regeneration. Rate-limited: 3 per day."""
     uid = current_user.id

--- a/backend/routers/swipe.py
+++ b/backend/routers/swipe.py
@@ -6,14 +6,14 @@ import logging
 import uuid
 from datetime import datetime, timezone
 
-from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException
+from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException, Query
 from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from backend.db import get_db
 from backend.db_models import Movie, SwipeResult, User, UserMovie
 from backend.routers.auth import get_current_user
-from backend.schemas import SwipeCardSchema, SwipeResponse, SwipeSubmit
+from backend.schemas import MediaType, SwipeCardSchema, SwipeResponse, SwipeSubmit
 from backend.services.expand import expand_pool
 
 logger = logging.getLogger(__name__)
@@ -48,7 +48,7 @@ def _community_rating_range(band_index: int) -> tuple[float, float]:
 async def get_swipe_cards(
     current_user: User = Depends(get_current_user),
     db: AsyncSession = Depends(get_db),
-    media_type: str = "movie",
+    media_type: MediaType = Query(default="movie"),
 ):
     """Return up to 10 unknown films for a swipe session, weighted by community rating band."""
     uid = current_user.id
@@ -163,7 +163,7 @@ async def submit_swipe_results(
     background_tasks: BackgroundTasks,
     current_user: User = Depends(get_current_user),
     db: AsyncSession = Depends(get_db),
-    media_type: str = "movie",
+    media_type: MediaType = Query(default="movie"),
 ):
     """Submit all swipe results at once — bulk update seen status."""
     uid = current_user.id
@@ -196,11 +196,12 @@ async def submit_swipe_results(
         else:
             unseen_count += 1
 
-    # Check if user has enough seen films to duel
+    # Check if user has enough seen films to duel (scoped by media_type)
     seen_unranked_stmt = (
         select(func.count())
         .select_from(UserMovie)
-        .where(UserMovie.user_id == uid, UserMovie.seen.is_(True), UserMovie.battles == 0)
+        .join(Movie, UserMovie.movie_id == Movie.id)
+        .where(UserMovie.user_id == uid, UserMovie.seen.is_(True), UserMovie.battles == 0, Movie.media_type == media_type)
     )
     seen_unranked = (await db.execute(seen_unranked_stmt)).scalar() or 0
 
@@ -208,17 +209,19 @@ async def submit_swipe_results(
     total_seen_stmt = (
         select(func.count())
         .select_from(UserMovie)
-        .where(UserMovie.user_id == uid, UserMovie.seen.is_(True))
+        .join(Movie, UserMovie.movie_id == Movie.id)
+        .where(UserMovie.user_id == uid, UserMovie.seen.is_(True), Movie.media_type == media_type)
     )
     total_seen = (await db.execute(total_seen_stmt)).scalar() or 0
 
     next_action = "duel" if (total_seen >= 10 and seen_unranked >= 3) else "swipe"
 
-    # Check if pool needs expansion
+    # Check if pool needs expansion (scoped by media_type)
     unknown_stmt = (
         select(func.count())
         .select_from(UserMovie)
-        .where(UserMovie.user_id == uid, UserMovie.seen.is_(None))
+        .join(Movie, UserMovie.movie_id == Movie.id)
+        .where(UserMovie.user_id == uid, UserMovie.seen.is_(None), Movie.media_type == media_type)
     )
     unknown_count = (await db.execute(unknown_stmt)).scalar() or 0
 

--- a/backend/routers/swipe.py
+++ b/backend/routers/swipe.py
@@ -48,19 +48,25 @@ def _community_rating_range(band_index: int) -> tuple[float, float]:
 async def get_swipe_cards(
     current_user: User = Depends(get_current_user),
     db: AsyncSession = Depends(get_db),
+    media_type: str = "movie",
 ):
     """Return up to 10 unknown films for a swipe session, weighted by community rating band."""
     uid = current_user.id
 
-    # Find user's median ELO to determine taste band
-    median_stmt = select(func.percentile_cont(0.5).within_group(UserMovie.elo)).where(
-        UserMovie.user_id == uid,
-        UserMovie.elo.is_not(None),
+    # Find user's median ELO to determine taste band (scoped to media_type)
+    median_stmt = (
+        select(func.percentile_cont(0.5).within_group(UserMovie.elo))
+        .join(Movie, UserMovie.movie_id == Movie.id)
+        .where(
+            UserMovie.user_id == uid,
+            UserMovie.elo.is_not(None),
+            Movie.media_type == media_type,
+        )
     )
     result = await db.execute(median_stmt)
     median_elo = result.scalar_one_or_none()
 
-    # Base query: unknown films for this user (must have poster)
+    # Base query: unknown films for this user (must have poster), filtered by media_type
     base = (
         select(
             Movie.id,
@@ -72,7 +78,12 @@ async def get_swipe_cards(
             Movie.community_rating,
         )
         .join(UserMovie, UserMovie.movie_id == Movie.id)
-        .where(UserMovie.user_id == uid, UserMovie.seen.is_(None), Movie.poster_url.isnot(None))
+        .where(
+            UserMovie.user_id == uid,
+            UserMovie.seen.is_(None),
+            Movie.poster_url.isnot(None),
+            Movie.media_type == media_type,
+        )
     )
 
     if median_elo is None:
@@ -152,6 +163,7 @@ async def submit_swipe_results(
     background_tasks: BackgroundTasks,
     current_user: User = Depends(get_current_user),
     db: AsyncSession = Depends(get_db),
+    media_type: str = "movie",
 ):
     """Submit all swipe results at once — bulk update seen status."""
     uid = current_user.id
@@ -211,6 +223,6 @@ async def submit_swipe_results(
     unknown_count = (await db.execute(unknown_stmt)).scalar() or 0
 
     if unknown_count < 50:
-        background_tasks.add_task(expand_pool, uid)
+        background_tasks.add_task(expand_pool, uid, media_type)
 
     return SwipeResponse(seen_count=seen_count, unseen_count=unseen_count, next_action=next_action)

--- a/backend/routers/tournaments.py
+++ b/backend/routers/tournaments.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import uuid
 from typing import Optional
 
-from fastapi import APIRouter, Depends, HTTPException
+from fastapi import APIRouter, Depends, HTTPException, Query
 from pydantic import BaseModel
 from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -15,6 +15,7 @@ from backend.db import get_db
 from backend.db_models import Movie, Tournament, TournamentMatch, User, UserMovie
 from backend.routers.auth import get_current_user
 from backend.schemas import (
+    MediaType,
     MovieSchema,
     TournamentCreate,
     TournamentListItem,
@@ -117,7 +118,7 @@ async def _load_tournament(
 async def get_available_genres(
     current_user: User = Depends(get_current_user),
     db: AsyncSession = Depends(get_db),
-    media_type: str = "movie",
+    media_type: MediaType = Query(default="movie"),
 ):
     """Return distinct genres from user's seen films for tournament filtering."""
     stmt = (
@@ -143,7 +144,7 @@ async def get_available_genres(
 async def get_pool_count(
     filter_type: Optional[str] = None,
     filter_value: Optional[str] = None,
-    media_type: str = "movie",
+    media_type: MediaType = Query(default="movie"),
     current_user: User = Depends(get_current_user),
     db: AsyncSession = Depends(get_db),
 ):

--- a/backend/routers/tournaments.py
+++ b/backend/routers/tournaments.py
@@ -49,6 +49,7 @@ def _movie_schema(movie: Optional[Movie]) -> Optional[MovieSchema]:
         year=movie.year,
         poster_url=movie.poster_url,
         overview=movie.overview,
+        media_type=movie.media_type,
     )
 
 
@@ -116,6 +117,7 @@ async def _load_tournament(
 async def get_available_genres(
     current_user: User = Depends(get_current_user),
     db: AsyncSession = Depends(get_db),
+    media_type: str = "movie",
 ):
     """Return distinct genres from user's seen films for tournament filtering."""
     stmt = (
@@ -128,6 +130,7 @@ async def get_available_genres(
             UserMovie.battles >= 1,
             UserMovie.elo.isnot(None),
             Movie.genres.isnot(None),
+            Movie.media_type == media_type,
         )
         .distinct()
         .order_by("genre")
@@ -140,13 +143,14 @@ async def get_available_genres(
 async def get_pool_count(
     filter_type: Optional[str] = None,
     filter_value: Optional[str] = None,
+    media_type: str = "movie",
     current_user: User = Depends(get_current_user),
     db: AsyncSession = Depends(get_db),
 ):
     """Return number of ranked films matching the given filter."""
     try:
         user_movies = await get_filtered_ranked_films(
-            db, current_user.id, filter_type, filter_value,
+            db, current_user.id, filter_type, filter_value, media_type=media_type,
         )
     except ValueError:
         return {"count": 0}
@@ -164,7 +168,7 @@ async def create_tournament(
 
     try:
         user_movies = await get_filtered_ranked_films(
-            db, uid, body.filter_type, body.filter_value,
+            db, uid, body.filter_type, body.filter_value, media_type=body.media_type,
         )
     except ValueError:
         raise HTTPException(status_code=400, detail="Invalid decade format")

--- a/backend/schemas.py
+++ b/backend/schemas.py
@@ -15,6 +15,9 @@ class UserResponse(BaseModel):
     created_at: datetime
 
 
+MediaType = Literal["movie", "show"]
+
+
 class MovieSchema(BaseModel):
     id: str
     trakt_id: int
@@ -25,6 +28,7 @@ class MovieSchema(BaseModel):
     poster_url: Optional[str] = None
     overview: Optional[str] = None
     genres: Optional[list[str]] = None
+    media_type: str = "movie"
 
 
 class MovieWithStateSchema(MovieSchema):
@@ -121,6 +125,7 @@ class TournamentCreate(BaseModel):
     filter_value: Optional[str] = None
     bracket_size: Literal[8, 16, 32, 64]
     ai_curated: bool = False
+    media_type: str = "movie"
 
 
 class TournamentMatchSchema(BaseModel):

--- a/backend/services/expand.py
+++ b/backend/services/expand.py
@@ -1,4 +1,4 @@
-"""Background pool expansion — fetch more movies when the swipe pool runs low."""
+"""Background pool expansion — fetch more movies/shows when the swipe pool runs low."""
 
 from __future__ import annotations
 
@@ -80,7 +80,7 @@ async def _expand_pool_inner(user_id: uuid.UUID, media_type: str = "movie") -> i
             total_added += added
 
         # Source C: Trakt anticipated
-        if total_added < TARGET_ADDED and ("anticipated", None) not in recent_keys:
+        if total_added < TARGET_ADDED and ("anticipated", media_type) not in recent_keys:
             added = await _expand_from_anticipated(
                 db, user_id, user, settings, recent_keys, now, media_type
             )
@@ -218,7 +218,7 @@ async def _expand_from_anticipated(
     now: datetime,
     media_type: str = "movie",
 ) -> int:
-    """Source B: Trakt anticipated movies/shows."""
+    """Source C: Trakt anticipated movies/shows."""
     client = TraktClient(
         client_id=settings.TRAKT_CLIENT_ID,
         access_token=user.trakt_access_token,
@@ -265,7 +265,7 @@ async def _expand_from_popular_pages(
     now: datetime,
     media_type: str = "movie",
 ) -> int:
-    """Source C: Deeper pages of Trakt popular movies/shows."""
+    """Source D: Deeper pages of Trakt popular movies/shows."""
     client = TraktClient(
         client_id=settings.TRAKT_CLIENT_ID,
         access_token=user.trakt_access_token,

--- a/backend/services/expand.py
+++ b/backend/services/expand.py
@@ -25,20 +25,20 @@ EXPANSION_COOLDOWN = timedelta(days=7)
 TARGET_ADDED = 100
 
 
-async def expand_pool(user_id: uuid.UUID) -> int:
-    """Expand a user's movie pool. Returns count of films added.
+async def expand_pool(user_id: uuid.UUID, media_type: str = "movie") -> int:
+    """Expand a user's movie/show pool. Returns count of films added.
 
     Runs in a background task with its own DB session.
     """
     try:
-        return await _expand_pool_inner(user_id)
+        return await _expand_pool_inner(user_id, media_type)
     except Exception:
         logger.exception("Pool expansion failed for user %s", user_id)
         sentry_sdk.capture_exception()
         return 0
 
 
-async def _expand_pool_inner(user_id: uuid.UUID) -> int:
+async def _expand_pool_inner(user_id: uuid.UUID, media_type: str = "movie") -> int:
     settings = get_settings()
     total_added = 0
 
@@ -68,12 +68,12 @@ async def _expand_pool_inner(user_id: uuid.UUID) -> int:
         # Source A: Trakt personalized recommendations (highest quality)
         if total_added < TARGET_ADDED:
             added = await _expand_from_recommendations(
-                db, user_id, user, settings, recent_keys, now
+                db, user_id, user, settings, recent_keys, now, media_type
             )
             total_added += added
 
-        # Source B: TMDB similar films from top-ranked movies
-        if total_added < TARGET_ADDED:
+        # Source B: TMDB similar films from top-ranked items (movies only)
+        if total_added < TARGET_ADDED and media_type == "movie":
             added = await _expand_from_similar(
                 db, user_id, settings, recent_keys, now
             )
@@ -82,14 +82,14 @@ async def _expand_pool_inner(user_id: uuid.UUID) -> int:
         # Source C: Trakt anticipated
         if total_added < TARGET_ADDED and ("anticipated", None) not in recent_keys:
             added = await _expand_from_anticipated(
-                db, user_id, user, settings, recent_keys, now
+                db, user_id, user, settings, recent_keys, now, media_type
             )
             total_added += added
 
         # Source D: Deeper popular pages
         if total_added < TARGET_ADDED:
             added = await _expand_from_popular_pages(
-                db, user_id, user, settings, recent_keys, now
+                db, user_id, user, settings, recent_keys, now, media_type
             )
             total_added += added
 
@@ -113,9 +113,11 @@ async def _expand_from_recommendations(
     settings,
     recent_keys: set[tuple[str, str | None]],
     now: datetime,
+    media_type: str = "movie",
 ) -> int:
     """Source A: Trakt personalized recommendations."""
-    if ("trakt_recommendations", "default") in recent_keys:
+    source_key = f"{media_type}_default"
+    if ("trakt_recommendations", source_key) in recent_keys:
         return 0
 
     client = TraktClient(
@@ -123,21 +125,24 @@ async def _expand_from_recommendations(
         access_token=user.trakt_access_token,
     )
     try:
-        recs = await client.get_recommendations(limit=100)
+        if media_type == "show":
+            recs = await client.get_recommendations_shows(limit=100)
+        else:
+            recs = await client.get_recommendations(limit=100)
     except Exception:
-        logger.exception("Failed to fetch Trakt recommendations")
+        logger.exception("Failed to fetch Trakt recommendations (%s)", media_type)
         return 0
 
     added = 0
-    for movie in recs:
-        ok = await _upsert_film_from_trakt(db, user_id, movie, now)
+    for item in recs:
+        ok = await _upsert_film_from_trakt(db, user_id, item, now, media_type)
         if ok:
             added += 1
 
     db.add(PoolExpansion(
         user_id=user_id,
         source="trakt_recommendations",
-        source_key="default",
+        source_key=source_key,
         films_added=added,
         ran_at=now,
     ))
@@ -211,36 +216,39 @@ async def _expand_from_anticipated(
     settings,
     recent_keys: set[tuple[str, str | None]],
     now: datetime,
+    media_type: str = "movie",
 ) -> int:
-    """Source B: Trakt anticipated movies."""
+    """Source B: Trakt anticipated movies/shows."""
     client = TraktClient(
         client_id=settings.TRAKT_CLIENT_ID,
         access_token=user.trakt_access_token,
     )
+    endpoint = "/shows/anticipated" if media_type == "show" else "/movies/anticipated"
+    item_key = "show" if media_type == "show" else "movie"
     try:
         async with client._client() as http:
             resp = await http.get(
-                "/movies/anticipated",
+                endpoint,
                 params={"limit": 100, "extended": "full"},
                 timeout=15.0,
             )
             resp.raise_for_status()
             items = resp.json()
     except Exception:
-        logger.exception("Failed to fetch anticipated movies")
+        logger.exception("Failed to fetch anticipated %ss", media_type)
         return 0
 
     added = 0
     for item in items:
-        movie_data = item.get("movie", item)
-        ok = await _upsert_film_from_trakt(db, user_id, movie_data, now)
+        data = item.get(item_key, item)
+        ok = await _upsert_film_from_trakt(db, user_id, data, now, media_type)
         if ok:
             added += 1
 
     db.add(PoolExpansion(
         user_id=user_id,
         source="anticipated",
-        source_key=None,
+        source_key=media_type,
         films_added=added,
         ran_at=now,
     ))
@@ -255,40 +263,43 @@ async def _expand_from_popular_pages(
     settings,
     recent_keys: set[tuple[str, str | None]],
     now: datetime,
+    media_type: str = "movie",
 ) -> int:
-    """Source C: Deeper pages of Trakt popular movies."""
+    """Source C: Deeper pages of Trakt popular movies/shows."""
     client = TraktClient(
         client_id=settings.TRAKT_CLIENT_ID,
         access_token=user.trakt_access_token,
     )
+    endpoint = "/shows/popular" if media_type == "show" else "/movies/popular"
+    source = f"popular_page_N_{media_type}"
     total = 0
     for page in range(2, 6):
         source_key = str(page)
-        if ("popular_page_N", source_key) in recent_keys:
+        if (source, source_key) in recent_keys:
             continue
 
         try:
             async with client._client() as http:
                 resp = await http.get(
-                    "/movies/popular",
+                    endpoint,
                     params={"page": page, "limit": 100, "extended": "full"},
                     timeout=15.0,
                 )
                 resp.raise_for_status()
-                movies = resp.json()
+                items = resp.json()
         except Exception:
-            logger.exception("Failed to fetch popular page %d", page)
+            logger.exception("Failed to fetch popular %s page %d", media_type, page)
             continue
 
         added = 0
-        for movie_data in movies:
-            ok = await _upsert_film_from_trakt(db, user_id, movie_data, now)
+        for item_data in items:
+            ok = await _upsert_film_from_trakt(db, user_id, item_data, now, media_type)
             if ok:
                 added += 1
 
         db.add(PoolExpansion(
             user_id=user_id,
-            source="popular_page_N",
+            source=source,
             source_key=source_key,
             films_added=added,
             ran_at=now,
@@ -307,8 +318,9 @@ async def _upsert_film_from_trakt(
     user_id: uuid.UUID,
     movie_data: dict,
     now: datetime,
+    media_type: str = "movie",
 ) -> bool:
-    """Upsert a Trakt movie dict into movies + user_movies. Returns True if new user_movie created."""
+    """Upsert a Trakt movie/show dict into movies + user_movies. Returns True if new user_movie created."""
     ids = movie_data.get("ids", {})
     trakt_id = ids.get("trakt")
     if not trakt_id:
@@ -319,6 +331,7 @@ async def _upsert_film_from_trakt(
 
     stmt = insert(Movie.__table__).values(
         trakt_id=trakt_id,
+        media_type=media_type,
         imdb_id=ids.get("imdb"),
         tmdb_id=ids.get("tmdb"),
         title=movie_data.get("title", "Unknown"),
@@ -329,7 +342,7 @@ async def _upsert_film_from_trakt(
         community_rating=community_rating,
         cached_at=now,
     ).on_conflict_do_update(
-        index_elements=["trakt_id"],
+        index_elements=["trakt_id", "media_type"],
         set_={
             "imdb_id": ids.get("imdb"),
             "tmdb_id": ids.get("tmdb"),
@@ -345,15 +358,13 @@ async def _upsert_film_from_trakt(
     await db.execute(stmt)
     await db.flush()
 
-    # Get movie UUID
     result = await db.execute(
-        select(Movie.id).where(Movie.trakt_id == trakt_id)
+        select(Movie.id).where(Movie.trakt_id == trakt_id, Movie.media_type == media_type)
     )
     movie_uuid = result.scalar_one_or_none()
     if not movie_uuid:
         return False
 
-    # Insert user_movie only if not exists (seen=None = unknown)
     um_stmt = insert(UserMovie.__table__).values(
         user_id=user_id,
         movie_id=movie_uuid,
@@ -407,9 +418,10 @@ async def _upsert_film_from_tmdb(
     if not trakt_id:
         return False
 
-    # Upsert the movie
+    # Upsert the movie (TMDB expansion is movies-only, so media_type="movie")
     stmt = insert(Movie.__table__).values(
         trakt_id=trakt_id,
+        media_type="movie",
         tmdb_id=tmdb_id,
         title=film.get("title", "Unknown"),
         year=film.get("year"),
@@ -417,7 +429,7 @@ async def _upsert_film_from_tmdb(
         overview=film.get("overview"),
         cached_at=now,
     ).on_conflict_do_update(
-        index_elements=["trakt_id"],
+        index_elements=["trakt_id", "media_type"],
         set_={
             "tmdb_id": tmdb_id,
             "title": film.get("title", "Unknown"),
@@ -431,7 +443,7 @@ async def _upsert_film_from_tmdb(
     await db.flush()
 
     movie_result = await db.execute(
-        select(Movie.id).where(Movie.trakt_id == trakt_id)
+        select(Movie.id).where(Movie.trakt_id == trakt_id, Movie.media_type == "movie")
     )
     movie_uuid = movie_result.scalar_one_or_none()
     if not movie_uuid:

--- a/backend/services/pool.py
+++ b/backend/services/pool.py
@@ -20,7 +20,7 @@ SYNC_COOLDOWN = timedelta(hours=1)
 
 
 async def populate_movie_pool(user: User, db: AsyncSession) -> None:
-    """Fetch movies from Trakt and populate the user's movie pool.
+    """Fetch movies and shows from Trakt and populate the user's pool.
 
     Called on login/session start. Throttled to once per hour.
     """
@@ -38,7 +38,7 @@ async def populate_movie_pool(user: User, db: AsyncSession) -> None:
         access_token=user.trakt_access_token,
     )
 
-    # Fetch all sources (serial to respect Trakt rate limits, graceful on failure)
+    # ── Movies ──────────────────────────────────────────────────────
     try:
         popular = await client.get_popular(limit=100)
     except Exception:
@@ -65,13 +65,10 @@ async def populate_movie_pool(user: User, db: AsyncSession) -> None:
         logger.exception("Failed to fetch ratings for %s", user.trakt_user_id)
         ratings_list = []
 
-    # Build ratings lookup: trakt_id -> rating (1-10)
     ratings_by_trakt_id: dict[int, int] = {
         r["trakt_id"]: r["rating"] for r in ratings_list
     }
 
-    # Collect all unique movies, tracking their source
-    # movie_data keyed by trakt_id -> (movie_dict, seen)
     movie_pool: dict[int, dict] = {}
     seen_trakt_ids: set[int] = set()
 
@@ -86,36 +83,106 @@ async def populate_movie_pool(user: User, db: AsyncSession) -> None:
         if trakt_id not in movie_pool:
             movie_pool[trakt_id] = movie
 
-    if not movie_pool:
-        logger.info("No movies fetched for %s", user.trakt_username)
+    await _upsert_pool(db, user, movie_pool, seen_trakt_ids, ratings_by_trakt_id, "movie", now)
+
+    # ── TV Shows ────────────────────────────────────────────────────
+    try:
+        popular_shows = await client.get_popular_shows(limit=100)
+    except Exception:
+        logger.exception("Failed to fetch popular shows")
+        popular_shows = []
+    try:
+        trending_shows = await client.get_trending_shows(limit=100)
+    except Exception:
+        logger.exception("Failed to fetch trending shows")
+        trending_shows = []
+    try:
+        recommended_shows = await client.get_recommendations_shows(limit=100)
+    except Exception:
+        logger.exception("Failed to fetch show recommendations")
+        recommended_shows = []
+    try:
+        watched_shows = await client.get_user_watched_shows(user.trakt_user_id)
+    except Exception:
+        logger.exception("Failed to fetch watched shows for %s", user.trakt_user_id)
+        watched_shows = []
+    try:
+        show_ratings_list = await client.get_user_ratings_shows(user.trakt_user_id)
+    except Exception:
+        logger.exception("Failed to fetch show ratings for %s", user.trakt_user_id)
+        show_ratings_list = []
+
+    show_ratings_by_trakt_id: dict[int, int] = {
+        r["trakt_id"]: r["rating"] for r in show_ratings_list
+    }
+
+    show_pool: dict[int, dict] = {}
+    seen_show_trakt_ids: set[int] = set()
+
+    for show in popular_shows + trending_shows + recommended_shows:
+        trakt_id = show["ids"]["trakt"]
+        if trakt_id not in show_pool:
+            show_pool[trakt_id] = show
+
+    for show in watched_shows:
+        trakt_id = show["ids"]["trakt"]
+        seen_show_trakt_ids.add(trakt_id)
+        if trakt_id not in show_pool:
+            show_pool[trakt_id] = show
+
+    await _upsert_pool(db, user, show_pool, seen_show_trakt_ids, show_ratings_by_trakt_id, "show", now)
+
+    # Update last_seen_at
+    user.last_seen_at = now
+    await db.flush()
+
+    logger.info(
+        "Pool sync complete for %s: %d movies + %d shows imported",
+        user.trakt_username,
+        len(movie_pool),
+        len(show_pool),
+    )
+
+
+async def _upsert_pool(
+    db: AsyncSession,
+    user: User,
+    pool: dict[int, dict],
+    seen_trakt_ids: set[int],
+    ratings_by_trakt_id: dict[int, int],
+    media_type: str,
+    now: datetime,
+) -> None:
+    """Upsert a pool of movies or shows into the DB."""
+    if not pool:
         return
 
-    # Upsert movies into the movies table
-    for movie_data in movie_pool.values():
-        ids = movie_data.get("ids", {})
-        trakt_rating = movie_data.get("rating", 0)
+    for item_data in pool.values():
+        ids = item_data.get("ids", {})
+        trakt_rating = item_data.get("rating", 0)
         community_rating = round(trakt_rating * 10, 1) if trakt_rating else None
         stmt = insert(Movie.__table__).values(
             trakt_id=ids["trakt"],
+            media_type=media_type,
             imdb_id=ids.get("imdb"),
             tmdb_id=ids.get("tmdb"),
-            title=movie_data.get("title", "Unknown"),
-            year=movie_data.get("year"),
-            genres=movie_data.get("genres"),
-            overview=movie_data.get("overview"),
-            runtime=movie_data.get("runtime"),
+            title=item_data.get("title", "Unknown"),
+            year=item_data.get("year"),
+            genres=item_data.get("genres"),
+            overview=item_data.get("overview"),
+            runtime=item_data.get("runtime"),
             community_rating=community_rating,
             cached_at=now,
         ).on_conflict_do_update(
-            index_elements=["trakt_id"],
+            index_elements=["trakt_id", "media_type"],
             set_={
                 "imdb_id": ids.get("imdb"),
                 "tmdb_id": ids.get("tmdb"),
-                "title": movie_data.get("title", "Unknown"),
-                "year": movie_data.get("year"),
-                "genres": movie_data.get("genres"),
-                "overview": movie_data.get("overview"),
-                "runtime": movie_data.get("runtime"),
+                "title": item_data.get("title", "Unknown"),
+                "year": item_data.get("year"),
+                "genres": item_data.get("genres"),
+                "overview": item_data.get("overview"),
+                "runtime": item_data.get("runtime"),
                 "community_rating": community_rating,
                 "cached_at": now,
             },
@@ -124,16 +191,17 @@ async def populate_movie_pool(user: User, db: AsyncSession) -> None:
 
     await db.flush()
 
-    # Fetch all movie rows we just upserted to get their UUIDs
-    trakt_ids = list(movie_pool.keys())
+    trakt_ids = list(pool.keys())
     result = await db.execute(
-        select(Movie.id, Movie.trakt_id).where(Movie.trakt_id.in_(trakt_ids))
+        select(Movie.id, Movie.trakt_id).where(
+            Movie.trakt_id.in_(trakt_ids),
+            Movie.media_type == media_type,
+        )
     )
-    movie_uuid_map: dict[int, str] = {row.trakt_id: row.id for row in result.all()}
+    uuid_map: dict[int, str] = {row.trakt_id: row.id for row in result.all()}
 
-    # Upsert user_movies
-    for trakt_id, movie_data in movie_pool.items():
-        movie_uuid = movie_uuid_map.get(trakt_id)
+    for trakt_id, item_data in pool.items():
+        movie_uuid = uuid_map.get(trakt_id)
         if not movie_uuid:
             continue
 
@@ -153,9 +221,7 @@ async def populate_movie_pool(user: User, db: AsyncSession) -> None:
         ).on_conflict_do_update(
             index_elements=["user_id", "movie_id"],
             set_={
-                # Update seen if we now know they watched it
                 "seen": seen if seen is True else UserMovie.__table__.c.seen,
-                # Update seeded_elo and rating if we have new data
                 "seeded_elo": seeded_elo
                 if seeded_elo is not None
                 else UserMovie.__table__.c.seeded_elo,
@@ -167,12 +233,4 @@ async def populate_movie_pool(user: User, db: AsyncSession) -> None:
         )
         await db.execute(stmt)
 
-    # Update last_seen_at
-    user.last_seen_at = now
     await db.flush()
-
-    logger.info(
-        "Pool sync complete for %s: %d movies imported",
-        user.trakt_username,
-        len(movie_pool),
-    )

--- a/backend/services/rankings.py
+++ b/backend/services/rankings.py
@@ -32,10 +32,11 @@ async def get_user_rankings(
     decade: Optional[str] = None,
     limit: int = 50,
     offset: int = 0,
+    media_type: str = "movie",
 ) -> tuple[list[UserMovie], int]:
     """Return (ranked user_movies with loaded movies, total count).
 
-    Filters: seen=True, battles>0, optional genre, optional decade.
+    Filters: seen=True, battles>0, media_type, optional genre, optional decade.
     Ordered by ELO descending.
     """
     base_filters = [
@@ -44,21 +45,19 @@ async def get_user_rankings(
         UserMovie.battles > 0,
     ]
 
+    # Always join Movie for media_type filter
     stmt = (
         select(UserMovie)
         .options(joinedload(UserMovie.movie))
-        .where(*base_filters)
+        .join(Movie, UserMovie.movie_id == Movie.id)
+        .where(*base_filters, Movie.media_type == media_type)
     )
     count_stmt = (
         select(func.count())
         .select_from(UserMovie)
-        .where(*base_filters)
+        .join(Movie, UserMovie.movie_id == Movie.id)
+        .where(*base_filters, Movie.media_type == media_type)
     )
-
-    needs_movie_join = genre is not None or decade is not None
-    if needs_movie_join:
-        stmt = stmt.join(Movie, UserMovie.movie_id == Movie.id)
-        count_stmt = count_stmt.join(Movie, UserMovie.movie_id == Movie.id)
 
     if genre:
         stmt = stmt.where(Movie.genres.any(genre))
@@ -80,7 +79,7 @@ async def get_user_rankings(
     return user_movies, total
 
 
-async def get_user_stats(db: AsyncSession, user_id: uuid.UUID) -> dict:
+async def get_user_stats(db: AsyncSession, user_id: uuid.UUID, media_type: str = "movie") -> dict:
     """Return aggregate stats for the user's rankings.
 
     Returns dict with keys: total_duels, total_movies_ranked, unseen_count,
@@ -89,10 +88,12 @@ async def get_user_stats(db: AsyncSession, user_id: uuid.UUID) -> dict:
     stmt = (
         select(UserMovie)
         .options(joinedload(UserMovie.movie))
+        .join(Movie, UserMovie.movie_id == Movie.id)
         .where(
             UserMovie.user_id == user_id,
             UserMovie.seen.is_(True),
             UserMovie.battles > 0,
+            Movie.media_type == media_type,
         )
         .order_by(UserMovie.elo.desc())
     )
@@ -102,7 +103,8 @@ async def get_user_stats(db: AsyncSession, user_id: uuid.UUID) -> dict:
     unseen_stmt = (
         select(func.count())
         .select_from(UserMovie)
-        .where(UserMovie.user_id == user_id, UserMovie.seen.is_(False))
+        .join(Movie, UserMovie.movie_id == Movie.id)
+        .where(UserMovie.user_id == user_id, UserMovie.seen.is_(False), Movie.media_type == media_type)
     )
     unseen_result = await db.execute(unseen_stmt)
     unseen_count = unseen_result.scalar() or 0
@@ -130,15 +132,17 @@ async def get_user_stats(db: AsyncSession, user_id: uuid.UUID) -> dict:
     }
 
 
-async def export_rankings_csv(db: AsyncSession, user_id: uuid.UUID) -> str:
+async def export_rankings_csv(db: AsyncSession, user_id: uuid.UUID, media_type: str = "movie") -> str:
     """Return CSV string content for Letterboxd export."""
     stmt = (
         select(UserMovie)
         .options(joinedload(UserMovie.movie))
+        .join(Movie, UserMovie.movie_id == Movie.id)
         .where(
             UserMovie.user_id == user_id,
             UserMovie.seen.is_(True),
             UserMovie.battles > 0,
+            Movie.media_type == media_type,
         )
         .order_by(UserMovie.elo.desc())
     )

--- a/backend/services/suggest.py
+++ b/backend/services/suggest.py
@@ -25,18 +25,19 @@ CANDIDATE_LIMIT = 50
 
 
 async def _build_taste_profile(
-    user_id: uuid.UUID, db: AsyncSession
+    user_id: uuid.UUID, db: AsyncSession, media_type: str = "movie"
 ) -> dict | None:
     """Return taste profile dict, or None if the user has < MIN_RANKED films."""
-    # Ranked films: seen=true, battles>=1, elo not null
     ranked_stmt = (
         select(UserMovie)
         .options(joinedload(UserMovie.movie))
+        .join(Movie, UserMovie.movie_id == Movie.id)
         .where(
             UserMovie.user_id == user_id,
             UserMovie.seen.is_(True),
             UserMovie.battles >= 1,
             UserMovie.elo.isnot(None),
+            Movie.media_type == media_type,
         )
         .order_by(UserMovie.elo.desc())
     )
@@ -84,10 +85,9 @@ async def _build_taste_profile(
 
 
 async def _get_candidates(
-    user_id: uuid.UUID, db: AsyncSession
+    user_id: uuid.UUID, db: AsyncSession, media_type: str = "movie"
 ) -> list[dict]:
     """Get 40-60 unknown films (seen=NULL) as candidates, preferring ones with posters."""
-    # Films where user has no user_movie row OR seen is NULL
     stmt = (
         select(UserMovie)
         .options(joinedload(UserMovie.movie))
@@ -96,6 +96,7 @@ async def _get_candidates(
             UserMovie.user_id == user_id,
             UserMovie.seen.is_(None),
             Movie.poster_url.isnot(None),
+            Movie.media_type == media_type,
         )
         .order_by(
             # By community rating
@@ -170,7 +171,7 @@ async def _call_llm(taste_profile: dict, candidates: list[dict]) -> list[dict]:
 
 
 async def generate_suggestions(
-    user_id: uuid.UUID, db: AsyncSession
+    user_id: uuid.UUID, db: AsyncSession, media_type: str = "movie"
 ) -> list[dict]:
     """Generate 6 personalized film suggestions.
 
@@ -178,11 +179,11 @@ async def generate_suggestions(
     Raises ValueError if LLM_API_KEY is not set.
     Returns empty list if user has < MIN_RANKED films (caller should check taste_profile).
     """
-    taste_profile = await _build_taste_profile(user_id, db)
+    taste_profile = await _build_taste_profile(user_id, db, media_type)
     if taste_profile is None:
         return []
 
-    candidates = await _get_candidates(user_id, db)
+    candidates = await _get_candidates(user_id, db, media_type)
     if len(candidates) < NUM_PICKS:
         logger.warning(
             "User %s has only %d candidate films, need at least %d",
@@ -211,16 +212,18 @@ async def generate_suggestions(
     return results
 
 
-async def has_enough_ranked(user_id: uuid.UUID, db: AsyncSession) -> bool:
-    """Check if user has at least MIN_RANKED ranked films."""
+async def has_enough_ranked(user_id: uuid.UUID, db: AsyncSession, media_type: str = "movie") -> bool:
+    """Check if user has at least MIN_RANKED ranked films of the given type."""
     count_stmt = (
         select(func.count())
         .select_from(UserMovie)
+        .join(Movie, UserMovie.movie_id == Movie.id)
         .where(
             UserMovie.user_id == user_id,
             UserMovie.seen.is_(True),
             UserMovie.battles >= 1,
             UserMovie.elo.isnot(None),
+            Movie.media_type == media_type,
         )
     )
     result = await db.execute(count_stmt)

--- a/backend/services/sync.py
+++ b/backend/services/sync.py
@@ -19,11 +19,14 @@ from backend.services.trakt import TraktClient
 logger = logging.getLogger(__name__)
 
 
-async def _rate_with_retry(client: TraktClient, trakt_id: int, rating: int) -> None:
+async def _rate_with_retry(client: TraktClient, trakt_id: int, rating: int, media_type: str = "movie") -> None:
     """Submit a single rating to Trakt, retrying once on 5xx."""
     for attempt in range(2):
         try:
-            await client.rate_movie(trakt_id, rating)
+            if media_type == "show":
+                await client.rate_show(trakt_id, rating)
+            else:
+                await client.rate_movie(trakt_id, rating)
             return
         except httpx.HTTPStatusError as exc:
             status = exc.response.status_code
@@ -44,18 +47,20 @@ async def _rate_with_retry(client: TraktClient, trakt_id: int, rating: int) -> N
 async def sync_post_duel(
     access_token: str,
     movie_ratings: list[tuple[int, int]],
+    media_type: str = "movie",
 ) -> None:
-    """Fire-and-forget: sync two specific movie ratings to Trakt after a duel.
+    """Fire-and-forget: sync two specific movie/show ratings to Trakt after a duel.
 
     Args:
         access_token: User's current Trakt access token.
         movie_ratings: List of (trakt_id, elo) pairs to sync.
+        media_type: "movie" or "show".
     """
     settings = get_settings()
     client = TraktClient(client_id=settings.TRAKT_CLIENT_ID, access_token=access_token)
     for trakt_id, elo in movie_ratings:
         rating = elo_to_trakt_rating(elo)
-        await _rate_with_retry(client, trakt_id, rating)
+        await _rate_with_retry(client, trakt_id, rating, media_type)
 
 
 async def sync_ratings_to_trakt(
@@ -91,7 +96,10 @@ async def sync_ratings_to_trakt(
     for um in user_movies:
         trakt_rating = elo_to_trakt_rating(um.elo)
         try:
-            await client.rate_movie(um.movie.trakt_id, trakt_rating)
+            if um.movie.media_type == "show":
+                await client.rate_show(um.movie.trakt_id, trakt_rating)
+            else:
+                await client.rate_movie(um.movie.trakt_id, trakt_rating)
             synced += 1
         except Exception:
             logger.exception(

--- a/backend/services/tmdb.py
+++ b/backend/services/tmdb.py
@@ -44,6 +44,26 @@ TMDB_GENRE_MAP: dict[int, str] = {
 }
 
 
+async def fetch_tv_poster_url(tmdb_id: int) -> str | None:
+    """Fetch poster URL from TMDB API for a TV show. Returns full URL or None."""
+    settings = get_settings()
+    if not settings.TMDB_API_KEY or not tmdb_id:
+        return None
+    async with httpx.AsyncClient() as client:
+        resp = await client.get(
+            f"https://api.themoviedb.org/3/tv/{tmdb_id}",
+            params={"api_key": settings.TMDB_API_KEY},
+        )
+        if resp.status_code != 200:
+            logger.warning("TMDB TV API returned %d for tmdb_id=%d", resp.status_code, tmdb_id)
+            return None
+        data = resp.json()
+        poster_path = data.get("poster_path")
+        if poster_path:
+            return f"https://image.tmdb.org/t/p/w500{poster_path}"
+        return None
+
+
 async def fetch_similar_films(tmdb_id: int, api_key: str) -> list[dict]:
     """Fetch recommended films from TMDB for a given movie.
 
@@ -87,24 +107,27 @@ async def fetch_similar_films(tmdb_id: int, api_key: str) -> list[dict]:
 
 
 async def backfill_posters(db: AsyncSession) -> None:
-    """Fetch poster URLs for movies that have tmdb_id but no poster_url."""
+    """Fetch poster URLs for movies/shows that have tmdb_id but no poster_url."""
     stmt = (
         select(Movie)
         .where(Movie.tmdb_id.isnot(None), Movie.poster_url.is_(None))
         .limit(50)
     )
     result = await db.execute(stmt)
-    movies = result.scalars().all()
+    items = result.scalars().all()
 
-    if not movies:
+    if not items:
         return
 
-    logger.info("Backfilling posters for %d movies", len(movies))
+    logger.info("Backfilling posters for %d items", len(items))
     filled = 0
-    for movie in movies:
-        url = await fetch_poster_url(movie.tmdb_id)
+    for item in items:
+        if item.media_type == "show":
+            url = await fetch_tv_poster_url(item.tmdb_id)
+        else:
+            url = await fetch_poster_url(item.tmdb_id)
         if url:
-            movie.poster_url = url
+            item.poster_url = url
             filled += 1
 
     if filled:

--- a/backend/services/tournament.py
+++ b/backend/services/tournament.py
@@ -58,6 +58,7 @@ async def get_filtered_ranked_films(
     user_id: uuid.UUID,
     filter_type: Optional[str] = None,
     filter_value: Optional[str] = None,
+    media_type: str = "movie",
 ) -> list[UserMovie]:
     """Query ranked films with optional genre/decade filtering.
 
@@ -66,14 +67,18 @@ async def get_filtered_ranked_films(
     """
     from sqlalchemy.orm import joinedload
 
+    from backend.db_models import Movie
+
     stmt = (
         select(UserMovie)
         .options(joinedload(UserMovie.movie))
+        .join(Movie, UserMovie.movie_id == Movie.id)
         .where(
             UserMovie.user_id == user_id,
             UserMovie.seen.is_(True),
             UserMovie.battles >= 1,
             UserMovie.elo.isnot(None),
+            Movie.media_type == media_type,
         )
     )
     result = await db.execute(stmt)

--- a/backend/services/trakt.py
+++ b/backend/services/trakt.py
@@ -158,3 +158,84 @@ class TraktClient:
                 },
             )
             resp.raise_for_status()
+
+    # ── TV Show methods ────────────────────────────────────────────────
+
+    async def get_popular_shows(self, limit: int = 100) -> list[dict]:
+        """Fetch popular TV shows."""
+        async with self._client() as client:
+            resp = await client.get(
+                "/shows/popular",
+                params={"limit": limit, "extended": "full"},
+            )
+            resp.raise_for_status()
+            return resp.json()
+
+    async def get_trending_shows(self, limit: int = 100) -> list[dict]:
+        """Fetch trending TV shows. Extracts the show dict from each item."""
+        async with self._client() as client:
+            resp = await client.get(
+                "/shows/trending",
+                params={"limit": limit, "extended": "full"},
+            )
+            resp.raise_for_status()
+            return [item["show"] for item in resp.json()]
+
+    async def get_user_watched_shows(self, username: str) -> list[dict]:
+        """Fetch a user's watched shows. Extracts the show dicts."""
+        async with self._client() as client:
+            resp = await client.get(
+                f"/users/{username}/watched/shows",
+                params={"extended": "full"},
+            )
+            resp.raise_for_status()
+            return [item["show"] for item in resp.json()]
+
+    async def get_user_ratings_shows(self, username: str) -> list[dict]:
+        """Fetch a user's show ratings. Returns [{rating, trakt_id}, ...]."""
+        async with self._client() as client:
+            resp = await client.get(
+                f"/users/{username}/ratings/shows",
+            )
+            resp.raise_for_status()
+            return [
+                {"rating": item["rating"], "trakt_id": item["show"]["ids"]["trakt"]}
+                for item in resp.json()
+            ]
+
+    async def get_recommendations_shows(self, limit: int = 100) -> list[dict]:
+        """Get personalized show recommendations for the authenticated user."""
+        async with self._client() as client:
+            resp = await client.get(
+                "/recommendations/shows",
+                params={"limit": limit, "extended": "full", "ignore_collected": "true"},
+            )
+            resp.raise_for_status()
+            return resp.json()
+
+    async def rate_show(self, trakt_id: int, rating: int) -> None:
+        """Submit a rating for a show (1-10 scale)."""
+        async with self._client() as client:
+            resp = await client.post(
+                "/sync/ratings",
+                json={
+                    "shows": [
+                        {
+                            "rating": rating,
+                            "ids": {"trakt": trakt_id},
+                        }
+                    ]
+                },
+            )
+            resp.raise_for_status()
+
+    async def add_show_to_watchlist(self, trakt_id: int) -> None:
+        """Add a show to the user's Trakt watchlist."""
+        async with self._client() as client:
+            resp = await client.post(
+                "/sync/watchlist",
+                json={
+                    "shows": [{"ids": {"trakt": trakt_id}}]
+                },
+            )
+            resp.raise_for_status()

--- a/backend/tests/test_media_type_filtering.py
+++ b/backend/tests/test_media_type_filtering.py
@@ -1,0 +1,112 @@
+"""Tests for media_type filtering across backend services.
+
+Verifies that rankings, suggestions, and sync services correctly
+pass and use the media_type parameter.
+"""
+
+from __future__ import annotations
+
+import uuid
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from backend.services.sync import _rate_with_retry
+
+
+# ---------------------------------------------------------------------------
+# _rate_with_retry — media_type dispatch
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_rate_with_retry_dispatches_to_movie():
+    """Default media_type='movie' calls rate_movie."""
+    client = AsyncMock()
+    await _rate_with_retry(client, trakt_id=123, rating=8, media_type="movie")
+    client.rate_movie.assert_awaited_once_with(123, 8)
+    client.rate_show.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_rate_with_retry_dispatches_to_show():
+    """media_type='show' calls rate_show."""
+    client = AsyncMock()
+    await _rate_with_retry(client, trakt_id=456, rating=7, media_type="show")
+    client.rate_show.assert_awaited_once_with(456, 7)
+    client.rate_movie.assert_not_awaited()
+
+
+# ---------------------------------------------------------------------------
+# get_user_rankings — media_type parameter propagation
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_rankings_passes_media_type():
+    """get_user_rankings builds a query that includes Movie.media_type filter."""
+    from backend.services.rankings import get_user_rankings
+
+    uid = uuid.uuid4()
+
+    # Mock db to return empty results
+    mock_result = MagicMock()
+    mock_result.unique.return_value.scalars.return_value.all.return_value = []
+    mock_count_result = MagicMock()
+    mock_count_result.scalar.return_value = 0
+
+    db = AsyncMock()
+    db.execute.side_effect = [mock_result, mock_count_result]
+
+    rankings, total = await get_user_rankings(db, uid, media_type="show")
+
+    assert total == 0
+    assert rankings == []
+    # Verify execute was called twice (main query + count query)
+    assert db.execute.await_count == 2
+
+
+# ---------------------------------------------------------------------------
+# has_enough_ranked — media_type propagation
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_has_enough_ranked_passes_media_type():
+    """has_enough_ranked filters by media_type."""
+    from backend.services.suggest import has_enough_ranked
+
+    uid = uuid.uuid4()
+    mock_result = MagicMock()
+    mock_result.scalar.return_value = 0
+
+    db = AsyncMock()
+    db.execute.return_value = mock_result
+
+    result = await has_enough_ranked(uid, db, media_type="show")
+    assert result is False
+    db.execute.assert_awaited_once()
+
+
+# ---------------------------------------------------------------------------
+# _sync_ratings_background — error handling
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_sync_ratings_background_handles_exceptions():
+    """_sync_ratings_background logs exceptions instead of crashing."""
+    from backend.routers.duels import _sync_ratings_background
+
+    uid = uuid.uuid4()
+    mid_a = uuid.uuid4()
+    mid_b = uuid.uuid4()
+
+    with patch("backend.routers.duels.async_session_factory") as mock_factory:
+        mock_factory.return_value.__aenter__ = AsyncMock(
+            side_effect=RuntimeError("DB down")
+        )
+        mock_factory.return_value.__aexit__ = AsyncMock(return_value=False)
+
+        # Should not raise — error is caught and logged
+        await _sync_ratings_background(uid, mid_a, 1100, mid_b, 900)

--- a/docs/PRD.md
+++ b/docs/PRD.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-FilmDuel is a web app that helps users discover and rank movies through pairwise comparisons. Users authenticate with their Trakt account, classify films rapidly via a Tinder-style swipe session, then duel seen films against each other to build an ELO-ranked library. Ratings sync back to Trakt in real time.
+FilmDuel is a web app that helps users discover and rank movies and TV shows through pairwise comparisons. Users authenticate with their Trakt account, toggle between Movies and TV Shows via the nav bar, classify films rapidly via a Tinder-style swipe session, then duel seen films against each other to build an ELO-ranked library. Ratings sync back to Trakt in real time.
 
 The experience has two distinct modes that alternate naturally:
 - **Swipe** — fast, mindless sorting. Seen it or not?

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -37,6 +37,14 @@ export default function App() {
   const location = useLocation();
   const isLogin = location.pathname === "/login";
 
+  const [mediaType, setMediaType] = useState(() =>
+    localStorage.getItem("filmduel_media_type") || "movie"
+  );
+
+  useEffect(() => {
+    localStorage.setItem("filmduel_media_type", mediaType);
+  }, [mediaType]);
+
   if (isLogin) {
     return (
       <div className="min-h-screen bg-[#0F0E0D] text-[#F5F0E8]">
@@ -49,14 +57,14 @@ export default function App() {
 
   return (
     <div className="min-h-screen bg-[#0F0E0D] text-[#F5F0E8] flex">
-      <Nav />
+      <Nav mediaType={mediaType} setMediaType={setMediaType} />
       <main className="flex-1 md:ml-64 min-h-screen">
         <Routes>
           <Route
             path="/"
             element={
               <ProtectedRoute>
-                <Duel />
+                <Duel mediaType={mediaType} />
               </ProtectedRoute>
             }
           />
@@ -64,7 +72,7 @@ export default function App() {
             path="/swipe"
             element={
               <ProtectedRoute>
-                <Swipe />
+                <Swipe mediaType={mediaType} />
               </ProtectedRoute>
             }
           />
@@ -72,7 +80,7 @@ export default function App() {
             path="/rankings"
             element={
               <ProtectedRoute>
-                <Rankings />
+                <Rankings mediaType={mediaType} />
               </ProtectedRoute>
             }
           />
@@ -80,7 +88,7 @@ export default function App() {
             path="/suggestions"
             element={
               <ProtectedRoute>
-                <Suggestions />
+                <Suggestions mediaType={mediaType} />
               </ProtectedRoute>
             }
           />
@@ -88,7 +96,7 @@ export default function App() {
             path="/tournaments"
             element={
               <ProtectedRoute>
-                <Tournaments />
+                <Tournaments mediaType={mediaType} />
               </ProtectedRoute>
             }
           />
@@ -103,57 +111,82 @@ export default function App() {
         </Routes>
       </main>
       {/* Mobile bottom nav */}
-      <nav className="fixed bottom-0 left-0 w-full z-50 flex justify-around items-center px-4 py-2 bg-[#0F0E0D]/80 backdrop-blur-xl md:hidden shadow-[0_-8px_32px_rgba(232,160,32,0.08)]">
-        <a
-          href="/"
-          className={`flex flex-col items-center justify-center px-6 py-2 transition-colors ${
-            location.pathname === "/"
-              ? "text-[#E8A020] border-t-2 border-[#E8A020] bg-[#E8A020]/10"
-              : "text-[#6B6760] hover:text-[#F5F0E8]"
-          }`}
-        >
-          <span className="text-[10px] font-bold uppercase tracking-[0.1em] font-headline">Duel</span>
-        </a>
-        <a
-          href="/swipe"
-          className={`flex flex-col items-center justify-center px-6 py-2 transition-colors ${
-            location.pathname === "/swipe"
-              ? "text-[#E8A020] border-t-2 border-[#E8A020] bg-[#E8A020]/10"
-              : "text-[#6B6760] hover:text-[#F5F0E8]"
-          }`}
-        >
-          <span className="text-[10px] font-bold uppercase tracking-[0.1em] font-headline">Swipe</span>
-        </a>
-        <a
-          href="/rankings"
-          className={`flex flex-col items-center justify-center px-6 py-2 transition-colors ${
-            location.pathname === "/rankings"
-              ? "text-[#E8A020] border-t-2 border-[#E8A020] bg-[#E8A020]/10"
-              : "text-[#6B6760] hover:text-[#F5F0E8]"
-          }`}
-        >
-          <span className="text-[10px] font-bold uppercase tracking-[0.1em] font-headline">Rankings</span>
-        </a>
-        <a
-          href="/suggestions"
-          className={`flex flex-col items-center justify-center px-6 py-2 transition-colors ${
-            location.pathname === "/suggestions"
-              ? "text-[#E8A020] border-t-2 border-[#E8A020] bg-[#E8A020]/10"
-              : "text-[#6B6760] hover:text-[#F5F0E8]"
-          }`}
-        >
-          <span className="text-[10px] font-bold uppercase tracking-[0.1em] font-headline">Watch Next</span>
-        </a>
-        <a
-          href="/tournaments"
-          className={`flex flex-col items-center justify-center px-6 py-2 transition-colors ${
-            location.pathname.startsWith("/tournaments")
-              ? "text-[#E8A020] border-t-2 border-[#E8A020] bg-[#E8A020]/10"
-              : "text-[#6B6760] hover:text-[#F5F0E8]"
-          }`}
-        >
-          <span className="text-[10px] font-bold uppercase tracking-[0.1em] font-headline">Brackets</span>
-        </a>
+      <nav className="fixed bottom-0 left-0 w-full z-50 flex flex-col items-center bg-[#0F0E0D]/80 backdrop-blur-xl md:hidden shadow-[0_-8px_32px_rgba(232,160,32,0.08)]">
+        {/* Media type toggle */}
+        <div className="flex w-full justify-center gap-1 px-4 pt-2 pb-1">
+          <button
+            onClick={() => setMediaType("movie")}
+            className={`flex-1 py-1 text-[10px] font-bold uppercase tracking-[0.1em] font-headline rounded-sm transition-colors ${
+              mediaType === "movie"
+                ? "bg-[#E8A020] text-[#0F0E0D]"
+                : "text-[#F5F0E8]/40 hover:text-[#F5F0E8]/60"
+            }`}
+          >
+            Movies
+          </button>
+          <button
+            onClick={() => setMediaType("show")}
+            className={`flex-1 py-1 text-[10px] font-bold uppercase tracking-[0.1em] font-headline rounded-sm transition-colors ${
+              mediaType === "show"
+                ? "bg-[#E8A020] text-[#0F0E0D]"
+                : "text-[#F5F0E8]/40 hover:text-[#F5F0E8]/60"
+            }`}
+          >
+            Shows
+          </button>
+        </div>
+        <div className="flex justify-around items-center w-full px-4 py-2">
+          <a
+            href="/"
+            className={`flex flex-col items-center justify-center px-6 py-2 transition-colors ${
+              location.pathname === "/"
+                ? "text-[#E8A020] border-t-2 border-[#E8A020] bg-[#E8A020]/10"
+                : "text-[#6B6760] hover:text-[#F5F0E8]"
+            }`}
+          >
+            <span className="text-[10px] font-bold uppercase tracking-[0.1em] font-headline">Duel</span>
+          </a>
+          <a
+            href="/swipe"
+            className={`flex flex-col items-center justify-center px-6 py-2 transition-colors ${
+              location.pathname === "/swipe"
+                ? "text-[#E8A020] border-t-2 border-[#E8A020] bg-[#E8A020]/10"
+                : "text-[#6B6760] hover:text-[#F5F0E8]"
+            }`}
+          >
+            <span className="text-[10px] font-bold uppercase tracking-[0.1em] font-headline">Swipe</span>
+          </a>
+          <a
+            href="/rankings"
+            className={`flex flex-col items-center justify-center px-6 py-2 transition-colors ${
+              location.pathname === "/rankings"
+                ? "text-[#E8A020] border-t-2 border-[#E8A020] bg-[#E8A020]/10"
+                : "text-[#6B6760] hover:text-[#F5F0E8]"
+            }`}
+          >
+            <span className="text-[10px] font-bold uppercase tracking-[0.1em] font-headline">Rankings</span>
+          </a>
+          <a
+            href="/suggestions"
+            className={`flex flex-col items-center justify-center px-6 py-2 transition-colors ${
+              location.pathname === "/suggestions"
+                ? "text-[#E8A020] border-t-2 border-[#E8A020] bg-[#E8A020]/10"
+                : "text-[#6B6760] hover:text-[#F5F0E8]"
+            }`}
+          >
+            <span className="text-[10px] font-bold uppercase tracking-[0.1em] font-headline">Watch Next</span>
+          </a>
+          <a
+            href="/tournaments"
+            className={`flex flex-col items-center justify-center px-6 py-2 transition-colors ${
+              location.pathname.startsWith("/tournaments")
+                ? "text-[#E8A020] border-t-2 border-[#E8A020] bg-[#E8A020]/10"
+                : "text-[#6B6760] hover:text-[#F5F0E8]"
+            }`}
+          >
+            <span className="text-[10px] font-bold uppercase tracking-[0.1em] font-headline">Brackets</span>
+          </a>
+        </div>
       </nav>
     </div>
   );

--- a/frontend/src/__tests__/Duel.test.jsx
+++ b/frontend/src/__tests__/Duel.test.jsx
@@ -48,7 +48,7 @@ function setupFetch(overrides = {}) {
         json: () => Promise.resolve(overrides.pair ?? fakePair),
       });
     }
-    if (url === "/api/rankings/stats") {
+    if (url.includes("/api/rankings/stats")) {
       return Promise.resolve({
         ok: true,
         status: 200,

--- a/frontend/src/__tests__/Rankings.test.jsx
+++ b/frontend/src/__tests__/Rankings.test.jsx
@@ -120,7 +120,7 @@ describe("Rankings", () => {
       expect(exportLink).toBeInTheDocument();
       expect(exportLink.closest("a")).toHaveAttribute(
         "href",
-        "/api/rankings/export/csv"
+        "/api/rankings/export/csv?media_type=movie"
       );
     });
   });

--- a/frontend/src/__tests__/api.test.js
+++ b/frontend/src/__tests__/api.test.js
@@ -56,7 +56,7 @@ describe("api", () => {
       mockFetchOk({ movie_a: {}, movie_b: {} });
       await fetchPair("discovery");
       expect(fetch).toHaveBeenCalledWith(
-        "/api/movies/pair?mode=discovery",
+        "/api/movies/pair?mode=discovery&media_type=movie",
         expect.objectContaining({
           credentials: "include",
           headers: expect.objectContaining({ "Content-Type": "application/json" }),
@@ -68,7 +68,7 @@ describe("api", () => {
       mockFetchOk({ movie_a: {}, movie_b: {} });
       await fetchPair("discovery", "abc123");
       expect(fetch).toHaveBeenCalledWith(
-        "/api/movies/pair?mode=discovery&last_pair_token=abc123",
+        "/api/movies/pair?mode=discovery&media_type=movie&last_pair_token=abc123",
         expect.any(Object)
       );
     });
@@ -100,7 +100,7 @@ describe("api", () => {
       mockFetchOk([{ id: 1, title: "Test" }]);
       await fetchSwipeCards();
       expect(fetch).toHaveBeenCalledWith(
-        "/api/swipe/cards",
+        "/api/swipe/cards?media_type=movie",
         expect.objectContaining({ credentials: "include" })
       );
     });
@@ -116,7 +116,7 @@ describe("api", () => {
       mockFetchOk({ seen_count: 1, unseen_count: 1 });
       await submitSwipeResults(results);
       expect(fetch).toHaveBeenCalledWith(
-        "/api/swipe/results",
+        "/api/swipe/results?media_type=movie",
         expect.objectContaining({
           method: "POST",
           body: JSON.stringify({ results }),

--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -19,8 +19,8 @@ async function request(path, options = {}) {
 
 export function getMe() { return request("/api/me"); }
 
-export function fetchPair(mode = "discovery", lastPairToken = null) {
-  const params = new URLSearchParams({ mode });
+export function fetchPair(mode = "discovery", lastPairToken = null, mediaType = "movie") {
+  const params = new URLSearchParams({ mode, media_type: mediaType });
   if (lastPairToken) params.set("last_pair_token", lastPairToken);
   return request(`/api/movies/pair?${params}`);
 }
@@ -32,20 +32,24 @@ export function submitDuel(movieAId, movieBId, outcome, mode = "discovery") {
   });
 }
 
-export function getRankings(limit = 50, offset = 0, genre = null, decade = null) {
-  const params = new URLSearchParams({ limit, offset });
+export function getRankings(limit = 50, offset = 0, genre = null, decade = null, mediaType = "movie") {
+  const params = new URLSearchParams({ limit, offset, media_type: mediaType });
   if (genre) params.set("genre", genre);
   if (decade) params.set("decade", decade);
   return request(`/api/rankings?${params}`);
 }
 
-export function fetchStats() { return request("/api/rankings/stats"); }
+export function fetchStats(mediaType = "movie") {
+  return request(`/api/rankings/stats?media_type=${mediaType}`);
+}
 export const getStats = fetchStats;
 
-export function fetchSwipeCards() { return request("/api/swipe/cards"); }
+export function fetchSwipeCards(mediaType = "movie") {
+  return request(`/api/swipe/cards?media_type=${mediaType}`);
+}
 
-export function submitSwipeResults(results) {
-  return request("/api/swipe/results", {
+export function submitSwipeResults(results, mediaType = "movie") {
+  return request(`/api/swipe/results?media_type=${mediaType}`, {
     method: "POST",
     body: JSON.stringify({ results }),
   });
@@ -61,18 +65,18 @@ export function getTournaments() {
   return request("/api/tournaments");
 }
 
-export function getTournamentGenres() {
-  return request("/api/tournaments/genres");
+export function getTournamentGenres(mediaType = "movie") {
+  return request(`/api/tournaments/genres?media_type=${mediaType}`);
 }
 
-export function getTournamentPoolCount(filterType, filterValue) {
-  const params = new URLSearchParams();
+export function getTournamentPoolCount(filterType, filterValue, mediaType = "movie") {
+  const params = new URLSearchParams({ media_type: mediaType });
   if (filterType) params.set("filter_type", filterType);
   if (filterValue) params.set("filter_value", filterValue);
   return request(`/api/tournaments/pool-count?${params}`);
 }
 
-export function createTournament(name, bracketSize, filterType, filterValue, aiCurated = false) {
+export function createTournament(name, bracketSize, filterType, filterValue, aiCurated = false, mediaType = "movie") {
   return request("/api/tournaments", {
     method: "POST",
     body: JSON.stringify({
@@ -81,6 +85,7 @@ export function createTournament(name, bracketSize, filterType, filterValue, aiC
       filter_type: filterType || null,
       filter_value: filterValue || null,
       ai_curated: aiCurated,
+      media_type: mediaType,
     }),
   });
 }
@@ -110,12 +115,12 @@ export function regenerateTournament(id) {
 
 // ── Suggestions ─────────────────────────────────────────────────────
 
-export function getSuggestions() {
-  return request("/api/suggestions");
+export function getSuggestions(mediaType = "movie") {
+  return request(`/api/suggestions?media_type=${mediaType}`);
 }
 
-export function regenerateSuggestions() {
-  return request("/api/suggestions/regenerate", { method: "POST" });
+export function regenerateSuggestions(mediaType = "movie") {
+  return request(`/api/suggestions/regenerate?media_type=${mediaType}`, { method: "POST" });
 }
 
 export function dismissSuggestion(id) {

--- a/frontend/src/components/Nav.jsx
+++ b/frontend/src/components/Nav.jsx
@@ -11,7 +11,7 @@ const navItems = [
   { path: "/tournaments", label: "Tournaments", icon: "bracket" },
 ];
 
-export default function Nav() {
+export default function Nav({ mediaType, setMediaType }) {
   const location = useLocation();
   const [showFeedback, setShowFeedback] = useState(false);
 
@@ -35,6 +35,30 @@ export default function Nav() {
             The Noir Projectionist
           </p>
         </div>
+      </div>
+
+      {/* Media type toggle */}
+      <div className="flex bg-[#0F0E0D] rounded-sm p-1 gap-1 mx-2">
+        <button
+          onClick={() => setMediaType("movie")}
+          className={`flex-1 py-2 text-xs font-headline font-bold uppercase tracking-widest transition-colors rounded-sm ${
+            mediaType === "movie"
+              ? "bg-[#E8A020] text-[#0F0E0D]"
+              : "text-[#F5F0E8]/40 hover:text-[#F5F0E8]/60"
+          }`}
+        >
+          Movies
+        </button>
+        <button
+          onClick={() => setMediaType("show")}
+          className={`flex-1 py-2 text-xs font-headline font-bold uppercase tracking-widest transition-colors rounded-sm ${
+            mediaType === "show"
+              ? "bg-[#E8A020] text-[#0F0E0D]"
+              : "text-[#F5F0E8]/40 hover:text-[#F5F0E8]/60"
+          }`}
+        >
+          Shows
+        </button>
       </div>
 
       {/* Nav items */}

--- a/frontend/src/pages/Duel.jsx
+++ b/frontend/src/pages/Duel.jsx
@@ -13,7 +13,7 @@ function SkeletonCard() {
   );
 }
 
-export default function Duel() {
+export default function Duel({ mediaType = "movie" }) {
   const navigate = useNavigate();
   const [pair, setPair] = useState(null);
   const [loading, setLoading] = useState(true);
@@ -35,16 +35,16 @@ export default function Duel() {
 
   const loadStats = useCallback(async () => {
     try {
-      const data = await fetchStats();
+      const data = await fetchStats(mediaType);
       setStats(data);
     } catch (err) {
       console.error("Failed to load stats:", err);
     }
-  }, []);
+  }, [mediaType]);
 
   const prefetchNext = useCallback(() => {
-    prefetchRef.current = fetchPair(MODE).catch(() => null);
-  }, []);
+    prefetchRef.current = fetchPair(MODE, null, mediaType).catch(() => null);
+  }, [mediaType]);
 
   const loadPair = useCallback(
     async (usePrefetch = false) => {
@@ -58,7 +58,7 @@ export default function Duel() {
           prefetchRef.current = null;
         }
         if (!data) {
-          data = await fetchPair(MODE);
+          data = await fetchPair(MODE, null, mediaType);
         }
         setPair(data);
         setAnimateKey((k) => k + 1);
@@ -77,10 +77,11 @@ export default function Duel() {
         setLoading(false);
       }
     },
-    []
+    [mediaType]
   );
 
   useEffect(() => {
+    prefetchRef.current = null;
     loadPair();
     loadStats();
   }, [loadPair, loadStats]);

--- a/frontend/src/pages/Rankings.jsx
+++ b/frontend/src/pages/Rankings.jsx
@@ -3,7 +3,7 @@ import { getRankings, fetchStats, syncTrakt } from "../api";
 
 const GENRE_FILTERS = ["All", "Drama", "Horror", "Sci-fi", "Thriller", "Comedy"];
 
-export default function Rankings() {
+export default function Rankings({ mediaType = "movie" }) {
   const [rankings, setRankings] = useState([]);
   const [stats, setStats] = useState(null);
   const [loading, setLoading] = useState(true);
@@ -17,8 +17,8 @@ export default function Rankings() {
       try {
         const genre = activeFilter === "All" ? null : activeFilter;
         const [rankData, statsData] = await Promise.all([
-          getRankings(50, 0, genre),
-          fetchStats(),
+          getRankings(50, 0, genre, null, mediaType),
+          fetchStats(mediaType),
         ]);
         setRankings(rankData.rankings);
         setTotal(rankData.total);
@@ -30,7 +30,7 @@ export default function Rankings() {
       }
     }
     load();
-  }, [activeFilter]);
+  }, [activeFilter, mediaType]);
 
   if (loading) {
     return (
@@ -61,8 +61,8 @@ export default function Rankings() {
                   // Reload rankings to reflect new data
                   const genre = activeFilter === "All" ? null : activeFilter;
                   const [rankData, statsData] = await Promise.all([
-                    getRankings(50, 0, genre),
-                    fetchStats(),
+                    getRankings(50, 0, genre, null, mediaType),
+                    fetchStats(mediaType),
                   ]);
                   setRankings(rankData.rankings);
                   setTotal(rankData.total);
@@ -228,7 +228,7 @@ export default function Rankings() {
                   <div className="flex gap-3 mt-1">
                     {r.movie.trakt_id && (
                       <a
-                        href={`https://trakt.tv/search/trakt/${r.movie.trakt_id}?id_type=movie`}
+                        href={`https://trakt.tv/search/trakt/${r.movie.trakt_id}?id_type=${r.movie.media_type === "show" ? "show" : "movie"}`}
                         target="_blank"
                         rel="noopener noreferrer"
                         className="text-[10px] font-label uppercase tracking-widest text-[#F5F0E8]/30 hover:text-[#E8A020] transition-colors"
@@ -257,7 +257,7 @@ export default function Rankings() {
       {/* Floating Export Button */}
       <div className="fixed bottom-20 md:bottom-12 right-6 md:right-12 flex flex-col items-end gap-4 z-50">
         <a
-          href="/api/rankings/export/csv"
+          href={`/api/rankings/export/csv?media_type=${mediaType}`}
           download
           className="flex items-center gap-3 px-6 md:px-8 py-4 bg-[#E8A020] text-[#0F0E0D] font-headline font-black uppercase tracking-widest text-sm shadow-[0_10px_30px_rgba(232,160,32,0.3)] hover:scale-105 active:scale-95 transition-all"
         >

--- a/frontend/src/pages/Suggestions.jsx
+++ b/frontend/src/pages/Suggestions.jsx
@@ -18,7 +18,7 @@ function SkeletonCard() {
   );
 }
 
-export default function Suggestions() {
+export default function Suggestions({ mediaType = "movie" }) {
   const [suggestions, setSuggestions] = useState([]);
   const [status, setStatus] = useState("loading");
   const [regenerating, setRegenerating] = useState(false);
@@ -28,7 +28,7 @@ export default function Suggestions() {
     setStatus("loading");
     setError(null);
     try {
-      const data = await getSuggestions();
+      const data = await getSuggestions(mediaType);
       setSuggestions(data.suggestions);
       setStatus(data.status);
     } catch (err) {
@@ -38,13 +38,13 @@ export default function Suggestions() {
     }
   }
 
-  useEffect(() => { load(); }, []);
+  useEffect(() => { load(); }, [mediaType]);
 
   async function handleRegenerate() {
     setRegenerating(true);
     setError(null);
     try {
-      const data = await regenerateSuggestions();
+      const data = await regenerateSuggestions(mediaType);
       setSuggestions(data.suggestions);
       setStatus(data.status);
     } catch (err) {
@@ -294,7 +294,7 @@ export default function Suggestions() {
                 )}
                 {s.movie.trakt_id && (
                   <a
-                    href={`https://trakt.tv/search/trakt/${s.movie.trakt_id}?id_type=movie`}
+                    href={`https://trakt.tv/search/trakt/${s.movie.trakt_id}?id_type=${s.movie.media_type === "show" ? "show" : "movie"}`}
                     target="_blank"
                     rel="noopener noreferrer"
                     className="text-[10px] font-label uppercase tracking-widest text-[#F5F0E8]/30 hover:text-[#E8A020] transition-colors"

--- a/frontend/src/pages/Swipe.jsx
+++ b/frontend/src/pages/Swipe.jsx
@@ -3,7 +3,7 @@ import { useNavigate } from "react-router-dom";
 import { fetchSwipeCards, submitSwipeResults } from "../api";
 import SwipeCard from "../components/SwipeCard";
 
-export default function Swipe() {
+export default function Swipe({ mediaType = "movie" }) {
   const navigate = useNavigate();
   const [cards, setCards] = useState([]);
   const [currentIndex, setCurrentIndex] = useState(0);
@@ -22,7 +22,7 @@ export default function Swipe() {
     setSummary(null);
     setCardKey(0);
     try {
-      const data = await fetchSwipeCards();
+      const data = await fetchSwipeCards(mediaType);
       if (!data || data.length === 0) {
         setCards([]);
       } else {
@@ -34,7 +34,7 @@ export default function Swipe() {
     } finally {
       setLoading(false);
     }
-  }, []);
+  }, [mediaType]);
 
   useEffect(() => {
     loadCards();
@@ -51,7 +51,7 @@ export default function Swipe() {
       if (currentIndex + 1 >= cards.length) {
         // All cards done, submit
         setSubmitting(true);
-        submitSwipeResults(newResults)
+        submitSwipeResults(newResults, mediaType)
           .then((res) => {
             setSummary(res);
           })

--- a/frontend/src/pages/Tournaments.jsx
+++ b/frontend/src/pages/Tournaments.jsx
@@ -5,7 +5,7 @@ import { getTournaments, createTournament, getTournamentGenres, getTournamentPoo
 const BRACKET_SIZES = [8, 16, 32, 64];
 const DECADES = ["1970s", "1980s", "1990s", "2000s", "2010s", "2020s"];
 
-export default function Tournaments() {
+export default function Tournaments({ mediaType = "movie" }) {
   const navigate = useNavigate();
   const [tournaments, setTournaments] = useState([]);
   const [loading, setLoading] = useState(true);
@@ -42,15 +42,15 @@ export default function Tournaments() {
     if (!showCreate) return;
     const filterType = filterMode === "all" ? null : filterMode;
     const fv = filterMode === "all" ? null : filterValue;
-    getTournamentPoolCount(filterType, fv)
+    getTournamentPoolCount(filterType, fv, mediaType)
       .then((data) => setPoolCount(data.count))
       .catch(() => setPoolCount(null));
-  }, [showCreate, filterMode, filterValue]);
+  }, [showCreate, filterMode, filterValue, mediaType]);
 
   async function handleOpenCreate() {
     setShowCreate(true);
     try {
-      const genres = await getTournamentGenres();
+      const genres = await getTournamentGenres(mediaType);
       setAvailableGenres(genres);
     } catch (err) {
       console.error("Failed to load genres:", err);
@@ -65,7 +65,7 @@ export default function Tournaments() {
       const filterType = filterMode === "all" ? null : filterMode;
       const fv = filterMode === "all" ? null : filterValue;
       const tournamentName = name.trim() || "AI Tournament";
-      const t = await createTournament(tournamentName, bracketSize, filterType, fv, aiCurated);
+      const t = await createTournament(tournamentName, bracketSize, filterType, fv, aiCurated, mediaType);
       navigate(`/tournaments/${t.id}`);
     } catch (err) {
       setError(err.message);


### PR DESCRIPTION
## Summary

Add TV show dueling alongside existing movie dueling. Users sync TV shows from Trakt, duel them with the same ELO system, view separate rankings, and run show-specific tournaments. Movies and shows are separate pools with a UI toggle. Implementation adds a `media_type` discriminator column to the `movies` table and parameterizes all queries/endpoints.

## Changes

| File | Action | Description |
|------|--------|-------------|
| `backend/migrations/versions/012_add_media_type.py` | CREATE | Alembic migration adding `media_type` column with `'movie'` default |
| `backend/db_models.py` | UPDATE | Added `media_type` column + composite unique constraint |
| `backend/schemas.py` | UPDATE | Added `MediaType` literal + `media_type` field to schemas |
| `backend/services/trakt.py` | UPDATE | Added 8 show methods mirroring movie methods |
| `backend/services/tmdb.py` | UPDATE | Added `fetch_tv_poster_url` + updated `backfill_posters` for shows |
| `backend/services/pool.py` | UPDATE | Refactored into `_upsert_pool` helper, added show sync block |
| `backend/services/expand.py` | UPDATE | Added `media_type` param to all expansion sources |
| `backend/services/rankings.py` | UPDATE | Added `media_type` filter to all 3 service functions |
| `backend/services/tournament.py` | UPDATE | Added `media_type` to tournament creation/filtering |
| `backend/services/suggest.py` | UPDATE | Added `media_type` throughout suggestion pipeline |
| `backend/services/sync.py` | UPDATE | Added `media_type` to `rate_with_retry` + `sync_post_duel` |
| `backend/routers/movies.py` | UPDATE | Added `media_type` filter to pair selection |
| `backend/routers/duels.py` | UPDATE | Updated background sync to detect media_type for Trakt |
| `backend/routers/rankings.py` | UPDATE | Added `media_type` to all 3 endpoints |
| `backend/routers/swipe.py` | UPDATE | Added `media_type` to cards + results endpoints |
| `backend/routers/tournaments.py` | UPDATE | Added `media_type` to genres, pool-count, create endpoints |
| `backend/routers/suggestions.py` | UPDATE | Added `media_type` throughout suggestion endpoints |
| `frontend/src/api.js` | UPDATE | Added `mediaType` param to 10 API functions |
| `frontend/src/App.jsx` | UPDATE | Added Movies/Shows toggle with `localStorage` persistence |
| `frontend/src/components/Nav.jsx` | UPDATE | Added media type toggle UI in navigation |
| `frontend/src/pages/Duel.jsx` | UPDATE | Accepts + uses `mediaType` prop |
| `frontend/src/pages/Rankings.jsx` | UPDATE | Accepts + uses `mediaType` prop |
| `frontend/src/pages/Swipe.jsx` | UPDATE | Accepts + uses `mediaType` prop |
| `frontend/src/pages/Tournaments.jsx` | UPDATE | Accepts + uses `mediaType` prop |
| `frontend/src/pages/Suggestions.jsx` | UPDATE | Accepts + uses `mediaType` prop |

## Tests

- `frontend/src/__tests__/api.test.js` — Updated 4 assertions for `media_type` query params
- `frontend/src/__tests__/Duel.test.jsx` — Updated to pass `mediaType` prop
- `frontend/src/__tests__/Rankings.test.jsx` — Updated to pass `mediaType` prop

## Validation

- [x] Static analysis passes (backend models import OK)
- [x] Frontend build passes (vite build, 1.77s)
- [x] Backend tests pass (157 passed, 0 failed)
- [x] Frontend tests pass (86 passed, 0 failed)

## Implementation Notes

### Deviations from Plan

1. **Pool service refactored to helper**: Extracted `_upsert_pool()` helper instead of duplicating 80+ lines of upsert logic (DRY)
2. **No new backend test files**: Updated existing tests only; new dedicated show test files deferred to follow-up
3. **Duels router updated**: Added media_type detection to `_sync_ratings_background` for correct Trakt sync (plan said "no change needed" but sync needed it)

### Out of Scope (by design)

- Episode-level tracking — shows ranked as a whole
- Mixed-type duels — movies never duel against shows
- Show-specific metadata (seasons, episodes, network)
- Separate DB tables or ELO columns for shows

---

**Workflow ID**: `8462a41234b697fce5a2f02c72822fe9`
