### PR TITLE
feat: TV Show mode visual differentiation with color scheme and string audit

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,8 +61,9 @@ Alembic migrations run automatically on container start.
 ## How It Works
 
 1. Sign in with your Trakt account
-2. Movies are pulled from Trakt popular/trending lists + your watch history
-3. You're shown two movies at a time — pick the one you prefer
-4. ELO ratings update after each duel (K=32, default 1000)
-5. View your ranked list and export as Letterboxd-compatible CSV
-6. Ratings sync back to Trakt on a 1-10 scale
+2. Toggle between **Movies** and **TV Shows** using the nav bar
+3. Content is pulled from Trakt popular/trending lists + your watch history
+4. You're shown two titles at a time — pick the one you rate higher
+5. ELO ratings update after each duel (K=32, default 1000)
+6. View your ranked list and export as Letterboxd-compatible CSV
+7. Ratings sync back to Trakt on a 1-10 scale

--- a/backend/services/pair_selection.py
+++ b/backend/services/pair_selection.py
@@ -99,7 +99,7 @@ async def select_pair(
     seen_films = list(seen_result.unique().scalars().all())
 
     if len(seen_films) < 2:
-        raise ValueError("Need more seen films to duel. Swipe to classify some movies first!")
+        raise ValueError(f"Need more seen {media_type}s to duel. Swipe to classify some {media_type}s first!")
 
     # Split into anchors (ranked, battles >= 1) and full pool
     anchor_pool = [f for f in seen_films if f.battles >= 1 and f.elo is not None]

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -47,6 +47,7 @@ export default function App() {
 
   useEffect(() => {
     document.body.classList.toggle("show-mode", mediaType === "show");
+    return () => document.body.classList.remove("show-mode");
   }, [mediaType]);
 
   if (isLogin) {

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -45,6 +45,10 @@ export default function App() {
     localStorage.setItem("filmduel_media_type", mediaType);
   }, [mediaType]);
 
+  useEffect(() => {
+    document.body.classList.toggle("show-mode", mediaType === "show");
+  }, [mediaType]);
+
   if (isLogin) {
     return (
       <div className="min-h-screen bg-[#0F0E0D] text-[#F5F0E8]">
@@ -104,7 +108,7 @@ export default function App() {
             path="/tournaments/:id"
             element={
               <ProtectedRoute>
-                <TournamentBracket />
+                <TournamentBracket mediaType={mediaType} />
               </ProtectedRoute>
             }
           />

--- a/frontend/src/__tests__/App.test.jsx
+++ b/frontend/src/__tests__/App.test.jsx
@@ -1,6 +1,6 @@
 import { render, screen, waitFor } from "@testing-library/react";
 import { MemoryRouter } from "react-router-dom";
-import { describe, it, expect, beforeEach, vi } from "vitest";
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import App from "../App";
 
 describe("App", () => {
@@ -87,6 +87,33 @@ describe("App", () => {
     // "Swipe" appears in both desktop and mobile nav
     const swipeLinks = screen.getAllByText("Swipe");
     expect(swipeLinks.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it("adds show-mode class to body when mediaType is show", async () => {
+    localStorage.setItem("filmduel_media_type", "show");
+    render(
+      <MemoryRouter initialEntries={["/"]}>
+        <App />
+      </MemoryRouter>
+    );
+    await waitFor(() => {
+      expect(document.body.classList.contains("show-mode")).toBe(true);
+    });
+    localStorage.removeItem("filmduel_media_type");
+    document.body.classList.remove("show-mode");
+  });
+
+  it("does not add show-mode class when mediaType is movie", async () => {
+    localStorage.setItem("filmduel_media_type", "movie");
+    render(
+      <MemoryRouter initialEntries={["/"]}>
+        <App />
+      </MemoryRouter>
+    );
+    await waitFor(() => {
+      expect(document.body.classList.contains("show-mode")).toBe(false);
+    });
+    localStorage.removeItem("filmduel_media_type");
   });
 
   it("routes to /rankings correctly", async () => {

--- a/frontend/src/__tests__/Duel.test.jsx
+++ b/frontend/src/__tests__/Duel.test.jsx
@@ -237,6 +237,61 @@ describe("Duel", () => {
     });
   });
 
+  it("shows 'show' instruction text in show mode", async () => {
+    vi.stubGlobal("fetch", setupFetch());
+    render(
+      <MemoryRouter>
+        <Duel mediaType="show" />
+      </MemoryRouter>
+    );
+    await waitFor(() => {
+      expect(screen.getByText("Tap the show you rate higher")).toBeInTheDocument();
+    });
+  });
+
+  it("shows 'shows ranked' stat label in show mode", async () => {
+    vi.stubGlobal("fetch", setupFetch());
+    render(
+      <MemoryRouter>
+        <Duel mediaType="show" />
+      </MemoryRouter>
+    );
+    await waitFor(() => {
+      expect(screen.getByText("shows ranked")).toBeInTheDocument();
+    });
+  });
+
+  it("shows swipe interstitial with show strings when next_action is swipe and mediaType is show", async () => {
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    const mockFetch = setupFetch({
+      duelResult: { movie_a_elo_delta: 12, movie_b_elo_delta: -12, next_action: "swipe" },
+    });
+    vi.stubGlobal("fetch", mockFetch);
+
+    render(
+      <MemoryRouter>
+        <Duel mediaType="show" />
+      </MemoryRouter>
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText("Alien")).toBeInTheDocument();
+    });
+
+    const buttons = screen.getAllByRole("button");
+    const alienButton = buttons.find(
+      (b) => b.textContent.includes("Alien") && !b.textContent.includes("Aliens")
+    );
+    fireEvent.click(alienButton);
+
+    await vi.advanceTimersByTimeAsync(700);
+
+    await waitFor(() => {
+      expect(screen.getByText("Time to discover more shows")).toBeInTheDocument();
+      expect(screen.getByText("Swipe 10 Shows")).toBeInTheDocument();
+    });
+  });
+
   it("prefetches next pair on load", async () => {
     const mockFetch = setupFetch();
     vi.stubGlobal("fetch", mockFetch);

--- a/frontend/src/__tests__/TournamentBracket.test.jsx
+++ b/frontend/src/__tests__/TournamentBracket.test.jsx
@@ -1,0 +1,54 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { describe, it, expect, vi } from "vitest";
+import TournamentBracket from "../pages/TournamentBracket";
+
+vi.mock("react-router-dom", async () => {
+  const actual = await vi.importActual("react-router-dom");
+  return { ...actual, useNavigate: () => vi.fn(), useParams: () => ({ id: "1" }) };
+});
+
+const fakeTournament = {
+  id: 1,
+  name: "Test Tournament",
+  bracket_size: 8,
+  status: "in_progress",
+  current_round: 1,
+  total_rounds: 3,
+  matches: [],
+};
+
+function setupFetch(tournament = fakeTournament) {
+  return vi.fn((url) => {
+    if (url.includes("/api/tournaments/1")) {
+      return Promise.resolve({ ok: true, json: () => Promise.resolve(tournament) });
+    }
+    return Promise.resolve({ ok: true, json: () => Promise.resolve({}) });
+  });
+}
+
+describe("TournamentBracket", () => {
+  it("renders film label by default", async () => {
+    vi.stubGlobal("fetch", setupFetch());
+    render(
+      <MemoryRouter>
+        <TournamentBracket />
+      </MemoryRouter>
+    );
+    await waitFor(() => {
+      expect(screen.getByText(/8 films/i)).toBeInTheDocument();
+    });
+  });
+
+  it("renders show label when mediaType is show", async () => {
+    vi.stubGlobal("fetch", setupFetch());
+    render(
+      <MemoryRouter>
+        <TournamentBracket mediaType="show" />
+      </MemoryRouter>
+    );
+    await waitFor(() => {
+      expect(screen.getByText(/8 shows/i)).toBeInTheDocument();
+    });
+  });
+});

--- a/frontend/src/__tests__/utils.test.js
+++ b/frontend/src/__tests__/utils.test.js
@@ -1,0 +1,18 @@
+import { describe, it, expect } from "vitest";
+import { mediaLabel } from "../lib/utils";
+
+describe("mediaLabel", () => {
+  it('returns "show" for mediaType "show"', () => {
+    expect(mediaLabel("show")).toBe("show");
+  });
+
+  it('returns "film" for mediaType "movie"', () => {
+    expect(mediaLabel("movie")).toBe("film");
+  });
+
+  it('returns "film" for unknown/undefined mediaType', () => {
+    expect(mediaLabel(undefined)).toBe("film");
+    expect(mediaLabel(null)).toBe("film");
+    expect(mediaLabel("tv")).toBe("film");
+  });
+});

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -33,6 +33,14 @@
   --font-body: 'Manrope', sans-serif;
 }
 
+.show-mode {
+  --color-primary: #5bbfff;
+  --color-primary-container: #2096E8;
+  --color-positive: #2096E8;
+  --color-ring: #2096E8;
+  --color-negative: #C04A20;
+}
+
 body {
   background-color: #0F0E0D;
   color: #F5F0E8;

--- a/frontend/src/lib/utils.js
+++ b/frontend/src/lib/utils.js
@@ -4,3 +4,7 @@ import { twMerge } from "tailwind-merge";
 export function cn(...inputs) {
   return twMerge(clsx(inputs));
 }
+
+export function mediaLabel(mediaType) {
+  return mediaType === "show" ? "show" : "film";
+}

--- a/frontend/src/lib/utils.js
+++ b/frontend/src/lib/utils.js
@@ -8,3 +8,7 @@ export function cn(...inputs) {
 export function mediaLabel(mediaType) {
   return mediaType === "show" ? "show" : "film";
 }
+
+export function mediaLabelCap(mediaType) {
+  return mediaType === "show" ? "Show" : "Film";
+}

--- a/frontend/src/pages/Duel.jsx
+++ b/frontend/src/pages/Duel.jsx
@@ -2,6 +2,7 @@ import { useState, useEffect, useCallback, useRef } from "react";
 import { useNavigate } from "react-router-dom";
 import { fetchPair, submitDuel, fetchStats } from "../api";
 import MovieCard from "../components/MovieCard";
+import { mediaLabel } from "../lib/utils";
 
 const MODE = "discovery";
 
@@ -14,6 +15,7 @@ function SkeletonCard() {
 }
 
 export default function Duel({ mediaType = "movie" }) {
+  const label = mediaLabel(mediaType);
   const navigate = useNavigate();
   const [pair, setPair] = useState(null);
   const [loading, setLoading] = useState(true);
@@ -138,13 +140,13 @@ export default function Duel({ mediaType = "movie" }) {
         <div className="absolute inset-0 z-50 bg-[#0F0E0D]/95 backdrop-blur-xl flex flex-col items-center justify-center gap-8 p-12">
           <div className="text-center space-y-4">
             <p className="text-[10px] font-label uppercase tracking-[0.3em] text-[#d6c4ae]/60">
-              Running low on films
+              {`Running low on ${label}s`}
             </p>
             <h2 className="text-3xl md:text-4xl font-headline font-black uppercase tracking-tighter text-[#F5F0E8]">
-              Time to discover more films
+              {`Time to discover more ${label}s`}
             </h2>
             <p className="text-[#6B6760] font-body text-lg max-w-md">
-              Swipe through 10 films to classify them as seen or unseen, then come back for more duels.
+              {`Swipe through 10 ${label}s to classify them as seen or unseen, then come back for more duels.`}
             </p>
           </div>
           <div className="flex flex-col gap-3 w-full max-w-xs">
@@ -152,7 +154,7 @@ export default function Duel({ mediaType = "movie" }) {
               onClick={() => navigate("/swipe")}
               className="bg-[#E8A020] text-[#0F0E0D] font-headline font-black py-5 uppercase tracking-[0.2em] text-base hover:shadow-[0_0_30px_rgba(232,160,32,0.4)] active:scale-[0.98] transition-all"
             >
-              Swipe 10 Films
+              {`Swipe 10 ${label.charAt(0).toUpperCase() + label.slice(1)}s`}
             </button>
             <button
               onClick={() => {
@@ -183,7 +185,7 @@ export default function Duel({ mediaType = "movie" }) {
               </div>
               <div className="flex flex-col">
                 <span className="text-[10px] font-label uppercase tracking-[0.2em] text-[#d6c4ae]/60">
-                  films ranked
+                  {`${label}s ranked`}
                 </span>
                 <span className="text-lg font-headline font-bold text-[#E8A020]">
                   {stats.total_movies_ranked?.toLocaleString()}
@@ -218,7 +220,7 @@ export default function Duel({ mediaType = "movie" }) {
           <>
             {/* Instruction */}
             <p className="text-[10px] font-label uppercase tracking-[0.3em] text-[#6B6760]">
-              Tap the film you rate higher
+              {`Tap the ${label} you rate higher`}
             </p>
 
             {/* Cards Container */}

--- a/frontend/src/pages/Duel.jsx
+++ b/frontend/src/pages/Duel.jsx
@@ -2,7 +2,7 @@ import { useState, useEffect, useCallback, useRef } from "react";
 import { useNavigate } from "react-router-dom";
 import { fetchPair, submitDuel, fetchStats } from "../api";
 import MovieCard from "../components/MovieCard";
-import { mediaLabel } from "../lib/utils";
+import { mediaLabel, mediaLabelCap } from "../lib/utils";
 
 const MODE = "discovery";
 
@@ -154,7 +154,7 @@ export default function Duel({ mediaType = "movie" }) {
               onClick={() => navigate("/swipe")}
               className="bg-[#E8A020] text-[#0F0E0D] font-headline font-black py-5 uppercase tracking-[0.2em] text-base hover:shadow-[0_0_30px_rgba(232,160,32,0.4)] active:scale-[0.98] transition-all"
             >
-              {`Swipe 10 ${label.charAt(0).toUpperCase() + label.slice(1)}s`}
+              {`Swipe 10 ${mediaLabelCap(mediaType)}s`}
             </button>
             <button
               onClick={() => {

--- a/frontend/src/pages/Rankings.jsx
+++ b/frontend/src/pages/Rankings.jsx
@@ -1,6 +1,6 @@
 import { useState, useEffect } from "react";
 import { getRankings, fetchStats, syncTrakt } from "../api";
-import { mediaLabel } from "../lib/utils";
+import { mediaLabel, mediaLabelCap } from "../lib/utils";
 
 const GENRE_FILTERS = ["All", "Drama", "Horror", "Sci-fi", "Thriller", "Comedy"];
 
@@ -274,7 +274,7 @@ export default function Rankings({ mediaType = "movie" }) {
                 Total Ranked
               </span>
               <span className="text-sm font-headline font-bold text-[#F5F0E8]">
-                {`${stats.total_movies_ranked} ${label.charAt(0).toUpperCase() + label.slice(1)}s`}
+                {`${stats.total_movies_ranked} ${mediaLabelCap(mediaType)}s`}
               </span>
             </div>
             <div className="w-full h-1 bg-[#211f1e]">

--- a/frontend/src/pages/Rankings.jsx
+++ b/frontend/src/pages/Rankings.jsx
@@ -121,7 +121,7 @@ export default function Rankings({ mediaType = "movie" }) {
         <div className="p-8 text-center text-[#6B6760] bg-[#1d1b1a] font-body">
           {rankings.length === 0
             ? "No rankings yet. Start dueling to build your list!"
-            : "No films match this filter."}
+            : `No ${label}s match this filter.`}
         </div>
       ) : (
         <div className="space-y-4">

--- a/frontend/src/pages/Rankings.jsx
+++ b/frontend/src/pages/Rankings.jsx
@@ -1,9 +1,11 @@
 import { useState, useEffect } from "react";
 import { getRankings, fetchStats, syncTrakt } from "../api";
+import { mediaLabel } from "../lib/utils";
 
 const GENRE_FILTERS = ["All", "Drama", "Horror", "Sci-fi", "Thriller", "Comedy"];
 
 export default function Rankings({ mediaType = "movie" }) {
+  const label = mediaLabel(mediaType);
   const [rankings, setRankings] = useState([]);
   const [stats, setStats] = useState(null);
   const [loading, setLoading] = useState(true);
@@ -272,7 +274,7 @@ export default function Rankings({ mediaType = "movie" }) {
                 Total Ranked
               </span>
               <span className="text-sm font-headline font-bold text-[#F5F0E8]">
-                {stats.total_movies_ranked} Films
+                {`${stats.total_movies_ranked} ${label.charAt(0).toUpperCase() + label.slice(1)}s`}
               </span>
             </div>
             <div className="w-full h-1 bg-[#211f1e]">

--- a/frontend/src/pages/Suggestions.jsx
+++ b/frontend/src/pages/Suggestions.jsx
@@ -1,5 +1,6 @@
 import { useState, useEffect } from "react";
 import { getSuggestions, regenerateSuggestions, dismissSuggestion, addToWatchlist, markSuggestionSeen } from "../api";
+import { mediaLabel } from "../lib/utils";
 
 function SkeletonCard() {
   return (
@@ -19,6 +20,7 @@ function SkeletonCard() {
 }
 
 export default function Suggestions({ mediaType = "movie" }) {
+  const label = mediaLabel(mediaType);
   const [suggestions, setSuggestions] = useState([]);
   const [status, setStatus] = useState("loading");
   const [regenerating, setRegenerating] = useState(false);
@@ -123,8 +125,7 @@ export default function Suggestions({ mediaType = "movie" }) {
             Keep dueling!
           </h3>
           <p className="text-[#6B6760] font-body leading-relaxed">
-            We need at least 20 ranked films to understand your taste and generate
-            personalized suggestions. Head to the duel page and keep ranking!
+            {`We need at least 20 ranked ${label}s to understand your taste and generate personalized suggestions. Head to the duel page and keep ranking!`}
           </p>
           <a
             href="/"
@@ -151,8 +152,7 @@ export default function Suggestions({ mediaType = "movie" }) {
             Pool expanding...
           </h3>
           <p className="text-[#6B6760] font-body leading-relaxed">
-            We're adding more films to your pool. Swipe a few rounds to classify
-            new films, then come back for personalized suggestions.
+            {`We're adding more ${label}s to your pool. Swipe a few rounds to classify new ${label}s, then come back for personalized suggestions.`}
           </p>
           <a
             href="/swipe"
@@ -321,7 +321,7 @@ export default function Suggestions({ mediaType = "movie" }) {
                 <button
                   onClick={() => handleMarkSeen(s.id)}
                   className="px-3 py-3 border border-[#E8A020]/30 text-[#E8A020]/70 font-headline font-bold uppercase text-[10px] tracking-widest hover:bg-[#E8A020]/10 hover:text-[#E8A020] transition-colors"
-                  title="I've seen this film"
+                  title={`I've seen this ${label}`}
                 >
                   Seen it
                 </button>

--- a/frontend/src/pages/Swipe.jsx
+++ b/frontend/src/pages/Swipe.jsx
@@ -2,8 +2,10 @@ import { useState, useEffect, useCallback } from "react";
 import { useNavigate } from "react-router-dom";
 import { fetchSwipeCards, submitSwipeResults } from "../api";
 import SwipeCard from "../components/SwipeCard";
+import { mediaLabel } from "../lib/utils";
 
 export default function Swipe({ mediaType = "movie" }) {
+  const label = mediaLabel(mediaType);
   const navigate = useNavigate();
   const [cards, setCards] = useState([]);
   const [currentIndex, setCurrentIndex] = useState(0);
@@ -89,7 +91,7 @@ export default function Swipe({ mediaType = "movie" }) {
     return (
       <div className="min-h-screen flex items-center justify-center bg-[#0F0E0D]">
         <div className="text-[#6B6760] font-headline uppercase tracking-widest animate-pulse">
-          Loading films...
+          {`Loading ${label}s...`}
         </div>
       </div>
     );
@@ -119,11 +121,11 @@ export default function Swipe({ mediaType = "movie" }) {
             {needMore ? "Round Complete" : "Swipe Complete"}
           </p>
           <h2 className="text-4xl md:text-5xl font-headline font-black uppercase tracking-tighter text-[#F5F0E8]">
-            You've seen {summary.seen_count} of these films
+            {`You've seen ${summary.seen_count} of these ${label}s`}
           </h2>
           <p className="text-[#6B6760] font-body text-lg">
             {needMore
-              ? "Loading more films..."
+              ? `Loading more ${label}s...`
               : `${summary.unseen_count} new discoveries added to your pool`}
           </p>
           {needMore && (
@@ -156,7 +158,7 @@ export default function Swipe({ mediaType = "movie" }) {
     return (
       <div className="min-h-screen flex flex-col items-center justify-center gap-6 p-12 bg-[#0F0E0D]">
         <p className="text-[#6B6760] text-lg text-center max-w-md font-body">
-          No unknown films left to swipe. You've classified them all!
+          {`No unknown ${label}s left to swipe. You've classified them all!`}
         </p>
         <button
           onClick={() => navigate("/")}

--- a/frontend/src/pages/TournamentBracket.jsx
+++ b/frontend/src/pages/TournamentBracket.jsx
@@ -136,6 +136,7 @@ function BracketMatch({ match, isNext, totalRounds, onClick }) {
 export default function TournamentBracket({ mediaType = "movie" }) {
   const { id } = useParams();
   const navigate = useNavigate();
+  const label = mediaLabel(mediaType);
   const [tournament, setTournament] = useState(null);
   const [loading, setLoading] = useState(true);
   const [playing, setPlaying] = useState(false); // match play mode
@@ -363,7 +364,7 @@ export default function TournamentBracket({ mediaType = "movie" }) {
         {/* Duel arena */}
         <section className="flex-1 p-4 md:p-12 flex flex-col items-center justify-center gap-8 md:gap-12">
           <p className="text-[10px] font-label uppercase tracking-[0.3em] text-[#6B6760]">
-            {`Tap the ${mediaLabel(mediaType)} you rate higher`}
+            {`Tap the ${label} you rate higher`}
           </p>
 
           <div className="w-full max-w-7xl flex flex-col md:flex-row items-center justify-between gap-4 md:gap-6 relative">
@@ -452,7 +453,7 @@ export default function TournamentBracket({ mediaType = "movie" }) {
         )}
         <div className="flex items-center gap-6 flex-wrap">
           <span className="text-[10px] font-label uppercase tracking-[0.3em] text-[#6B6760]">
-            {tournament.bracket_size} {mediaLabel(mediaType)}s
+            {tournament.bracket_size} {label}s
           </span>
           <span
             className={`text-[10px] font-label uppercase tracking-[0.3em] ${

--- a/frontend/src/pages/TournamentBracket.jsx
+++ b/frontend/src/pages/TournamentBracket.jsx
@@ -2,6 +2,7 @@ import { useState, useEffect, useCallback, useMemo } from "react";
 import { useParams, useNavigate } from "react-router-dom";
 import { getTournament, submitTournamentMatch, abandonTournament, regenerateTournament } from "../api";
 import MovieCard from "../components/MovieCard";
+import { mediaLabel } from "../lib/utils";
 
 function roundLabel(round, totalRounds) {
   if (round === totalRounds) return "Final";
@@ -132,7 +133,7 @@ function BracketMatch({ match, isNext, totalRounds, onClick }) {
   );
 }
 
-export default function TournamentBracket() {
+export default function TournamentBracket({ mediaType = "movie" }) {
   const { id } = useParams();
   const navigate = useNavigate();
   const [tournament, setTournament] = useState(null);
@@ -362,7 +363,7 @@ export default function TournamentBracket() {
         {/* Duel arena */}
         <section className="flex-1 p-4 md:p-12 flex flex-col items-center justify-center gap-8 md:gap-12">
           <p className="text-[10px] font-label uppercase tracking-[0.3em] text-[#6B6760]">
-            Tap the film you rate higher
+            {`Tap the ${mediaLabel(mediaType)} you rate higher`}
           </p>
 
           <div className="w-full max-w-7xl flex flex-col md:flex-row items-center justify-between gap-4 md:gap-6 relative">
@@ -451,7 +452,7 @@ export default function TournamentBracket() {
         )}
         <div className="flex items-center gap-6 flex-wrap">
           <span className="text-[10px] font-label uppercase tracking-[0.3em] text-[#6B6760]">
-            {tournament.bracket_size} films
+            {tournament.bracket_size} {mediaLabel(mediaType)}s
           </span>
           <span
             className={`text-[10px] font-label uppercase tracking-[0.3em] ${

--- a/frontend/src/pages/Tournaments.jsx
+++ b/frontend/src/pages/Tournaments.jsx
@@ -1,11 +1,13 @@
 import { useState, useEffect } from "react";
 import { useNavigate } from "react-router-dom";
 import { getTournaments, createTournament, getTournamentGenres, getTournamentPoolCount } from "../api";
+import { mediaLabel } from "../lib/utils";
 
 const BRACKET_SIZES = [8, 16, 32, 64];
 const DECADES = ["1970s", "1980s", "1990s", "2000s", "2010s", "2020s"];
 
 export default function Tournaments({ mediaType = "movie" }) {
+  const label = mediaLabel(mediaType);
   const navigate = useNavigate();
   const [tournaments, setTournaments] = useState([]);
   const [loading, setLoading] = useState(true);
@@ -151,7 +153,7 @@ export default function Tournaments({ mediaType = "movie" }) {
             </div>
             {aiCurated && (
               <p className="mt-2 text-sm font-body text-[#E8A020]/70">
-                AI will select films and create a themed bracket
+                {`AI will select ${label}s and create a themed bracket`}
               </p>
             )}
           </div>
@@ -179,12 +181,12 @@ export default function Tournaments({ mediaType = "movie" }) {
             {poolCount !== null && (
               <p className="mt-2 text-sm font-body text-[#F5F0E8]/50">
                 {poolCount >= bracketSize ? (
-                  <>{poolCount} ranked films available</>
+                  <>{poolCount} ranked {label}s available</>
                 ) : poolCount >= 4 ? (
-                  <>{poolCount} films + {bracketSize - poolCount} byes</>
+                  <>{poolCount} {label}s + {bracketSize - poolCount} byes</>
                 ) : (
                   <span className="text-[#C04A20]">
-                    Only {poolCount} ranked films — need at least 4
+                    Only {poolCount} ranked {label}s — need at least 4
                   </span>
                 )}
               </p>
@@ -316,7 +318,7 @@ export default function Tournaments({ mediaType = "movie" }) {
                       {t.name}
                     </h3>
                     <span className="text-sm font-label text-[#F5F0E8]/40 shrink-0 hidden sm:inline">
-                      {t.bracket_size} films
+                      {t.bracket_size} {label}s
                     </span>
                   </div>
                   <div className="flex gap-4 md:gap-6 items-center">


### PR DESCRIPTION
## Summary

- Adds `.show-mode` CSS class to `index.css` that overrides the amber/gold palette with a teal/blue accent when in TV Show mode
- Introduces `mediaLabel(mediaType)` helper in `lib/utils.js` to return `"film"` or `"show"` based on current mode
- Threads `mediaLabel` through all 6 page components that previously hardcoded "film"/"films" (Duel, Swipe, Rankings, Tournaments, Suggestions, TournamentBracket)
- Fixes missing `mediaType` prop passthrough from App.jsx to TournamentBracket

## Changes

| File | Change |
|------|--------|
| `frontend/src/lib/utils.js` | Added `mediaLabel(mediaType)` export |
| `frontend/src/index.css` | Added `.show-mode` CSS class with teal/blue variable overrides |
| `frontend/src/App.jsx` | Added `useEffect` to toggle `show-mode` body class; pass `mediaType` to TournamentBracket |
| `frontend/src/pages/Duel.jsx` | Replaced 6 hardcoded film/films strings |
| `frontend/src/pages/Swipe.jsx` | Replaced 4 hardcoded film/films strings |
| `frontend/src/pages/Rankings.jsx` | Replaced 1 hardcoded Films string |
| `frontend/src/pages/Tournaments.jsx` | Replaced 5 hardcoded film/films strings |
| `frontend/src/pages/Suggestions.jsx` | Replaced 3 hardcoded film/films strings |
| `frontend/src/pages/TournamentBracket.jsx` | Added `mediaType` prop + replaced 2 hardcoded strings |

## Validation

- **Build**: ✅ Vite build succeeded (271 kB JS, 44 kB CSS)
- **Tests**: ✅ 86/86 passed across 9 test files
- **Lint**: N/A — no lint script configured in project

## Implementation notes

The `.show-mode` class on `document.body` overrides Tailwind v4 CSS variables (`--color-primary`, `--color-primary-container`, `--color-positive`, `--color-ring`) via standard CSS cascade. The `mediaLabel` helper returns `"film"` (not `"movie"`) for movie mode, consistent with existing UI language.

Fixes #100