### PR TITLE
test: improve coverage and fix flaky tests

### DIFF
--- a/backend/routers/auth.py
+++ b/backend/routers/auth.py
@@ -64,7 +64,10 @@ def get_current_user_id(request: Request) -> str:
             issuer="filmduel",
             audience="filmduel",
         )
-        return payload["sub"]
+        user_id = payload.get("sub")
+        if not user_id:
+            raise HTTPException(status_code=401, detail="Invalid session — missing subject")
+        return user_id
     except jwt.ExpiredSignatureError:
         raise HTTPException(status_code=401, detail="Session expired")
     except jwt.InvalidTokenError:

--- a/backend/tests/test_auth.py
+++ b/backend/tests/test_auth.py
@@ -149,7 +149,7 @@ class TestGetCurrentUserId:
         assert exc_info.value.status_code == 401
 
     def test_token_missing_sub_raises_401(self, monkeypatch):
-        """Token without 'sub' claim should raise 401 (KeyError caught as InvalidTokenError)."""
+        """Token without 'sub' claim should raise 401."""
         monkeypatch.setattr("backend.routers.auth.get_settings", lambda: SETTINGS)
         payload = {
             "iss": "filmduel",
@@ -160,8 +160,7 @@ class TestGetCurrentUserId:
         }
         token = pyjwt.encode(payload, SETTINGS.SECRET_KEY, algorithm=JWT_ALGORITHM)
         request = _make_request({COOKIE_NAME: token})
-        # The code does payload["sub"] which will KeyError — but since
-        # that's not caught as jwt error, it will bubble up.
-        # Let's verify the behavior:
-        with pytest.raises((HTTPException, KeyError)):
+        with pytest.raises(HTTPException) as exc_info:
             get_current_user_id(request)
+        assert exc_info.value.status_code == 401
+        assert "missing subject" in exc_info.value.detail.lower()

--- a/backend/tests/test_duel_router.py
+++ b/backend/tests/test_duel_router.py
@@ -1,0 +1,117 @@
+"""Tests for the duel submission endpoint."""
+
+from __future__ import annotations
+
+import uuid
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+from backend.main import app
+from backend.db import get_db
+from backend.routers.auth import get_current_user
+from backend.schemas import DuelOutcome, DuelResult
+from backend.services.duel import ProcessDuelResult
+
+
+def _make_user():
+    user = MagicMock()
+    user.id = uuid.uuid4()
+    user.trakt_username = "testuser"
+    return user
+
+
+def _make_db():
+    return AsyncMock()
+
+
+FAKE_USER = _make_user()
+
+
+def _override_user():
+    return FAKE_USER
+
+
+def _override_db():
+    return _make_db()
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+class TestSubmitDuel:
+    def setup_method(self):
+        app.dependency_overrides[get_current_user] = _override_user
+        app.dependency_overrides[get_db] = _override_db
+
+    def teardown_method(self):
+        app.dependency_overrides.clear()
+
+    def test_valid_submission_returns_200(self):
+        """Valid duel submission returns 200 with ELO deltas."""
+        mid_a = str(uuid.uuid4())
+        mid_b = str(uuid.uuid4())
+
+        fake_result = ProcessDuelResult(
+            api_result=DuelResult(
+                outcome=DuelOutcome.a_wins,
+                movie_a_elo_delta=15,
+                movie_b_elo_delta=-15,
+                next_action="duel",
+            ),
+            new_elo_a=1015,
+            new_elo_b=985,
+        )
+
+        with patch("backend.routers.duels.process_duel", new_callable=AsyncMock) as mock_pd:
+            mock_pd.return_value = fake_result
+            client = TestClient(app)
+            response = client.post(
+                "/api/duels",
+                json={
+                    "movie_a_id": mid_a,
+                    "movie_b_id": mid_b,
+                    "outcome": "a_wins",
+                    "mode": "discovery",
+                },
+            )
+
+        assert response.status_code == 200
+        body = response.json()
+        assert body["movie_a_elo_delta"] == 15
+        assert body["movie_b_elo_delta"] == -15
+        assert body["next_action"] == "duel"
+
+    def test_self_duel_returns_400(self):
+        """Dueling a movie against itself should return 400."""
+        same_id = str(uuid.uuid4())
+        client = TestClient(app)
+        response = client.post(
+            "/api/duels",
+            json={
+                "movie_a_id": same_id,
+                "movie_b_id": same_id,
+                "outcome": "a_wins",
+                "mode": "discovery",
+            },
+        )
+        assert response.status_code == 400
+        assert "itself" in response.json()["detail"].lower()
+
+    def test_missing_auth_returns_401(self):
+        """Request without authentication should return 401."""
+        app.dependency_overrides.clear()
+        client = TestClient(app)
+        response = client.post(
+            "/api/duels",
+            json={
+                "movie_a_id": str(uuid.uuid4()),
+                "movie_b_id": str(uuid.uuid4()),
+                "outcome": "a_wins",
+            },
+        )
+        # Without auth override, should fail with 401
+        assert response.status_code == 401

--- a/backend/tests/test_duel_service.py
+++ b/backend/tests/test_duel_service.py
@@ -32,6 +32,39 @@ def _make_user_movie(
     return um
 
 
+def _make_fake_execute(um_a: MagicMock, um_b: MagicMock, seen_unranked: int = 5, total_seen: int = 20):
+    """Build a fake db.execute that dispatches by SQL statement content, not call order."""
+    returned_a = False
+    returned_b = False
+
+    async def fake_execute(stmt):
+        nonlocal returned_a, returned_b
+        result = MagicMock()
+        stmt_str = str(stmt)
+        # Count queries (contain 'count')
+        if "count" in stmt_str.lower():
+            # Distinguish seen_unranked (battles == 0) from total_seen
+            if "battles" in stmt_str.lower() or (not returned_a and "count" in stmt_str.lower()):
+                result.scalar_one.return_value = seen_unranked
+            else:
+                result.scalar_one.return_value = total_seen
+            return result
+        # UserMovie select queries — return um_a first, then um_b
+        if not returned_a:
+            returned_a = True
+            result.scalar_one_or_none.return_value = um_a
+            return result
+        if not returned_b:
+            returned_b = True
+            result.scalar_one_or_none.return_value = um_b
+            return result
+        # Fallback for any additional queries
+        result.scalar_one.return_value = seen_unranked
+        return result
+
+    return fake_execute
+
+
 # ---------------------------------------------------------------------------
 # get_or_create_user_movie
 # ---------------------------------------------------------------------------
@@ -90,26 +123,8 @@ async def test_process_duel_a_wins_elo():
     um_a = _make_user_movie(uid, mid_a, elo=1000, battles=5)
     um_b = _make_user_movie(uid, mid_b, elo=1000, battles=5)
 
-    call_count = 0
-
-    async def fake_execute(stmt):
-        nonlocal call_count
-        call_count += 1
-        result = MagicMock()
-        # First two calls: get_or_create for um_a and um_b
-        if call_count == 1:
-            result.scalar_one_or_none.return_value = um_a
-            return result
-        elif call_count == 2:
-            result.scalar_one_or_none.return_value = um_b
-            return result
-        else:
-            # seen_unranked count query
-            result.scalar_one.return_value = 5
-            return result
-
     db = AsyncMock()
-    db.execute = fake_execute
+    db.execute = _make_fake_execute(um_a, um_b)
 
     result = await process_duel(db, uid, mid_a, mid_b, "a_wins", "discovery")
 
@@ -136,24 +151,8 @@ async def test_process_duel_b_wins_elo():
     um_a = _make_user_movie(uid, mid_a, elo=1000, battles=5)
     um_b = _make_user_movie(uid, mid_b, elo=1000, battles=5)
 
-    call_count = 0
-
-    async def fake_execute(stmt):
-        nonlocal call_count
-        call_count += 1
-        result = MagicMock()
-        if call_count == 1:
-            result.scalar_one_or_none.return_value = um_a
-            return result
-        elif call_count == 2:
-            result.scalar_one_or_none.return_value = um_b
-            return result
-        else:
-            result.scalar_one.return_value = 5
-            return result
-
     db = AsyncMock()
-    db.execute = fake_execute
+    db.execute = _make_fake_execute(um_a, um_b)
 
     result = await process_duel(db, uid, mid_a, mid_b, "b_wins", "discovery")
 
@@ -178,24 +177,8 @@ async def test_process_duel_creates_duel_record():
     um_a = _make_user_movie(uid, mid_a, elo=1000, battles=3)
     um_b = _make_user_movie(uid, mid_b, elo=1000, battles=3)
 
-    call_count = 0
-
-    async def fake_execute(stmt):
-        nonlocal call_count
-        call_count += 1
-        result = MagicMock()
-        if call_count == 1:
-            result.scalar_one_or_none.return_value = um_a
-            return result
-        elif call_count == 2:
-            result.scalar_one_or_none.return_value = um_b
-            return result
-        else:
-            result.scalar_one.return_value = 5
-            return result
-
     db = AsyncMock()
-    db.execute = fake_execute
+    db.execute = _make_fake_execute(um_a, um_b)
 
     await process_duel(db, uid, mid_a, mid_b, "a_wins", "ranked")
 
@@ -232,25 +215,8 @@ async def test_next_action_swipe_when_few_seen_unranked():
     um_a = _make_user_movie(uid, mid_a, elo=1000, battles=2)
     um_b = _make_user_movie(uid, mid_b, elo=1000, battles=2)
 
-    call_count = 0
-
-    async def fake_execute(stmt):
-        nonlocal call_count
-        call_count += 1
-        result = MagicMock()
-        if call_count == 1:
-            result.scalar_one_or_none.return_value = um_a
-            return result
-        elif call_count == 2:
-            result.scalar_one_or_none.return_value = um_b
-            return result
-        else:
-            # Return seen_unranked count of 2 (< 3)
-            result.scalar_one.return_value = 2
-            return result
-
     db = AsyncMock()
-    db.execute = fake_execute
+    db.execute = _make_fake_execute(um_a, um_b, seen_unranked=2, total_seen=20)
 
     result = await process_duel(db, uid, mid_a, mid_b, "a_wins", "discovery")
     assert result.api_result.next_action == "swipe"
@@ -266,24 +232,8 @@ async def test_next_action_duel_when_enough_seen_unranked():
     um_a = _make_user_movie(uid, mid_a, elo=1000, battles=2)
     um_b = _make_user_movie(uid, mid_b, elo=1000, battles=2)
 
-    call_count = 0
-
-    async def fake_execute(stmt):
-        nonlocal call_count
-        call_count += 1
-        result = MagicMock()
-        if call_count == 1:
-            result.scalar_one_or_none.return_value = um_a
-            return result
-        elif call_count == 2:
-            result.scalar_one_or_none.return_value = um_b
-            return result
-        else:
-            result.scalar_one.return_value = 10
-            return result
-
     db = AsyncMock()
-    db.execute = fake_execute
+    db.execute = _make_fake_execute(um_a, um_b, seen_unranked=10, total_seen=20)
 
     result = await process_duel(db, uid, mid_a, mid_b, "a_wins", "discovery")
     assert result.api_result.next_action == "duel"
@@ -304,24 +254,8 @@ async def test_process_duel_uses_seeded_elo_when_no_elo():
     um_a = _make_user_movie(uid, mid_a, elo=None, seeded_elo=1200, battles=0)
     um_b = _make_user_movie(uid, mid_b, elo=None, seeded_elo=800, battles=0)
 
-    call_count = 0
-
-    async def fake_execute(stmt):
-        nonlocal call_count
-        call_count += 1
-        result = MagicMock()
-        if call_count == 1:
-            result.scalar_one_or_none.return_value = um_a
-            return result
-        elif call_count == 2:
-            result.scalar_one_or_none.return_value = um_b
-            return result
-        else:
-            result.scalar_one.return_value = 5
-            return result
-
     db = AsyncMock()
-    db.execute = fake_execute
+    db.execute = _make_fake_execute(um_a, um_b)
 
     result = await process_duel(db, uid, mid_a, mid_b, "a_wins", "discovery")
 
@@ -331,3 +265,143 @@ async def test_process_duel_uses_seeded_elo_when_no_elo():
     # ELO values should be based on seeded_elo, not default 1000
     assert result.new_elo_a > 1200
     assert result.new_elo_b < 800
+
+
+# ---------------------------------------------------------------------------
+# process_duel — a_only outcome
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_process_duel_a_only_skips_elo():
+    """a_only marks A as seen, B as unseen, no ELO change."""
+    uid = uuid.uuid4()
+    mid_a = uuid.uuid4()
+    mid_b = uuid.uuid4()
+
+    um_a = _make_user_movie(uid, mid_a, elo=1000, battles=5, seen=None)
+    um_b = _make_user_movie(uid, mid_b, elo=1000, battles=5, seen=None)
+
+    db = AsyncMock()
+    db.execute = _make_fake_execute(um_a, um_b)
+
+    result = await process_duel(db, uid, mid_a, mid_b, "a_only", "discovery")
+
+    assert result.api_result.movie_a_elo_delta == 0
+    assert result.api_result.movie_b_elo_delta == 0
+    assert um_a.seen is True
+    assert um_b.seen is False
+    # Battles should NOT be incremented for non-competitive outcomes
+    assert um_a.battles == 5
+    assert um_b.battles == 5
+
+
+# ---------------------------------------------------------------------------
+# process_duel — b_only outcome
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_process_duel_b_only_skips_elo():
+    """b_only marks B as seen, A as unseen, no ELO change."""
+    uid = uuid.uuid4()
+    mid_a = uuid.uuid4()
+    mid_b = uuid.uuid4()
+
+    um_a = _make_user_movie(uid, mid_a, elo=1000, battles=5, seen=None)
+    um_b = _make_user_movie(uid, mid_b, elo=1000, battles=5, seen=None)
+
+    db = AsyncMock()
+    db.execute = _make_fake_execute(um_a, um_b)
+
+    result = await process_duel(db, uid, mid_a, mid_b, "b_only", "discovery")
+
+    assert result.api_result.movie_a_elo_delta == 0
+    assert result.api_result.movie_b_elo_delta == 0
+    assert um_a.seen is False
+    assert um_b.seen is True
+    assert um_a.battles == 5
+    assert um_b.battles == 5
+
+
+# ---------------------------------------------------------------------------
+# process_duel — neither outcome
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_process_duel_neither_skips_elo():
+    """neither marks both as unseen, no ELO change."""
+    uid = uuid.uuid4()
+    mid_a = uuid.uuid4()
+    mid_b = uuid.uuid4()
+
+    um_a = _make_user_movie(uid, mid_a, elo=1000, battles=5, seen=None)
+    um_b = _make_user_movie(uid, mid_b, elo=1000, battles=5, seen=None)
+
+    db = AsyncMock()
+    db.execute = _make_fake_execute(um_a, um_b)
+
+    result = await process_duel(db, uid, mid_a, mid_b, "neither", "discovery")
+
+    assert result.api_result.movie_a_elo_delta == 0
+    assert result.api_result.movie_b_elo_delta == 0
+    assert um_a.seen is False
+    assert um_b.seen is False
+
+
+# ---------------------------------------------------------------------------
+# process_duel — pair_type classification
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_pair_type_ranked_vs_ranked():
+    """Both films with battles >= 1 should produce pair_type='ranked_vs_ranked'."""
+    uid = uuid.uuid4()
+    mid_a = uuid.uuid4()
+    mid_b = uuid.uuid4()
+
+    um_a = _make_user_movie(uid, mid_a, elo=1000, battles=3)
+    um_b = _make_user_movie(uid, mid_b, elo=1000, battles=5)
+
+    db = AsyncMock()
+    db.execute = _make_fake_execute(um_a, um_b)
+
+    await process_duel(db, uid, mid_a, mid_b, "a_wins", "ranked")
+
+    from backend.db_models import Duel
+
+    duel_adds = [
+        call.args[0]
+        for call in db.add.call_args_list
+        if isinstance(call.args[0], Duel)
+    ]
+    assert len(duel_adds) == 1
+    assert duel_adds[0].pair_type == "ranked_vs_ranked"
+
+
+@pytest.mark.asyncio
+async def test_pair_type_ranked_vs_unranked():
+    """One film with battles=0 should produce pair_type='ranked_vs_unranked'."""
+    uid = uuid.uuid4()
+    mid_a = uuid.uuid4()
+    mid_b = uuid.uuid4()
+
+    um_a = _make_user_movie(uid, mid_a, elo=1000, battles=3)
+    um_b = _make_user_movie(uid, mid_b, elo=None, battles=0)
+
+    db = AsyncMock()
+    db.execute = _make_fake_execute(um_a, um_b)
+
+    await process_duel(db, uid, mid_a, mid_b, "a_wins", "discovery")
+
+    from backend.db_models import Duel
+
+    duel_adds = [
+        call.args[0]
+        for call in db.add.call_args_list
+        if isinstance(call.args[0], Duel)
+    ]
+    assert len(duel_adds) == 1
+    assert duel_adds[0].pair_type == "ranked_vs_unranked"

--- a/backend/tests/test_expand_service.py
+++ b/backend/tests/test_expand_service.py
@@ -1,0 +1,151 @@
+"""Tests for expand_pool service — pool expansion with Trakt/TMDB sources."""
+
+from __future__ import annotations
+
+import uuid
+from datetime import datetime, timedelta, timezone
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from backend.services.expand import EXPANSION_COOLDOWN, _expand_pool_inner
+
+
+def _mock_session_factory(db):
+    """Create a context manager that yields the given db mock."""
+    cm = AsyncMock()
+    cm.__aenter__ = AsyncMock(return_value=db)
+    cm.__aexit__ = AsyncMock(return_value=False)
+    return cm
+
+
+def _make_user(user_id=None):
+    user = MagicMock()
+    user.id = user_id or uuid.uuid4()
+    user.trakt_access_token = "fake-token"
+    user.trakt_user_id = "testuser"
+    return user
+
+
+class TestExpandPoolInner:
+    @pytest.mark.asyncio
+    async def test_happy_path_calls_recommendations_source(self):
+        """expand_pool should call Trakt recommendations and upsert films."""
+        user_id = uuid.uuid4()
+        user = _make_user(user_id)
+        db = AsyncMock()
+
+        # Mock recent expansions query (empty = no cooldowns)
+        recent_result = MagicMock()
+        recent_result.all.return_value = []
+
+        # Mock Movie lookup after upsert
+        movie_uuid = uuid.uuid4()
+        movie_lookup = MagicMock()
+        movie_lookup.scalar_one_or_none.return_value = movie_uuid
+
+        # Mock user_movie insert
+        insert_result = MagicMock()
+        insert_result.rowcount = 1
+
+        call_idx = 0
+
+        async def fake_execute(stmt):
+            nonlocal call_idx
+            call_idx += 1
+            result = MagicMock()
+            stmt_str = str(stmt)
+            if "pool_expansion" in stmt_str.lower() or call_idx == 1:
+                result.all.return_value = []
+                return result
+            if "movie" in stmt_str.lower() and "select" in stmt_str.lower():
+                result.scalar_one_or_none.return_value = movie_uuid
+                return result
+            result.rowcount = 1
+            return result
+
+        db.execute = fake_execute
+        db.get = AsyncMock(return_value=user)
+
+        fake_recs = [
+            {"ids": {"trakt": 101, "imdb": "tt001"}, "title": "Rec Film", "year": 2024}
+        ]
+        trakt_mock = AsyncMock()
+        trakt_mock.get_recommendations.return_value = fake_recs
+
+        with (
+            patch("backend.services.expand.async_session_factory", return_value=_mock_session_factory(db)),
+            patch("backend.services.expand.TraktClient", return_value=trakt_mock),
+            patch("backend.services.expand.get_settings") as mock_settings,
+            patch("backend.services.expand.backfill_posters", new_callable=AsyncMock),
+        ):
+            mock_settings.return_value = MagicMock(
+                TRAKT_CLIENT_ID="fake", TMDB_API_KEY=""
+            )
+            result = await _expand_pool_inner(user_id, "movie")
+
+        assert result >= 0
+        trakt_mock.get_recommendations.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_cooldown_skips_source(self):
+        """Source with recent expansion within cooldown should be skipped."""
+        user_id = uuid.uuid4()
+        user = _make_user(user_id)
+        db = AsyncMock()
+
+        # Return recent expansion that covers all sources
+        recent_result = MagicMock()
+        recent_row = MagicMock()
+        recent_row.source = "trakt_recommendations"
+        recent_row.source_key = "movie_default"
+        recent_result.all.return_value = [recent_row]
+
+        call_idx = 0
+
+        async def fake_execute(stmt):
+            nonlocal call_idx
+            call_idx += 1
+            result = MagicMock()
+            if call_idx == 1:
+                result.all.return_value = [recent_row]
+                return result
+            result.all.return_value = []
+            result.scalar_one_or_none.return_value = None
+            result.rowcount = 0
+            return result
+
+        db.execute = fake_execute
+        db.get = AsyncMock(return_value=user)
+
+        trakt_mock = AsyncMock()
+        trakt_mock.get_recommendations.return_value = []
+
+        with (
+            patch("backend.services.expand.async_session_factory", return_value=_mock_session_factory(db)),
+            patch("backend.services.expand.TraktClient", return_value=trakt_mock),
+            patch("backend.services.expand.get_settings") as mock_settings,
+            patch("backend.services.expand.backfill_posters", new_callable=AsyncMock),
+        ):
+            mock_settings.return_value = MagicMock(
+                TRAKT_CLIENT_ID="fake", TMDB_API_KEY=""
+            )
+            await _expand_pool_inner(user_id, "movie")
+
+        # Recommendations should NOT be called (cooldown active)
+        trakt_mock.get_recommendations.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_returns_zero_when_user_not_found(self):
+        """Should return 0 when user doesn't exist."""
+        db = AsyncMock()
+        db.get = AsyncMock(return_value=None)
+
+        with (
+            patch("backend.services.expand.async_session_factory", return_value=_mock_session_factory(db)),
+            patch("backend.services.expand.get_settings") as mock_settings,
+        ):
+            mock_settings.return_value = MagicMock(TRAKT_CLIENT_ID="fake")
+            result = await _expand_pool_inner(uuid.uuid4(), "movie")
+
+        assert result == 0

--- a/backend/tests/test_pair_selection.py
+++ b/backend/tests/test_pair_selection.py
@@ -1,6 +1,7 @@
 """Tests for pair selection algorithm in routers/movies.py."""
 
 import random
+import unittest.mock
 import uuid
 from types import SimpleNamespace
 from unittest.mock import MagicMock
@@ -203,16 +204,19 @@ class TestWeightedSample:
 
     def test_settlement_weight_formula(self):
         """Films with fewer battles should have higher weight = 1/(battles+1)."""
-        # Run many samples to verify statistical tendency
         low_battles = _make_user_movie(battles=0)  # weight=1.0
         high_battles = _make_user_movie(battles=99)  # weight=0.01
-        random.seed(42)
-        counts = {id(low_battles): 0, id(high_battles): 0}
-        for _ in range(1000):
-            pick = _weighted_sample([low_battles, high_battles])
-            counts[id(pick)] += 1
-        # The low-battles film should be picked far more often
-        assert counts[id(low_battles)] > counts[id(high_battles)] * 5
+        with unittest.mock.patch("backend.services.pair_selection.random.choices") as mock_choices:
+            mock_choices.return_value = [low_battles]
+            result = _weighted_sample([low_battles, high_battles])
+            assert result is low_battles
+            # Verify weights passed to random.choices
+            call_args = mock_choices.call_args
+            weights = call_args[1]["weights"] if "weights" in call_args[1] else call_args[0][1]
+            # weight for low_battles = 1/(0+1) = 1.0, for high_battles = 1/(99+1) = 0.01
+            assert weights[0] == pytest.approx(1.0)
+            assert weights[1] == pytest.approx(0.01)
+            assert weights[0] > weights[1] * 5
 
     def test_single_film_list(self):
         film = _make_user_movie(battles=5)
@@ -236,18 +240,17 @@ class TestPickChallenger:
         assert result in candidates
 
     def test_close_match_preference(self):
-        """With seed forcing roll < 0.7, should prefer close ELO matches."""
+        """When roll < 0.7, _pick_challenger should prefer close ELO matches."""
         anchor = _make_user_movie(elo=1000, battles=5)
         close = _make_user_movie(elo=1020, battles=5)
         far = _make_user_movie(elo=1500, battles=5)
-        # Run many picks; close should dominate
-        random.seed(0)
-        close_count = 0
-        for _ in range(200):
-            pick = _pick_challenger(anchor, [close, far])
-            if pick is close:
-                close_count += 1
-        assert close_count > 100  # should be majority
+        with unittest.mock.patch("backend.services.pair_selection.random.random", return_value=0.3):
+            with unittest.mock.patch(
+                "backend.services.pair_selection.random.choices",
+                side_effect=lambda population, weights, k: [population[0]],
+            ):
+                result = _pick_challenger(anchor, [close, far])
+                assert result is close
 
     def test_falls_back_to_unranked_candidates(self):
         """When no ranked candidates, falls back to settlement-weighted sample."""

--- a/backend/tests/test_pool_service.py
+++ b/backend/tests/test_pool_service.py
@@ -1,0 +1,103 @@
+"""Tests for populate_movie_pool core flow."""
+
+from __future__ import annotations
+
+import uuid
+from datetime import datetime, timedelta, timezone
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from backend.services.pool import SYNC_COOLDOWN, populate_movie_pool
+
+
+def _make_user(last_seen_at=None):
+    user = MagicMock()
+    user.id = uuid.uuid4()
+    user.trakt_user_id = "testuser"
+    user.trakt_username = "testuser"
+    user.trakt_access_token = "fake-token"
+    user.last_seen_at = last_seen_at
+    return user
+
+
+class TestPopulateMoviePool:
+    @pytest.mark.asyncio
+    async def test_fetches_and_upserts_from_trakt(self):
+        """populate_movie_pool calls Trakt APIs and upserts films."""
+        user = _make_user(last_seen_at=None)
+        db = AsyncMock()
+
+        fake_popular = [
+            {
+                "ids": {"trakt": 1, "imdb": "tt001", "tmdb": 100},
+                "title": "Pop Film",
+                "year": 2024,
+                "genres": ["Drama"],
+                "rating": 7.5,
+            }
+        ]
+        fake_watched = [
+            {
+                "ids": {"trakt": 2, "imdb": "tt002", "tmdb": 200},
+                "title": "Watched Film",
+                "year": 2023,
+                "genres": ["Action"],
+            }
+        ]
+
+        trakt_mock = AsyncMock()
+        trakt_mock.get_popular.return_value = fake_popular
+        trakt_mock.get_trending.return_value = []
+        trakt_mock.get_recommendations.return_value = []
+        trakt_mock.get_user_watched.return_value = fake_watched
+        trakt_mock.get_user_ratings.return_value = []
+        trakt_mock.get_popular_shows.return_value = []
+        trakt_mock.get_trending_shows.return_value = []
+        trakt_mock.get_recommendations_shows.return_value = []
+        trakt_mock.get_user_watched_shows.return_value = []
+        trakt_mock.get_user_ratings_shows.return_value = []
+
+        # Mock the DB execute for movie upserts and UUID lookups
+        movie_uuid_1 = uuid.uuid4()
+        movie_uuid_2 = uuid.uuid4()
+
+        exec_count = 0
+
+        async def fake_execute(stmt):
+            nonlocal exec_count
+            exec_count += 1
+            result = MagicMock()
+            # After upserts, the UUID lookup returns movie UUIDs
+            result.all.return_value = [
+                MagicMock(id=movie_uuid_1, trakt_id=1),
+                MagicMock(id=movie_uuid_2, trakt_id=2),
+            ]
+            result.rowcount = 1
+            return result
+
+        db.execute = fake_execute
+
+        with (
+            patch("backend.services.pool.TraktClient", return_value=trakt_mock),
+            patch("backend.services.pool.get_settings") as mock_settings,
+        ):
+            mock_settings.return_value = MagicMock(TRAKT_CLIENT_ID="fake")
+            await populate_movie_pool(user, db)
+
+        trakt_mock.get_popular.assert_awaited_once()
+        trakt_mock.get_user_watched.assert_awaited_once()
+        # last_seen_at should be updated
+        assert user.last_seen_at is not None
+
+    @pytest.mark.asyncio
+    async def test_cooldown_skips_sync(self):
+        """Should skip sync when last_seen_at is within cooldown."""
+        recent_time = datetime.now(timezone.utc) - timedelta(minutes=30)
+        user = _make_user(last_seen_at=recent_time)
+        db = AsyncMock()
+
+        await populate_movie_pool(user, db)
+
+        # No DB execute calls since we skipped
+        db.execute.assert_not_awaited()

--- a/backend/tests/test_suggest_service.py
+++ b/backend/tests/test_suggest_service.py
@@ -1,0 +1,37 @@
+"""Tests for suggestion service — taste profile and threshold checks."""
+
+from __future__ import annotations
+
+import uuid
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from backend.services.suggest import MIN_RANKED, has_enough_ranked
+
+
+def _mock_count_result(count: int):
+    """Build a mock DB result that returns a scalar count."""
+    result = MagicMock()
+    result.scalar.return_value = count
+    return result
+
+
+class TestHasEnoughRanked:
+    @pytest.mark.asyncio
+    async def test_returns_false_below_threshold(self):
+        """User with < MIN_RANKED films should return False."""
+        db = AsyncMock()
+        db.execute.return_value = _mock_count_result(MIN_RANKED - 1)
+
+        result = await has_enough_ranked(uuid.uuid4(), db, "movie")
+        assert result is False
+
+    @pytest.mark.asyncio
+    async def test_returns_true_at_threshold(self):
+        """User with exactly MIN_RANKED films should return True."""
+        db = AsyncMock()
+        db.execute.return_value = _mock_count_result(MIN_RANKED)
+
+        result = await has_enough_ranked(uuid.uuid4(), db, "movie")
+        assert result is True

--- a/backend/tests/test_tournament_service.py
+++ b/backend/tests/test_tournament_service.py
@@ -1,8 +1,16 @@
-"""Tests for tournament service pure functions."""
+"""Tests for tournament service pure functions and bracket logic."""
+
+import uuid
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
-from backend.services.tournament import _num_rounds, generate_seeded_bracket
+from backend.services.tournament import (
+    _num_rounds,
+    create_tournament_bracket,
+    generate_seeded_bracket,
+    validate_match,
+)
 
 
 class TestGenerateSeededBracket:
@@ -74,3 +82,200 @@ class TestNumRounds:
 
     def test_size_64(self):
         assert _num_rounds(64) == 6
+
+
+# ---------------------------------------------------------------------------
+# create_tournament_bracket — bye handling
+# ---------------------------------------------------------------------------
+
+
+def _make_seeded_film(movie_id=None, elo=1000):
+    """Create a mock UserMovie for seeding tests."""
+    um = MagicMock()
+    um.movie_id = movie_id or uuid.uuid4()
+    um.elo = elo
+    return um
+
+
+class TestCreateTournamentBracketWithByes:
+    @pytest.mark.asyncio
+    async def test_bracket_5_films_in_8_slots_creates_correct_matches(self):
+        """5 films in an 8-slot bracket should create 4 round-1 matches and 3 byes."""
+        tournament_id = uuid.uuid4()
+        films = [_make_seeded_film(elo=1500 - i * 100) for i in range(5)]
+        added_objects = []
+
+        db = AsyncMock()
+        db.add = MagicMock(side_effect=lambda obj: added_objects.append(obj))
+
+        # Mock the round-2 match lookup for bye propagation
+        round2_matches = {}
+        for pos in range(4):
+            m = MagicMock()
+            m.movie_a_id = None
+            m.movie_b_id = None
+            round2_matches[pos] = m
+
+        async def fake_execute(stmt):
+            stmt_str = str(stmt)
+            result = MagicMock()
+            if "round" in stmt_str and "is_bye" in stmt_str:
+                # Return bye matches from round 1
+                bye_matches = [obj for obj in added_objects if getattr(obj, "is_bye", False)]
+                result.scalars.return_value.all.return_value = bye_matches
+                return result
+            # Round 2 position lookup
+            for pos in range(4):
+                if f"position == {pos}" in stmt_str or True:
+                    pass
+            result.scalar_one.return_value = round2_matches.get(0, MagicMock())
+            return result
+
+        db.execute = fake_execute
+
+        await create_tournament_bracket(db, tournament_id, 8, films)
+
+        from backend.db_models import TournamentMatch
+        round1_matches = [
+            obj for obj in added_objects
+            if isinstance(obj, TournamentMatch) and obj.round == 1
+        ]
+        assert len(round1_matches) == 4
+
+        bye_matches = [m for m in round1_matches if m.is_bye]
+        real_matches = [m for m in round1_matches if not getattr(m, "is_bye", False)]
+        assert len(bye_matches) == 3
+        assert len(real_matches) == 1
+
+    @pytest.mark.asyncio
+    async def test_bracket_8_films_no_byes(self):
+        """8 films in an 8-slot bracket should have zero byes."""
+        tournament_id = uuid.uuid4()
+        films = [_make_seeded_film() for _ in range(8)]
+        added_objects = []
+
+        db = AsyncMock()
+        db.add = MagicMock(side_effect=lambda obj: added_objects.append(obj))
+
+        await create_tournament_bracket(db, tournament_id, 8, films)
+
+        from backend.db_models import TournamentMatch
+        round1_matches = [
+            obj for obj in added_objects
+            if isinstance(obj, TournamentMatch) and obj.round == 1
+        ]
+        bye_matches = [m for m in round1_matches if getattr(m, "is_bye", False)]
+        assert len(bye_matches) == 0
+        assert len(round1_matches) == 4
+
+    @pytest.mark.asyncio
+    async def test_bye_winner_has_correct_movie_id(self):
+        """Bye match winner_movie_id should equal the present film's movie_id."""
+        tournament_id = uuid.uuid4()
+        films = [_make_seeded_film() for _ in range(5)]
+        added_objects = []
+
+        db = AsyncMock()
+        db.add = MagicMock(side_effect=lambda obj: added_objects.append(obj))
+
+        # Simple mock for flush and execute (bye propagation queries)
+        round2_mock = MagicMock()
+        round2_mock.movie_a_id = None
+        round2_mock.movie_b_id = None
+
+        async def fake_execute(stmt):
+            result = MagicMock()
+            stmt_str = str(stmt)
+            if "is_bye" in stmt_str:
+                bye_matches = [obj for obj in added_objects if getattr(obj, "is_bye", False)]
+                result.scalars.return_value.all.return_value = bye_matches
+            else:
+                result.scalar_one.return_value = round2_mock
+            return result
+
+        db.execute = fake_execute
+
+        await create_tournament_bracket(db, tournament_id, 8, films)
+
+        from backend.db_models import TournamentMatch
+        bye_matches = [
+            obj for obj in added_objects
+            if isinstance(obj, TournamentMatch) and getattr(obj, "is_bye", False)
+        ]
+        for bm in bye_matches:
+            assert bm.winner_movie_id is not None
+            assert bm.winner_movie_id == bm.movie_a_id
+
+
+# ---------------------------------------------------------------------------
+# validate_match
+# ---------------------------------------------------------------------------
+
+
+class TestValidateMatch:
+    def test_rejects_already_played_match(self):
+        """Should raise ValueError for a match that already has a winner."""
+        match_id = uuid.uuid4()
+        winner_id = uuid.uuid4()
+        loser_id = uuid.uuid4()
+
+        match = MagicMock()
+        match.id = match_id
+        match.movie_a_id = winner_id
+        match.movie_b_id = loser_id
+        match.winner_movie_id = winner_id  # already played
+
+        tournament = MagicMock()
+        tournament.status = "active"
+        tournament.matches = [match]
+
+        with pytest.raises(ValueError, match="already played"):
+            validate_match(tournament, match_id, winner_id)
+
+    def test_rejects_winner_not_in_match(self):
+        """Should raise ValueError if winner_id is not movie_a or movie_b."""
+        match_id = uuid.uuid4()
+        movie_a = uuid.uuid4()
+        movie_b = uuid.uuid4()
+        wrong_winner = uuid.uuid4()
+
+        match = MagicMock()
+        match.id = match_id
+        match.movie_a_id = movie_a
+        match.movie_b_id = movie_b
+        match.winner_movie_id = None
+
+        tournament = MagicMock()
+        tournament.status = "active"
+        tournament.matches = [match]
+
+        with pytest.raises(ValueError, match="must be one of"):
+            validate_match(tournament, match_id, wrong_winner)
+
+    def test_returns_loser_id(self):
+        """Should return the loser_id when validation passes."""
+        match_id = uuid.uuid4()
+        movie_a = uuid.uuid4()
+        movie_b = uuid.uuid4()
+
+        match = MagicMock()
+        match.id = match_id
+        match.movie_a_id = movie_a
+        match.movie_b_id = movie_b
+        match.winner_movie_id = None
+
+        tournament = MagicMock()
+        tournament.status = "active"
+        tournament.matches = [match]
+
+        loser = validate_match(tournament, match_id, movie_a)
+        assert loser == movie_b
+
+    def test_rejects_inactive_tournament(self):
+        """Should raise ValueError for a non-active tournament."""
+        tournament = MagicMock()
+        tournament.status = "completed"
+        tournament.matches = []
+
+        with pytest.raises(ValueError, match="not active"):
+            validate_match(tournament, uuid.uuid4(), uuid.uuid4())

--- a/backend/tests/test_trakt_client.py
+++ b/backend/tests/test_trakt_client.py
@@ -1,0 +1,117 @@
+"""Tests for TraktClient HTTP methods."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import httpx
+import pytest
+
+from backend.services.trakt import TraktClient
+
+
+def _mock_response(json_data, status_code=200):
+    """Build a mock httpx.Response."""
+    resp = MagicMock(spec=httpx.Response)
+    resp.status_code = status_code
+    resp.json.return_value = json_data
+    resp.raise_for_status = MagicMock()
+    if status_code >= 400:
+        resp.raise_for_status.side_effect = httpx.HTTPStatusError(
+            "error", request=MagicMock(), response=resp
+        )
+    return resp
+
+
+class TestTraktClientExchangeCode:
+    @pytest.mark.asyncio
+    async def test_exchange_code_posts_correct_payload(self):
+        """exchange_code sends correct JSON body and returns token dict."""
+        expected_tokens = {"access_token": "abc", "refresh_token": "def", "expires_in": 7776000}
+        mock_resp = _mock_response(expected_tokens)
+
+        mock_client = AsyncMock()
+        mock_client.post.return_value = mock_resp
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=False)
+
+        client = TraktClient(client_id="test-client-id")
+        with patch.object(client, "_client", return_value=mock_client):
+            result = await client.exchange_code("auth-code", "secret", "http://redirect")
+
+        assert result == expected_tokens
+        call_args = mock_client.post.call_args
+        assert call_args[0][0] == "/oauth/token"
+        body = call_args[1]["json"]
+        assert body["code"] == "auth-code"
+        assert body["client_id"] == "test-client-id"
+        assert body["client_secret"] == "secret"
+        assert body["grant_type"] == "authorization_code"
+
+
+class TestTraktClientPopular:
+    @pytest.mark.asyncio
+    async def test_get_popular_movies_url(self):
+        """get_popular calls /movies/popular with correct params."""
+        mock_resp = _mock_response([{"ids": {"trakt": 1}, "title": "Film"}])
+
+        mock_client = AsyncMock()
+        mock_client.get.return_value = mock_resp
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=False)
+
+        client = TraktClient(client_id="test-id")
+        with patch.object(client, "_client", return_value=mock_client):
+            result = await client.get_popular(limit=50)
+
+        assert result == [{"ids": {"trakt": 1}, "title": "Film"}]
+        call_args = mock_client.get.call_args
+        assert call_args[0][0] == "/movies/popular"
+        assert call_args[1]["params"]["limit"] == 50
+
+    @pytest.mark.asyncio
+    async def test_get_popular_shows_url(self):
+        """get_popular_shows calls /shows/popular."""
+        mock_resp = _mock_response([{"ids": {"trakt": 2}, "title": "Show"}])
+
+        mock_client = AsyncMock()
+        mock_client.get.return_value = mock_resp
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=False)
+
+        client = TraktClient(client_id="test-id")
+        with patch.object(client, "_client", return_value=mock_client):
+            result = await client.get_popular_shows(limit=50)
+
+        assert result == [{"ids": {"trakt": 2}, "title": "Show"}]
+        call_args = mock_client.get.call_args
+        assert call_args[0][0] == "/shows/popular"
+
+
+class TestTraktClientAuthHeader:
+    def test_auth_header_present_when_token_provided(self):
+        """Constructor should add Bearer token when access_token is provided."""
+        client = TraktClient(client_id="cid", access_token="my-token")
+        assert client._headers["Authorization"] == "Bearer my-token"
+
+    def test_no_auth_header_without_token(self):
+        """Constructor should not add Authorization header without access_token."""
+        client = TraktClient(client_id="cid")
+        assert "Authorization" not in client._headers
+
+
+class TestTraktClientErrorPropagation:
+    @pytest.mark.asyncio
+    async def test_http_error_raises(self):
+        """4xx/5xx responses should raise HTTPStatusError."""
+        mock_resp = _mock_response({}, status_code=401)
+
+        mock_client = AsyncMock()
+        mock_client.get.return_value = mock_resp
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=False)
+
+        client = TraktClient(client_id="test-id")
+        with patch.object(client, "_client", return_value=mock_client):
+            with pytest.raises(httpx.HTTPStatusError):
+                await client.get_popular()

--- a/frontend/src/__tests__/App.test.jsx
+++ b/frontend/src/__tests__/App.test.jsx
@@ -45,14 +45,20 @@ describe("App", () => {
   });
 
   it("shows loading state while checking auth", () => {
-    // fetch never resolves
-    vi.stubGlobal("fetch", vi.fn(() => new Promise(() => {})));
+    const controller = new AbortController();
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(() => new Promise((_, reject) => {
+        controller.signal.addEventListener("abort", () => reject(new DOMException("Aborted", "AbortError")));
+      }))
+    );
     render(
       <MemoryRouter initialEntries={["/"]}>
         <App />
       </MemoryRouter>
     );
     expect(screen.getByText("Loading...")).toBeInTheDocument();
+    controller.abort();
   });
 
   it("redirects to /login when unauthenticated", async () => {

--- a/frontend/src/__tests__/Duel.test.jsx
+++ b/frontend/src/__tests__/Duel.test.jsx
@@ -72,9 +72,19 @@ describe("Duel", () => {
     vi.stubGlobal("fetch", setupFetch());
   });
 
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
   it("shows loading skeleton initially", () => {
-    // fetch never resolves so we see loading
-    vi.stubGlobal("fetch", vi.fn(() => new Promise(() => {})));
+    // Use AbortController so the pending fetch can be cleaned up
+    const controller = new AbortController();
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(() => new Promise((_, reject) => {
+        controller.signal.addEventListener("abort", () => reject(new DOMException("Aborted", "AbortError")));
+      }))
+    );
     render(
       <MemoryRouter>
         <Duel />
@@ -83,6 +93,7 @@ describe("Duel", () => {
     // Skeleton has animate-pulse divs
     const pulseElements = document.querySelectorAll(".animate-pulse");
     expect(pulseElements.length).toBeGreaterThan(0);
+    controller.abort();
   });
 
   it("renders two movie cards when pair loads", async () => {
@@ -195,6 +206,7 @@ describe("Duel", () => {
   });
 
   it("shows swipe interstitial when next_action is swipe", async () => {
+    vi.useFakeTimers({ shouldAdvanceTime: true });
     const mockFetch = setupFetch({
       duelResult: { movie_a_elo_delta: 12, movie_b_elo_delta: -12, next_action: "swipe" },
     });
@@ -216,14 +228,13 @@ describe("Duel", () => {
     );
     fireEvent.click(alienButton);
 
-    // The swipe prompt appears after a 900ms setTimeout
-    await waitFor(
-      () => {
-        expect(screen.getByText("Time to discover more films")).toBeInTheDocument();
-        expect(screen.getByText("Swipe 10 Films")).toBeInTheDocument();
-      },
-      { timeout: 3000 }
-    );
+    // Advance past the 600ms winner flash timeout
+    await vi.advanceTimersByTimeAsync(700);
+
+    await waitFor(() => {
+      expect(screen.getByText("Time to discover more films")).toBeInTheDocument();
+      expect(screen.getByText("Swipe 10 Films")).toBeInTheDocument();
+    });
   });
 
   it("prefetches next pair on load", async () => {

--- a/frontend/src/__tests__/Nav.test.jsx
+++ b/frontend/src/__tests__/Nav.test.jsx
@@ -74,10 +74,7 @@ describe("Nav", () => {
   });
 
   it("Sign Out button calls logout API", async () => {
-    // Mock window.location for redirect
-    const originalLocation = window.location;
-    delete window.location;
-    window.location = { href: "" };
+    vi.stubGlobal("location", { href: "" });
 
     renderNav();
     fireEvent.click(screen.getByText("Sign Out"));
@@ -89,7 +86,7 @@ describe("Nav", () => {
       );
     });
 
-    window.location = originalLocation;
+    vi.unstubAllGlobals();
   });
 
   it("renders START DUEL button", () => {

--- a/frontend/src/__tests__/Rankings.test.jsx
+++ b/frontend/src/__tests__/Rankings.test.jsx
@@ -143,13 +143,20 @@ describe("Rankings", () => {
   });
 
   it("shows loading state initially", () => {
-    vi.stubGlobal("fetch", vi.fn(() => new Promise(() => {})));
+    const controller = new AbortController();
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(() => new Promise((_, reject) => {
+        controller.signal.addEventListener("abort", () => reject(new DOMException("Aborted", "AbortError")));
+      }))
+    );
     render(
       <MemoryRouter>
         <Rankings />
       </MemoryRouter>
     );
     expect(screen.getByText("Loading rankings...")).toBeInTheDocument();
+    controller.abort();
   });
 
   it("renders genre filter pills", async () => {


### PR DESCRIPTION
## Summary
- **Fix auth handler bug:** `payload["sub"]` KeyError on missing JWT subject now returns 401 instead of crashing with 500
- **Fix flaky frontend tests:** use fake timers for Duel swipe interstitial, safe `window.location` cleanup in Nav, resolve never-settling fetch stubs in App/Duel/Rankings loading tests
- **Replace brittle statistical tests:** seed-dependent pair selection tests now use deterministic mocks instead of `random.seed()` with loop assertions
- **Add 5 new test suites:** TraktClient (HTTP mocking), duel router (endpoint integration), expand/pool/suggest services (business logic coverage)
- **Expand existing suites:** tournament bracket creation with bye handling, duel service missing outcome branches (`a_only`, `b_only`, `neither`), pair_type classification

## Changes
- 14 files changed, +978 / -148 lines
- 5 new test files, 9 modified
- 1 production bugfix (`backend/routers/auth.py` — KeyError → proper 401)

## Test plan
- [x] Frontend tests pass (86/86 via Vitest)
- [ ] Backend tests pass (Python not available in worktree — requires virtualenv activation)

🤖 Generated with [Claude Code](https://claude.com/claude-code)