### PR TITLE
feat: replace hardcoded amber colors with theme tokens for TV show mode

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -116,14 +116,14 @@ export default function App() {
         </Routes>
       </main>
       {/* Mobile bottom nav */}
-      <nav className="fixed bottom-0 left-0 w-full z-50 flex flex-col items-center bg-[#0F0E0D]/80 backdrop-blur-xl md:hidden shadow-[0_-8px_32px_rgba(232,160,32,0.08)]">
+      <nav className="fixed bottom-0 left-0 w-full z-50 flex flex-col items-center bg-[#0F0E0D]/80 backdrop-blur-xl md:hidden shadow-accent-bottom-nav">
         {/* Media type toggle */}
         <div className="flex w-full justify-center gap-1 px-4 pt-2 pb-1">
           <button
             onClick={() => setMediaType("movie")}
             className={`flex-1 py-1 text-[10px] font-bold uppercase tracking-[0.1em] font-headline rounded-sm transition-colors ${
               mediaType === "movie"
-                ? "bg-[#E8A020] text-[#0F0E0D]"
+                ? "bg-primary-container text-[#0F0E0D]"
                 : "text-[#F5F0E8]/40 hover:text-[#F5F0E8]/60"
             }`}
           >
@@ -133,7 +133,7 @@ export default function App() {
             onClick={() => setMediaType("show")}
             className={`flex-1 py-1 text-[10px] font-bold uppercase tracking-[0.1em] font-headline rounded-sm transition-colors ${
               mediaType === "show"
-                ? "bg-[#E8A020] text-[#0F0E0D]"
+                ? "bg-primary-container text-[#0F0E0D]"
                 : "text-[#F5F0E8]/40 hover:text-[#F5F0E8]/60"
             }`}
           >
@@ -145,7 +145,7 @@ export default function App() {
             href="/"
             className={`flex flex-col items-center justify-center px-6 py-2 transition-colors ${
               location.pathname === "/"
-                ? "text-[#E8A020] border-t-2 border-[#E8A020] bg-[#E8A020]/10"
+                ? "text-primary-container border-t-2 border-primary-container bg-primary-container/10"
                 : "text-[#6B6760] hover:text-[#F5F0E8]"
             }`}
           >
@@ -155,7 +155,7 @@ export default function App() {
             href="/swipe"
             className={`flex flex-col items-center justify-center px-6 py-2 transition-colors ${
               location.pathname === "/swipe"
-                ? "text-[#E8A020] border-t-2 border-[#E8A020] bg-[#E8A020]/10"
+                ? "text-primary-container border-t-2 border-primary-container bg-primary-container/10"
                 : "text-[#6B6760] hover:text-[#F5F0E8]"
             }`}
           >
@@ -165,7 +165,7 @@ export default function App() {
             href="/rankings"
             className={`flex flex-col items-center justify-center px-6 py-2 transition-colors ${
               location.pathname === "/rankings"
-                ? "text-[#E8A020] border-t-2 border-[#E8A020] bg-[#E8A020]/10"
+                ? "text-primary-container border-t-2 border-primary-container bg-primary-container/10"
                 : "text-[#6B6760] hover:text-[#F5F0E8]"
             }`}
           >
@@ -175,7 +175,7 @@ export default function App() {
             href="/suggestions"
             className={`flex flex-col items-center justify-center px-6 py-2 transition-colors ${
               location.pathname === "/suggestions"
-                ? "text-[#E8A020] border-t-2 border-[#E8A020] bg-[#E8A020]/10"
+                ? "text-primary-container border-t-2 border-primary-container bg-primary-container/10"
                 : "text-[#6B6760] hover:text-[#F5F0E8]"
             }`}
           >
@@ -185,7 +185,7 @@ export default function App() {
             href="/tournaments"
             className={`flex flex-col items-center justify-center px-6 py-2 transition-colors ${
               location.pathname.startsWith("/tournaments")
-                ? "text-[#E8A020] border-t-2 border-[#E8A020] bg-[#E8A020]/10"
+                ? "text-primary-container border-t-2 border-primary-container bg-primary-container/10"
                 : "text-[#6B6760] hover:text-[#F5F0E8]"
             }`}
           >

--- a/frontend/src/__tests__/Nav.test.jsx
+++ b/frontend/src/__tests__/Nav.test.jsx
@@ -38,22 +38,22 @@ describe("Nav", () => {
     expect(screen.getByText("Rankings")).toBeInTheDocument();
   });
 
-  it("active nav item (Current Duel) has amber bg styling on /", () => {
+  it("active nav item (Current Duel) has accent bg styling on /", () => {
     renderNav("/");
     const duelLink = screen.getByText("Current Duel").closest("a");
-    expect(duelLink.className).toContain("bg-[#E8A020]");
+    expect(duelLink.className).toContain("bg-primary-container");
   });
 
-  it("active nav item (Rankings) has amber styling on /rankings", () => {
+  it("active nav item (Rankings) has accent styling on /rankings", () => {
     renderNav("/rankings");
     const rankingsLink = screen.getByText("Rankings").closest("a");
-    expect(rankingsLink.className).toContain("bg-[#E8A020]");
+    expect(rankingsLink.className).toContain("bg-primary-container");
   });
 
-  it("inactive nav item does NOT have amber bg", () => {
+  it("inactive nav item does NOT have accent bg", () => {
     renderNav("/");
     const swipeLink = screen.getByText("Swipe").closest("a");
-    expect(swipeLink.className).not.toContain("bg-[#E8A020]");
+    expect(swipeLink.className).not.toContain("bg-primary-container");
   });
 
   it("Report Issue is a button (not a link)", () => {

--- a/frontend/src/components/MovieCard.jsx
+++ b/frontend/src/components/MovieCard.jsx
@@ -24,9 +24,9 @@ export default function MovieCard({
           "cursor-pointer hover:scale-[1.02] active:scale-95",
         !clickable && "cursor-default",
         highlight &&
-          "border-2 border-[#E8A020] shadow-[0_0_30px_rgba(232,160,32,0.15)]",
+          "border-2 border-primary-container shadow-accent-md",
         chosen === "winner" &&
-          "border-2 border-[#E8A020] shadow-[0_0_40px_rgba(232,160,32,0.35)] scale-[1.03] animate-winner-pulse",
+          "border-2 border-primary-container shadow-accent-lg scale-[1.03] animate-winner-pulse",
         chosen === "loser" && "opacity-40 scale-[0.97]"
       )}
       onClick={clickable ? onClick : undefined}
@@ -64,7 +64,7 @@ export default function MovieCard({
         {/* Pick winner label when highlighted */}
         {highlight && (
           <div className="absolute -top-0 left-1/2 -translate-x-1/2 z-20">
-            <span className="bg-[#E8A020] text-[#442b00] px-4 py-1 font-headline font-bold text-[10px] uppercase tracking-tighter">
+            <span className="bg-primary-container text-primary-foreground px-4 py-1 font-headline font-bold text-[10px] uppercase tracking-tighter">
               Pick winner
             </span>
           </div>
@@ -73,7 +73,7 @@ export default function MovieCard({
         {/* Winner label after duel */}
         {chosen === "winner" && (
           <div className="absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 z-20">
-            <span className="bg-[#E8A020] text-[#442b00] px-5 py-2 font-headline font-black text-lg uppercase tracking-wider shadow-[0_0_30px_rgba(232,160,32,0.5)]">
+            <span className="bg-primary-container text-primary-foreground px-5 py-2 font-headline font-black text-lg uppercase tracking-wider shadow-accent-md">
               Winner
             </span>
           </div>
@@ -85,7 +85,7 @@ export default function MovieCard({
             {genres.map((g) => (
               <span
                 key={g}
-                className="bg-[#0F0E0D]/80 backdrop-blur-md px-3 py-1 text-[10px] font-label font-bold uppercase tracking-widest border border-[#E8A020]/20 text-[#E8A020]"
+                className="bg-[#0F0E0D]/80 backdrop-blur-md px-3 py-1 text-[10px] font-label font-bold uppercase tracking-widest border border-primary-container/20 text-primary-container"
               >
                 {g}
               </span>
@@ -113,7 +113,7 @@ export default function MovieCard({
             className={cn(
               "text-lg font-black font-headline px-3 py-1",
               delta >= 0
-                ? "bg-[#E8A020] text-[#442b00]"
+                ? "bg-primary-container text-primary-foreground"
                 : "bg-[#C04A20] text-[#F5F0E8]"
             )}
           >

--- a/frontend/src/components/Nav.jsx
+++ b/frontend/src/components/Nav.jsx
@@ -28,7 +28,7 @@ export default function Nav({ mediaType, setMediaType }) {
           <img src="/logo.png" alt="FilmDuel" className="w-10 h-10 object-contain" />
         </div>
         <div>
-          <h1 className="text-[#E8A020] text-xl font-black font-headline tracking-tighter uppercase">
+          <h1 className="text-primary-container text-xl font-black font-headline tracking-tighter uppercase">
             FILMDUEL
           </h1>
           <p className="text-[#F5F0E8]/40 text-[10px] uppercase tracking-[0.2em] font-bold">
@@ -43,7 +43,7 @@ export default function Nav({ mediaType, setMediaType }) {
           onClick={() => setMediaType("movie")}
           className={`flex-1 py-2 text-xs font-headline font-bold uppercase tracking-widest transition-colors rounded-sm ${
             mediaType === "movie"
-              ? "bg-[#E8A020] text-[#0F0E0D]"
+              ? "bg-primary-container text-[#0F0E0D]"
               : "text-[#F5F0E8]/40 hover:text-[#F5F0E8]/60"
           }`}
         >
@@ -53,7 +53,7 @@ export default function Nav({ mediaType, setMediaType }) {
           onClick={() => setMediaType("show")}
           className={`flex-1 py-2 text-xs font-headline font-bold uppercase tracking-widest transition-colors rounded-sm ${
             mediaType === "show"
-              ? "bg-[#E8A020] text-[#0F0E0D]"
+              ? "bg-primary-container text-[#0F0E0D]"
               : "text-[#F5F0E8]/40 hover:text-[#F5F0E8]/60"
           }`}
         >
@@ -74,7 +74,7 @@ export default function Nav({ mediaType, setMediaType }) {
               to={item.path}
               className={
                 isActive
-                  ? "flex items-center gap-4 px-4 py-3 bg-[#E8A020] text-[#0F0E0D] rounded-none shadow-[0_0_15px_rgba(232,160,32,0.3)] font-headline font-bold uppercase tracking-wider transition-all duration-300"
+                  ? "flex items-center gap-4 px-4 py-3 bg-primary-container text-[#0F0E0D] rounded-none shadow-accent-sm font-headline font-bold uppercase tracking-wider transition-all duration-300"
                   : "flex items-center gap-4 px-4 py-3 text-[#F5F0E8]/40 hover:text-[#F5F0E8] hover:bg-[#1d1b1a] font-headline font-bold uppercase tracking-wider transition-all hover:translate-x-1 duration-300"
               }
             >
@@ -88,13 +88,13 @@ export default function Nav({ mediaType, setMediaType }) {
       <div className="px-2 space-y-3">
         <Link
           to="/"
-          className="block w-full bg-[#E8A020] text-[#0F0E0D] font-headline font-black uppercase py-4 tracking-widest text-sm text-center hover:scale-[1.02] active:scale-95 transition-all"
+          className="block w-full bg-primary-container text-[#0F0E0D] font-headline font-black uppercase py-4 tracking-widest text-sm text-center hover:scale-[1.02] active:scale-95 transition-all"
         >
           START DUEL
         </Link>
         <button
           onClick={() => setShowFeedback(true)}
-          className="block w-full text-center text-[#F5F0E8]/30 hover:text-[#E8A020]/70 font-headline font-bold uppercase text-xs tracking-widest py-2 transition-colors"
+          className="block w-full text-center text-[#F5F0E8]/30 hover:text-primary-container/70 font-headline font-bold uppercase text-xs tracking-widest py-2 transition-colors"
         >
           Report Issue
         </button>

--- a/frontend/src/components/ReportIssueModal.jsx
+++ b/frontend/src/components/ReportIssueModal.jsx
@@ -61,14 +61,14 @@ export default function ReportIssueModal({ onClose }) {
 
   return (
     <div className="fixed inset-0 z-50 bg-[#0F0E0D]/95 backdrop-blur-xl flex items-center justify-center p-6">
-      <div className="bg-[#1d1b1a] border-l-4 border-[#E8A020] p-8 w-full max-w-lg">
+      <div className="bg-[#1d1b1a] border-l-4 border-primary-container p-8 w-full max-w-lg">
         <h2 className="font-headline font-black uppercase text-[#F5F0E8] text-xl mb-6">
           Report Issue
         </h2>
 
         {success ? (
           <div className="text-center py-8">
-            <p className="text-[#E8A020] font-headline font-bold text-lg">
+            <p className="text-primary-container font-headline font-bold text-lg">
               Thank you for your feedback!
             </p>
             <p className="text-[#F5F0E8]/50 text-sm mt-2">This window will close shortly.</p>
@@ -85,7 +85,7 @@ export default function ReportIssueModal({ onClose }) {
                   value={title}
                   onChange={(e) => setTitle(e.target.value)}
                   placeholder="Brief title of the issue"
-                  className="w-full bg-[#0F0E0D] border border-[#F5F0E8]/10 text-[#F5F0E8] font-body px-4 py-3 placeholder:text-[#6B6760]/50 focus:border-[#E8A020]/50 focus:outline-none transition-colors"
+                  className="w-full bg-[#0F0E0D] border border-[#F5F0E8]/10 text-[#F5F0E8] font-body px-4 py-3 placeholder:text-[#6B6760]/50 focus:border-primary-container/50 focus:outline-none transition-colors"
                 />
               </div>
 
@@ -98,7 +98,7 @@ export default function ReportIssueModal({ onClose }) {
                   onChange={(e) => setDescription(e.target.value)}
                   placeholder="Describe the issue or suggestion..."
                   rows={4}
-                  className="w-full bg-[#0F0E0D] border border-[#F5F0E8]/10 text-[#F5F0E8] font-body px-4 py-3 placeholder:text-[#6B6760]/50 focus:border-[#E8A020]/50 focus:outline-none transition-colors resize-none"
+                  className="w-full bg-[#0F0E0D] border border-[#F5F0E8]/10 text-[#F5F0E8] font-body px-4 py-3 placeholder:text-[#6B6760]/50 focus:border-primary-container/50 focus:outline-none transition-colors resize-none"
                 />
               </div>
 
@@ -121,7 +121,7 @@ export default function ReportIssueModal({ onClose }) {
                     <div className="flex gap-2">
                       <button
                         onClick={() => setShowEditor(true)}
-                        className="text-[#E8A020] text-xs font-headline font-bold uppercase tracking-wider hover:text-[#E8A020]/80 transition-colors"
+                        className="text-primary-container text-xs font-headline font-bold uppercase tracking-wider hover:text-primary-container/80 transition-colors"
                       >
                         Edit Screenshot
                       </button>
@@ -136,7 +136,7 @@ export default function ReportIssueModal({ onClose }) {
                 ) : (
                   <button
                     onClick={() => fileInputRef.current?.click()}
-                    className="text-[#F5F0E8]/40 text-xs font-headline font-bold uppercase tracking-wider hover:text-[#E8A020]/70 transition-colors"
+                    className="text-[#F5F0E8]/40 text-xs font-headline font-bold uppercase tracking-wider hover:text-primary-container/70 transition-colors"
                   >
                     Attach Screenshot
                   </button>
@@ -150,7 +150,7 @@ export default function ReportIssueModal({ onClose }) {
               <button
                 onClick={handleSubmit}
                 disabled={!title.trim() || !description.trim() || submitting}
-                className="bg-[#E8A020] text-[#0F0E0D] font-headline font-black uppercase px-6 py-3 tracking-widest text-sm hover:scale-[1.02] active:scale-95 transition-all disabled:opacity-40 disabled:cursor-not-allowed disabled:hover:scale-100"
+                className="bg-primary-container text-[#0F0E0D] font-headline font-black uppercase px-6 py-3 tracking-widest text-sm hover:scale-[1.02] active:scale-95 transition-all disabled:opacity-40 disabled:cursor-not-allowed disabled:hover:scale-100"
               >
                 {submitting ? "Submitting..." : "Submit"}
               </button>

--- a/frontend/src/components/ScreenshotEditor.jsx
+++ b/frontend/src/components/ScreenshotEditor.jsx
@@ -282,7 +282,7 @@ export default function ScreenshotEditor({ imageDataUrl, onSave, onCancel }) {
               onClick={() => setTool(t.id)}
               className={`flex items-center gap-1.5 px-3 py-1.5 text-xs font-headline font-bold uppercase tracking-wider transition-colors ${
                 tool === t.id
-                  ? "bg-[#E8A020] text-[#0F0E0D]"
+                  ? "bg-primary-container text-[#0F0E0D]"
                   : "text-[#F5F0E8]/60 hover:text-[#F5F0E8]"
               }`}
             >
@@ -305,7 +305,7 @@ export default function ScreenshotEditor({ imageDataUrl, onSave, onCancel }) {
 
         <button
           onClick={handleSave}
-          className="flex items-center gap-1.5 px-3 py-1.5 text-xs font-headline font-bold uppercase tracking-wider bg-[#E8A020] text-[#0F0E0D] hover:bg-[#E8A020]/80 transition-colors"
+          className="flex items-center gap-1.5 px-3 py-1.5 text-xs font-headline font-bold uppercase tracking-wider bg-primary-container text-[#0F0E0D] hover:bg-primary-container/80 transition-colors"
         >
           <Check size={14} />
           Done

--- a/frontend/src/components/SwipeCard.jsx
+++ b/frontend/src/components/SwipeCard.jsx
@@ -109,7 +109,7 @@ export default function SwipeCard({ movie, onSwipe }) {
 
         {/* Community rating badge */}
         {movie.community_rating && (
-          <div className="absolute top-4 right-4 bg-[#E8A020] text-[#0F0E0D] font-headline font-black text-sm px-3 py-1">
+          <div className="absolute top-4 right-4 bg-primary-container text-[#0F0E0D] font-headline font-black text-sm px-3 py-1">
             {movie.community_rating.toFixed(0)}
           </div>
         )}
@@ -121,7 +121,7 @@ export default function SwipeCard({ movie, onSwipe }) {
               {genres.map((g) => (
                 <span
                   key={g}
-                  className="bg-[#0F0E0D]/80 backdrop-blur-md px-3 py-1 text-[10px] font-label font-bold uppercase tracking-widest border border-[#E8A020]/20 text-[#E8A020]"
+                  className="bg-[#0F0E0D]/80 backdrop-blur-md px-3 py-1 text-[10px] font-label font-bold uppercase tracking-widest border border-primary-container/20 text-primary-container"
                 >
                   {g}
                 </span>

--- a/frontend/src/components/ui/badge.jsx
+++ b/frontend/src/components/ui/badge.jsx
@@ -3,12 +3,12 @@ import { cva } from "class-variance-authority";
 import { cn } from "../../lib/utils";
 
 const badgeVariants = cva(
-  "inline-flex items-center border px-2.5 py-0.5 text-xs font-bold font-headline uppercase tracking-wider transition-colors focus:outline-none focus:ring-2 focus:ring-[#E8A020] focus:ring-offset-2",
+  "inline-flex items-center border px-2.5 py-0.5 text-xs font-bold font-headline uppercase tracking-wider transition-colors focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2",
   {
     variants: {
       variant: {
         default:
-          "border-transparent bg-[#E8A020] text-[#442b00] shadow",
+          "border-transparent bg-primary-container text-primary-foreground shadow",
         secondary:
           "border-[#514534]/30 bg-[#1d1b1a] text-[#d6c4ae]",
         destructive:

--- a/frontend/src/components/ui/button.jsx
+++ b/frontend/src/components/ui/button.jsx
@@ -3,21 +3,21 @@ import { cva } from "class-variance-authority";
 import { cn } from "../../lib/utils";
 
 const buttonVariants = cva(
-  "inline-flex items-center justify-center whitespace-nowrap text-sm font-bold font-headline uppercase tracking-widest transition-all focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-[#E8A020] disabled:pointer-events-none disabled:opacity-50 cursor-pointer",
+  "inline-flex items-center justify-center whitespace-nowrap text-sm font-bold font-headline uppercase tracking-widest transition-all focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50 cursor-pointer",
   {
     variants: {
       variant: {
         default:
-          "bg-[#ffbe5b] text-[#442b00] shadow hover:shadow-[0_0_20px_rgba(232,160,32,0.3)] hover:scale-[1.02] active:scale-95",
+          "bg-primary text-primary-foreground shadow hover:shadow-accent-sm hover:scale-[1.02] active:scale-95",
         destructive:
           "bg-[#93000a] text-[#ffdad6] shadow-sm hover:bg-[#93000a]/90",
         outline:
-          "border border-[#514534]/30 bg-transparent hover:border-[#E8A020]/50 hover:bg-[#1d1b1a] text-[#d6c4ae]",
+          "border border-[#514534]/30 bg-transparent hover:border-primary-container/50 hover:bg-[#1d1b1a] text-[#d6c4ae]",
         secondary:
-          "border border-[#514534]/30 bg-transparent text-[#d6c4ae] hover:border-[#E8A020]/50 hover:bg-[#1d1b1a]",
+          "border border-[#514534]/30 bg-transparent text-[#d6c4ae] hover:border-primary-container/50 hover:bg-[#1d1b1a]",
         ghost:
           "text-[#d6c4ae] hover:bg-[#1d1b1a] hover:text-[#F5F0E8]",
-        link: "text-[#E8A020] underline-offset-4 hover:underline",
+        link: "text-primary-container underline-offset-4 hover:underline",
       },
       size: {
         default: "h-10 px-6 py-2",

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -36,10 +36,17 @@
 .show-mode {
   --color-primary: #5bbfff;
   --color-primary-container: #2096E8;
+  --color-primary-foreground: #002b44;
   --color-positive: #2096E8;
   --color-ring: #2096E8;
   --color-negative: #C04A20;
 }
+
+.shadow-accent-sm { box-shadow: 0 0 15px color-mix(in srgb, var(--color-primary-container) 30%, transparent); }
+.shadow-accent-md { box-shadow: 0 0 30px color-mix(in srgb, var(--color-primary-container) 30%, transparent); }
+.shadow-accent-lg { box-shadow: 0 0 40px color-mix(in srgb, var(--color-primary-container) 40%, transparent); }
+.shadow-accent-inset { box-shadow: inset 0 0 40px color-mix(in srgb, var(--color-primary-container) 5%, transparent); }
+.shadow-accent-bottom-nav { box-shadow: 0 -8px 32px color-mix(in srgb, var(--color-primary-container) 8%, transparent); }
 
 body {
   background-color: #0F0E0D;
@@ -65,11 +72,31 @@ body {
 }
 
 @keyframes winner-pulse {
-  0% { box-shadow: 0 0 0 0 rgba(232, 160, 32, 0.6); }
-  50% { box-shadow: 0 0 40px 8px rgba(232, 160, 32, 0.35); }
-  100% { box-shadow: 0 0 20px 2px rgba(232, 160, 32, 0.2); }
+  0% { box-shadow: 0 0 0 0 color-mix(in srgb, var(--color-primary-container) 60%, transparent); }
+  50% { box-shadow: 0 0 40px 8px color-mix(in srgb, var(--color-primary-container) 35%, transparent); }
+  100% { box-shadow: 0 0 20px 2px color-mix(in srgb, var(--color-primary-container) 20%, transparent); }
 }
 
 .animate-winner-pulse {
   animation: winner-pulse 0.6s ease-out;
+}
+
+.animate-pulse-slow {
+  animation: pulse-slow 2s ease-in-out infinite;
+}
+
+@keyframes pulse-slow {
+  0%, 100% { box-shadow: 0 0 10px color-mix(in srgb, var(--color-primary-container) 10%, transparent); }
+  50% { box-shadow: 0 0 25px color-mix(in srgb, var(--color-primary-container) 25%, transparent); }
+}
+
+.animate-fade-out {
+  animation: fade-in-out 600ms ease-in-out forwards;
+}
+
+@keyframes fade-in-out {
+  0% { opacity: 0; transform: scale(0.95); }
+  20% { opacity: 1; transform: scale(1); }
+  80% { opacity: 1; transform: scale(1); }
+  100% { opacity: 0; transform: scale(1.02); }
 }

--- a/frontend/src/pages/Duel.jsx
+++ b/frontend/src/pages/Duel.jsx
@@ -120,12 +120,12 @@ export default function Duel({ mediaType = "movie" }) {
       <div className="flex flex-col items-center justify-center min-h-[60vh] gap-6 p-12">
         <p className="text-[#6B6760] text-lg text-center max-w-md font-body">
           {isPoolEmpty
-            ? "Watch more movies on Trakt to get started! You need at least 2 movies in your library."
-            : "Something went wrong loading your movies."}
+            ? `Watch more ${label}s on Trakt to get started! You need at least 2 ${label}s in your library.`
+            : `Something went wrong loading your ${label}s.`}
         </p>
         <button
           onClick={() => loadPair()}
-          className="border border-[#514534]/30 hover:border-[#E8A020]/50 hover:bg-[#1d1b1a] text-[#d6c4ae] font-headline font-bold uppercase tracking-widest text-xs py-4 px-8 transition-all"
+          className="border border-[#514534]/30 hover:border-primary-container/50 hover:bg-[#1d1b1a] text-[#d6c4ae] font-headline font-bold uppercase tracking-widest text-xs py-4 px-8 transition-all"
         >
           Try Again
         </button>
@@ -152,7 +152,7 @@ export default function Duel({ mediaType = "movie" }) {
           <div className="flex flex-col gap-3 w-full max-w-xs">
             <button
               onClick={() => navigate("/swipe")}
-              className="bg-[#E8A020] text-[#0F0E0D] font-headline font-black py-5 uppercase tracking-[0.2em] text-base hover:shadow-[0_0_30px_rgba(232,160,32,0.4)] active:scale-[0.98] transition-all"
+              className="bg-primary-container text-[#0F0E0D] font-headline font-black py-5 uppercase tracking-[0.2em] text-base hover:shadow-accent-md active:scale-[0.98] transition-all"
             >
               {`Swipe 10 ${mediaLabelCap(mediaType)}s`}
             </button>
@@ -162,7 +162,7 @@ export default function Duel({ mediaType = "movie" }) {
                 loadPair(true);
                 loadStats();
               }}
-              className="border border-[#514534]/30 hover:border-[#E8A020]/50 hover:bg-[#1d1b1a] text-[#d6c4ae] font-headline font-bold uppercase tracking-widest text-xs py-4 transition-all"
+              className="border border-[#514534]/30 hover:border-primary-container/50 hover:bg-[#1d1b1a] text-[#d6c4ae] font-headline font-bold uppercase tracking-widest text-xs py-4 transition-all"
             >
               Keep Dueling
             </button>
@@ -171,7 +171,7 @@ export default function Duel({ mediaType = "movie" }) {
       )}
 
       {/* Top Stats Bar */}
-      <header className="h-20 px-6 md:px-12 flex justify-between items-center bg-[#0F0E0D]/70 backdrop-blur-xl border-b border-[#E8A020]/10 sticky top-0 z-30">
+      <header className="h-20 px-6 md:px-12 flex justify-between items-center bg-[#0F0E0D]/70 backdrop-blur-xl border-b border-primary-container/10 sticky top-0 z-30">
         <div className="flex gap-6 md:gap-12">
           {stats && (
             <>
@@ -179,7 +179,7 @@ export default function Duel({ mediaType = "movie" }) {
                 <span className="text-[10px] font-label uppercase tracking-[0.2em] text-[#d6c4ae]/60">
                   duels played
                 </span>
-                <span className="text-lg font-headline font-bold text-[#E8A020]">
+                <span className="text-lg font-headline font-bold text-primary-container">
                   {stats.total_duels?.toLocaleString()}
                 </span>
               </div>
@@ -187,7 +187,7 @@ export default function Duel({ mediaType = "movie" }) {
                 <span className="text-[10px] font-label uppercase tracking-[0.2em] text-[#d6c4ae]/60">
                   {`${label}s ranked`}
                 </span>
-                <span className="text-lg font-headline font-bold text-[#E8A020]">
+                <span className="text-lg font-headline font-bold text-primary-container">
                   {stats.total_movies_ranked?.toLocaleString()}
                 </span>
               </div>
@@ -195,7 +195,7 @@ export default function Duel({ mediaType = "movie" }) {
                 <span className="text-[10px] font-label uppercase tracking-[0.2em] text-[#d6c4ae]/60">
                   to discover
                 </span>
-                <span className="text-lg font-headline font-bold text-[#E8A020]">
+                <span className="text-lg font-headline font-bold text-primary-container">
                   {(stats.unseen_count ?? 0).toLocaleString()}
                 </span>
               </div>

--- a/frontend/src/pages/Rankings.jsx
+++ b/frontend/src/pages/Rankings.jsx
@@ -50,7 +50,7 @@ export default function Rankings({ mediaType = "movie" }) {
       <header className="mb-12">
         <div className="flex items-start justify-between mb-8 gap-4">
           <h2 className="text-5xl md:text-7xl font-headline font-black uppercase tracking-tighter text-[#F5F0E8] leading-none">
-            Your <span className="text-[#E8A020]">rankings</span>
+            Your <span className="text-primary-container">rankings</span>
           </h2>
           <button
             onClick={async () => {
@@ -80,12 +80,12 @@ export default function Rankings({ mediaType = "movie" }) {
             disabled={syncState === "syncing"}
             className={`shrink-0 mt-2 px-4 py-2 font-label font-bold uppercase text-xs tracking-widest border transition-all ${
               syncState === "syncing"
-                ? "border-[#E8A020]/30 text-[#E8A020]/50 cursor-wait"
+                ? "border-primary-container/30 text-primary-container/50 cursor-wait"
                 : syncState === "done"
                 ? "border-green-500/50 text-green-400"
                 : syncState === "error"
                 ? "border-red-500/50 text-red-400"
-                : "border-[#F5F0E8]/10 text-[#F5F0E8]/60 hover:border-[#E8A020]/40 hover:text-[#E8A020]"
+                : "border-[#F5F0E8]/10 text-[#F5F0E8]/60 hover:border-primary-container/40 hover:text-primary-container"
             }`}
           >
             {syncState === "syncing"
@@ -106,8 +106,8 @@ export default function Rankings({ mediaType = "movie" }) {
               onClick={() => setActiveFilter(filter)}
               className={
                 activeFilter === filter
-                  ? "px-6 py-2 bg-[#E8A020] text-[#0F0E0D] font-label font-bold uppercase text-xs tracking-widest border border-[#E8A020]"
-                  : "px-6 py-2 bg-transparent text-[#F5F0E8]/60 font-label font-bold uppercase text-xs tracking-widest border border-[#F5F0E8]/10 hover:border-[#E8A020]/40 transition-colors"
+                  ? "px-6 py-2 bg-primary-container text-[#0F0E0D] font-label font-bold uppercase text-xs tracking-widest border border-primary-container"
+                  : "px-6 py-2 bg-transparent text-[#F5F0E8]/60 font-label font-bold uppercase text-xs tracking-widest border border-[#F5F0E8]/10 hover:border-primary-container/40 transition-colors"
               }
             >
               {filter}
@@ -134,7 +134,7 @@ export default function Rankings({ mediaType = "movie" }) {
                 key={r.movie.id}
                 className={`group relative flex items-center gap-4 md:gap-8 p-4 md:p-6 transition-colors ${
                   isFirst
-                    ? "bg-[#1d1b1a] border-l-4 border-[#E8A020] shadow-[inset_0_0_40px_rgba(232,160,32,0.05)]"
+                    ? "bg-[#1d1b1a] border-l-4 border-primary-container shadow-accent-inset"
                     : "bg-[#141312] border-l-4 border-transparent hover:bg-[#1d1b1a]"
                 }`}
               >
@@ -143,8 +143,8 @@ export default function Rankings({ mediaType = "movie" }) {
                   <span
                     className={`font-headline font-black italic ${
                       isFirst
-                        ? "text-4xl md:text-6xl text-[#E8A020]"
-                        : "text-3xl md:text-5xl text-[#F5F0E8]/20 group-hover:text-[#E8A020]/40 transition-colors"
+                        ? "text-4xl md:text-6xl text-primary-container"
+                        : "text-3xl md:text-5xl text-[#F5F0E8]/20 group-hover:text-primary-container/40 transition-colors"
                     }`}
                   >
                     {rank}
@@ -191,7 +191,7 @@ export default function Rankings({ mediaType = "movie" }) {
                       <span
                         className={`font-headline font-bold ${
                           isFirst
-                            ? "text-lg text-[#E8A020]"
+                            ? "text-lg text-primary-container"
                             : "text-md text-[#F5F0E8]/60"
                         }`}
                       >
@@ -233,7 +233,7 @@ export default function Rankings({ mediaType = "movie" }) {
                         href={`https://trakt.tv/search/trakt/${r.movie.trakt_id}?id_type=${r.movie.media_type === "show" ? "show" : "movie"}`}
                         target="_blank"
                         rel="noopener noreferrer"
-                        className="text-[10px] font-label uppercase tracking-widest text-[#F5F0E8]/30 hover:text-[#E8A020] transition-colors"
+                        className="text-[10px] font-label uppercase tracking-widest text-[#F5F0E8]/30 hover:text-primary-container transition-colors"
                       >
                         Trakt
                       </a>
@@ -243,7 +243,7 @@ export default function Rankings({ mediaType = "movie" }) {
                         href={`https://www.imdb.com/title/${r.movie.imdb_id}/`}
                         target="_blank"
                         rel="noopener noreferrer"
-                        className="text-[10px] font-label uppercase tracking-widest text-[#F5F0E8]/30 hover:text-[#E8A020] transition-colors"
+                        className="text-[10px] font-label uppercase tracking-widest text-[#F5F0E8]/30 hover:text-primary-container transition-colors"
                       >
                         IMDB
                       </a>
@@ -261,7 +261,7 @@ export default function Rankings({ mediaType = "movie" }) {
         <a
           href={`/api/rankings/export/csv?media_type=${mediaType}`}
           download
-          className="flex items-center gap-3 px-6 md:px-8 py-4 bg-[#E8A020] text-[#0F0E0D] font-headline font-black uppercase tracking-widest text-sm shadow-[0_10px_30px_rgba(232,160,32,0.3)] hover:scale-105 active:scale-95 transition-all"
+          className="flex items-center gap-3 px-6 md:px-8 py-4 bg-primary-container text-[#0F0E0D] font-headline font-black uppercase tracking-widest text-sm shadow-accent-md hover:scale-105 active:scale-95 transition-all"
         >
           Export to Letterboxd
         </a>
@@ -279,7 +279,7 @@ export default function Rankings({ mediaType = "movie" }) {
             </div>
             <div className="w-full h-1 bg-[#211f1e]">
               <div
-                className="h-full bg-[#E8A020]"
+                className="h-full bg-primary-container"
                 style={{
                   width: `${Math.min(
                     100,

--- a/frontend/src/pages/Suggestions.jsx
+++ b/frontend/src/pages/Suggestions.jsx
@@ -1,6 +1,6 @@
 import { useState, useEffect } from "react";
 import { getSuggestions, regenerateSuggestions, dismissSuggestion, addToWatchlist, markSuggestionSeen } from "../api";
-import { mediaLabel } from "../lib/utils";
+import { mediaLabel, mediaLabelCap } from "../lib/utils";
 
 function SkeletonCard() {
   return (
@@ -98,7 +98,7 @@ export default function Suggestions({ mediaType = "movie" }) {
       <div className="min-h-screen bg-[#0F0E0D] p-6 md:p-12 pb-32">
         <header className="mb-12">
           <h2 className="text-5xl md:text-7xl font-headline font-black uppercase tracking-tighter text-[#F5F0E8] mb-2 leading-none">
-            Watch <span className="text-[#E8A020]">Next</span>
+            Watch <span className="text-primary-container">Next</span>
           </h2>
           <p className="text-[#6B6760] font-body text-sm">AI-curated picks based on your taste</p>
         </header>
@@ -117,7 +117,7 @@ export default function Suggestions({ mediaType = "movie" }) {
       <div className="min-h-screen bg-[#0F0E0D] p-6 md:p-12 pb-32">
         <header className="mb-12">
           <h2 className="text-5xl md:text-7xl font-headline font-black uppercase tracking-tighter text-[#F5F0E8] mb-2 leading-none">
-            Watch <span className="text-[#E8A020]">Next</span>
+            Watch <span className="text-primary-container">Next</span>
           </h2>
         </header>
         <div className="max-w-md mx-auto text-center space-y-6 mt-24">
@@ -129,7 +129,7 @@ export default function Suggestions({ mediaType = "movie" }) {
           </p>
           <a
             href="/"
-            className="inline-block mt-6 px-8 py-4 bg-[#E8A020] text-[#0F0E0D] font-headline font-black uppercase tracking-widest text-sm hover:scale-[1.02] active:scale-95 transition-all"
+            className="inline-block mt-6 px-8 py-4 bg-primary-container text-[#0F0E0D] font-headline font-black uppercase tracking-widest text-sm hover:scale-[1.02] active:scale-95 transition-all"
           >
             Start Dueling
           </a>
@@ -144,7 +144,7 @@ export default function Suggestions({ mediaType = "movie" }) {
       <div className="min-h-screen bg-[#0F0E0D] p-6 md:p-12 pb-32">
         <header className="mb-12">
           <h2 className="text-5xl md:text-7xl font-headline font-black uppercase tracking-tighter text-[#F5F0E8] mb-2 leading-none">
-            Watch <span className="text-[#E8A020]">Next</span>
+            Watch <span className="text-primary-container">Next</span>
           </h2>
         </header>
         <div className="max-w-md mx-auto text-center space-y-6 mt-24">
@@ -156,9 +156,9 @@ export default function Suggestions({ mediaType = "movie" }) {
           </p>
           <a
             href="/swipe"
-            className="inline-block mt-6 px-8 py-4 bg-[#E8A020] text-[#0F0E0D] font-headline font-black uppercase tracking-widest text-sm hover:scale-[1.02] active:scale-95 transition-all"
+            className="inline-block mt-6 px-8 py-4 bg-primary-container text-[#0F0E0D] font-headline font-black uppercase tracking-widest text-sm hover:scale-[1.02] active:scale-95 transition-all"
           >
-            Swipe Films
+            {`Swipe ${mediaLabelCap(mediaType)}s`}
           </a>
         </div>
       </div>
@@ -171,14 +171,14 @@ export default function Suggestions({ mediaType = "movie" }) {
       <div className="min-h-screen bg-[#0F0E0D] p-6 md:p-12 pb-32">
         <header className="mb-12">
           <h2 className="text-5xl md:text-7xl font-headline font-black uppercase tracking-tighter text-[#F5F0E8] mb-2 leading-none">
-            Watch <span className="text-[#E8A020]">Next</span>
+            Watch <span className="text-primary-container">Next</span>
           </h2>
         </header>
         <div className="max-w-md mx-auto text-center space-y-6 mt-24">
           <p className="text-[#F5F0E8]/60 font-body">{error || "Something went wrong."}</p>
           <button
             onClick={load}
-            className="px-8 py-4 bg-[#E8A020] text-[#0F0E0D] font-headline font-black uppercase tracking-widest text-sm hover:scale-[1.02] active:scale-95 transition-all"
+            className="px-8 py-4 bg-primary-container text-[#0F0E0D] font-headline font-black uppercase tracking-widest text-sm hover:scale-[1.02] active:scale-95 transition-all"
           >
             Try Again
           </button>
@@ -193,7 +193,7 @@ export default function Suggestions({ mediaType = "movie" }) {
       <div className="min-h-screen bg-[#0F0E0D] p-6 md:p-12 pb-32">
         <header className="mb-12">
           <h2 className="text-5xl md:text-7xl font-headline font-black uppercase tracking-tighter text-[#F5F0E8] mb-2 leading-none">
-            Watch <span className="text-[#E8A020]">Next</span>
+            Watch <span className="text-primary-container">Next</span>
           </h2>
         </header>
         <div className="max-w-md mx-auto text-center space-y-6 mt-24">
@@ -206,7 +206,7 @@ export default function Suggestions({ mediaType = "movie" }) {
           <button
             onClick={handleRegenerate}
             disabled={regenerating}
-            className="px-8 py-4 bg-[#E8A020] text-[#0F0E0D] font-headline font-black uppercase tracking-widest text-sm hover:scale-[1.02] active:scale-95 transition-all disabled:opacity-50"
+            className="px-8 py-4 bg-primary-container text-[#0F0E0D] font-headline font-black uppercase tracking-widest text-sm hover:scale-[1.02] active:scale-95 transition-all disabled:opacity-50"
           >
             {regenerating ? "Generating..." : "Regenerate Suggestions"}
           </button>
@@ -224,14 +224,14 @@ export default function Suggestions({ mediaType = "movie" }) {
       <header className="mb-12 flex flex-col sm:flex-row sm:items-end sm:justify-between gap-4">
         <div>
           <h2 className="text-5xl md:text-7xl font-headline font-black uppercase tracking-tighter text-[#F5F0E8] mb-2 leading-none">
-            Watch <span className="text-[#E8A020]">Next</span>
+            Watch <span className="text-primary-container">Next</span>
           </h2>
           <p className="text-[#6B6760] font-body text-sm">AI-curated picks based on your taste</p>
         </div>
         <button
           onClick={handleRegenerate}
           disabled={regenerating}
-          className="px-6 py-3 bg-transparent border border-[#F5F0E8]/10 text-[#F5F0E8]/60 font-headline font-bold uppercase text-xs tracking-widest hover:border-[#E8A020]/40 hover:text-[#E8A020] transition-colors disabled:opacity-50 shrink-0"
+          className="px-6 py-3 bg-transparent border border-[#F5F0E8]/10 text-[#F5F0E8]/60 font-headline font-bold uppercase text-xs tracking-widest hover:border-primary-container/40 hover:text-primary-container transition-colors disabled:opacity-50 shrink-0"
         >
           {regenerating ? "Generating..." : "Refresh"}
         </button>
@@ -247,7 +247,7 @@ export default function Suggestions({ mediaType = "movie" }) {
         {activeSuggestions.map((s) => (
           <div
             key={s.id}
-            className="group bg-[#141312] overflow-hidden transition-all hover:shadow-[0_0_30px_rgba(232,160,32,0.08)]"
+            className="group bg-[#141312] overflow-hidden transition-all hover:shadow-accent-sm"
           >
             {/* Poster */}
             <div className="relative aspect-[2/3] overflow-hidden">
@@ -287,7 +287,7 @@ export default function Suggestions({ mediaType = "movie" }) {
                     href={`https://www.imdb.com/title/${s.movie.imdb_id}/`}
                     target="_blank"
                     rel="noopener noreferrer"
-                    className="text-[10px] font-label uppercase tracking-widest text-[#F5F0E8]/30 hover:text-[#E8A020] transition-colors"
+                    className="text-[10px] font-label uppercase tracking-widest text-[#F5F0E8]/30 hover:text-primary-container transition-colors"
                   >
                     IMDB
                   </a>
@@ -297,7 +297,7 @@ export default function Suggestions({ mediaType = "movie" }) {
                     href={`https://trakt.tv/search/trakt/${s.movie.trakt_id}?id_type=${s.movie.media_type === "show" ? "show" : "movie"}`}
                     target="_blank"
                     rel="noopener noreferrer"
-                    className="text-[10px] font-label uppercase tracking-widest text-[#F5F0E8]/30 hover:text-[#E8A020] transition-colors"
+                    className="text-[10px] font-label uppercase tracking-widest text-[#F5F0E8]/30 hover:text-primary-container transition-colors"
                   >
                     Trakt
                   </a>
@@ -307,20 +307,20 @@ export default function Suggestions({ mediaType = "movie" }) {
               {/* Action buttons */}
               <div className="flex gap-2">
                 {s.added_to_watchlist_at ? (
-                  <div className="flex-1 flex items-center justify-center gap-2 px-4 py-3 bg-[#E8A020]/20 text-[#E8A020] font-headline font-bold uppercase text-xs tracking-widest">
+                  <div className="flex-1 flex items-center justify-center gap-2 px-4 py-3 bg-primary-container/20 text-primary-container font-headline font-bold uppercase text-xs tracking-widest">
                     On Watchlist
                   </div>
                 ) : (
                   <button
                     onClick={() => handleAddToWatchlist(s.id)}
-                    className="flex-1 px-4 py-3 bg-[#E8A020] text-[#0F0E0D] font-headline font-bold uppercase text-xs tracking-widest hover:scale-[1.02] active:scale-95 transition-all"
+                    className="flex-1 px-4 py-3 bg-primary-container text-[#0F0E0D] font-headline font-bold uppercase text-xs tracking-widest hover:scale-[1.02] active:scale-95 transition-all"
                   >
                     Watchlist
                   </button>
                 )}
                 <button
                   onClick={() => handleMarkSeen(s.id)}
-                  className="px-3 py-3 border border-[#E8A020]/30 text-[#E8A020]/70 font-headline font-bold uppercase text-[10px] tracking-widest hover:bg-[#E8A020]/10 hover:text-[#E8A020] transition-colors"
+                  className="px-3 py-3 border border-primary-container/30 text-primary-container/70 font-headline font-bold uppercase text-[10px] tracking-widest hover:bg-primary-container/10 hover:text-primary-container transition-colors"
                   title={`I've seen this ${label}`}
                 >
                   Seen it

--- a/frontend/src/pages/Swipe.jsx
+++ b/frontend/src/pages/Swipe.jsx
@@ -104,7 +104,7 @@ export default function Swipe({ mediaType = "movie" }) {
         <p className="text-[#6B6760] text-lg text-center max-w-md font-body">{error}</p>
         <button
           onClick={loadCards}
-          className="border border-[#514534]/30 hover:border-[#E8A020]/50 hover:bg-[#1d1b1a] text-[#d6c4ae] font-headline font-bold uppercase tracking-widest text-xs py-4 px-8 transition-all"
+          className="border border-[#514534]/30 hover:border-primary-container/50 hover:bg-[#1d1b1a] text-[#d6c4ae] font-headline font-bold uppercase tracking-widest text-xs py-4 px-8 transition-all"
         >
           Try Again
         </button>
@@ -129,7 +129,7 @@ export default function Swipe({ mediaType = "movie" }) {
               : `${summary.unseen_count} new discoveries added to your pool`}
           </p>
           {needMore && (
-            <div className="w-16 h-0.5 bg-[#E8A020] mx-auto animate-pulse mt-4" />
+            <div className="w-16 h-0.5 bg-primary-container mx-auto animate-pulse mt-4" />
           )}
         </div>
 
@@ -137,13 +137,13 @@ export default function Swipe({ mediaType = "movie" }) {
           <div className="flex flex-col gap-3 w-full max-w-xs">
             <button
               onClick={() => navigate("/")}
-              className="bg-[#E8A020] text-[#0F0E0D] font-headline font-black py-5 uppercase tracking-[0.2em] text-base hover:shadow-[0_0_30px_rgba(232,160,32,0.4)] active:scale-[0.98] transition-all"
+              className="bg-primary-container text-[#0F0E0D] font-headline font-black py-5 uppercase tracking-[0.2em] text-base hover:shadow-accent-md active:scale-[0.98] transition-all"
             >
               Start Dueling
             </button>
             <button
               onClick={loadCards}
-              className="border border-[#514534]/30 hover:border-[#E8A020]/50 hover:bg-[#1d1b1a] text-[#d6c4ae] font-headline font-bold uppercase tracking-widest text-xs py-4 transition-all"
+              className="border border-[#514534]/30 hover:border-primary-container/50 hover:bg-[#1d1b1a] text-[#d6c4ae] font-headline font-bold uppercase tracking-widest text-xs py-4 transition-all"
             >
               Swipe More
             </button>
@@ -162,7 +162,7 @@ export default function Swipe({ mediaType = "movie" }) {
         </p>
         <button
           onClick={() => navigate("/")}
-          className="bg-[#E8A020] text-[#0F0E0D] font-headline font-black py-4 px-8 uppercase tracking-[0.2em] text-sm hover:shadow-[0_0_30px_rgba(232,160,32,0.4)] active:scale-[0.98] transition-all"
+          className="bg-primary-container text-[#0F0E0D] font-headline font-black py-4 px-8 uppercase tracking-[0.2em] text-sm hover:shadow-accent-md active:scale-[0.98] transition-all"
         >
           Back to Duels
         </button>
@@ -176,11 +176,11 @@ export default function Swipe({ mediaType = "movie" }) {
   return (
     <div className="min-h-screen flex flex-col bg-[#0F0E0D]">
       {/* Progress header */}
-      <header className="h-16 px-6 flex items-center justify-between bg-[#0F0E0D]/70 backdrop-blur-xl border-b border-[#E8A020]/10 sticky top-0 z-30">
+      <header className="h-16 px-6 flex items-center justify-between bg-[#0F0E0D]/70 backdrop-blur-xl border-b border-primary-container/10 sticky top-0 z-30">
         <span className="text-[10px] font-label uppercase tracking-[0.3em] text-[#d6c4ae]/60">
           Swipe Session
         </span>
-        <span className="font-headline font-bold text-[#E8A020] text-lg">
+        <span className="font-headline font-bold text-primary-container text-lg">
           {currentIndex + 1} / {total}
         </span>
       </header>
@@ -188,7 +188,7 @@ export default function Swipe({ mediaType = "movie" }) {
       {/* Progress bar */}
       <div className="h-1 bg-[#1d1b1a]">
         <div
-          className="h-full bg-[#E8A020] transition-all duration-300"
+          className="h-full bg-primary-container transition-all duration-300"
           style={{ width: `${((currentIndex + 1) / total) * 100}%` }}
         />
       </div>
@@ -209,7 +209,7 @@ export default function Swipe({ mediaType = "movie" }) {
           <button
             onClick={() => handleButtonSwipe(true)}
             disabled={submitting}
-            className="flex-1 bg-[#E8A020] text-[#0F0E0D] font-headline font-black uppercase tracking-widest text-xs py-4 hover:shadow-[0_0_20px_rgba(232,160,32,0.3)] active:scale-[0.98] transition-all disabled:opacity-40"
+            className="flex-1 bg-primary-container text-[#0F0E0D] font-headline font-black uppercase tracking-widest text-xs py-4 hover:shadow-accent-sm active:scale-[0.98] transition-all disabled:opacity-40"
           >
             Seen it
           </button>

--- a/frontend/src/pages/TournamentBracket.jsx
+++ b/frontend/src/pages/TournamentBracket.jsx
@@ -36,7 +36,7 @@ function PosterThumb({ movie, isWinner, isLoser }) {
         }}
       />
       {isWinner && (
-        <div className="absolute inset-0 border border-[#E8A020]/60" />
+        <div className="absolute inset-0 border border-primary-container/60" />
       )}
     </div>
   );
@@ -56,7 +56,7 @@ function BracketMatch({ match, isNext, totalRounds, onClick }) {
         isBye
           ? "border-[#F5F0E8]/5 opacity-50"
           : isNext && !played
-          ? "border-[#E8A020]/60 shadow-[0_0_20px_rgba(232,160,32,0.15)] cursor-pointer hover:border-[#E8A020] animate-pulse-slow"
+          ? "border-primary-container/60 shadow-accent-sm cursor-pointer hover:border-primary-container animate-pulse-slow"
           : played
           ? "border-[#F5F0E8]/5"
           : "border-[#F5F0E8]/5 opacity-60"
@@ -65,7 +65,7 @@ function BracketMatch({ match, isNext, totalRounds, onClick }) {
       {/* Movie A */}
       <div
         className={`flex items-center gap-2 px-2 py-1.5 border-b border-[#F5F0E8]/5 ${
-          aWins && !isBye ? "bg-[#E8A020]/10" : ""
+          aWins && !isBye ? "bg-primary-container/10" : ""
         }`}
       >
         <PosterThumb
@@ -78,7 +78,7 @@ function BracketMatch({ match, isNext, totalRounds, onClick }) {
             isBye
               ? "text-[#F5F0E8]/50"
               : aWins
-              ? "text-[#E8A020]"
+              ? "text-primary-container"
               : bWins
               ? "text-[#F5F0E8]/30"
               : "text-[#F5F0E8]/70"
@@ -90,7 +90,7 @@ function BracketMatch({ match, isNext, totalRounds, onClick }) {
       {/* Movie B */}
       <div
         className={`flex items-center gap-2 px-2 py-1.5 ${
-          bWins && !isBye ? "bg-[#E8A020]/10" : ""
+          bWins && !isBye ? "bg-primary-container/10" : ""
         }`}
       >
         {isBye ? (
@@ -110,7 +110,7 @@ function BracketMatch({ match, isNext, totalRounds, onClick }) {
             <span
               className={`text-[11px] font-headline font-bold uppercase tracking-tight truncate ${
                 bWins
-                  ? "text-[#E8A020]"
+                  ? "text-primary-container"
                   : aWins
                   ? "text-[#F5F0E8]/30"
                   : "text-[#F5F0E8]/70"
@@ -124,7 +124,7 @@ function BracketMatch({ match, isNext, totalRounds, onClick }) {
       {/* Next match indicator */}
       {isNext && !played && !isBye && (
         <div className="absolute -top-2 left-1/2 -translate-x-1/2 z-10">
-          <span className="bg-[#E8A020] text-[#0F0E0D] px-2 py-0.5 text-[8px] font-headline font-black uppercase tracking-wider">
+          <span className="bg-primary-container text-[#0F0E0D] px-2 py-0.5 text-[8px] font-headline font-black uppercase tracking-wider">
             Next
           </span>
         </div>
@@ -327,7 +327,7 @@ export default function TournamentBracket({ mediaType = "movie" }) {
         <p className="text-[#C04A20] font-body text-lg">{error}</p>
         <button
           onClick={() => navigate("/tournaments")}
-          className="border border-[#514534]/30 hover:border-[#E8A020]/50 hover:bg-[#1d1b1a] text-[#d6c4ae] font-headline font-bold uppercase tracking-widest text-xs py-4 px-8 transition-all"
+          className="border border-[#514534]/30 hover:border-primary-container/50 hover:bg-[#1d1b1a] text-[#d6c4ae] font-headline font-bold uppercase tracking-widest text-xs py-4 px-8 transition-all"
         >
           Back to Tournaments
         </button>
@@ -344,7 +344,7 @@ export default function TournamentBracket({ mediaType = "movie" }) {
     return (
       <div className="min-h-screen flex flex-col bg-[#0F0E0D] relative">
         {/* Context header */}
-        <header className="h-16 px-6 md:px-12 flex justify-between items-center bg-[#0F0E0D]/70 backdrop-blur-xl border-b border-[#E8A020]/10 sticky top-0 z-30">
+        <header className="h-16 px-6 md:px-12 flex justify-between items-center bg-[#0F0E0D]/70 backdrop-blur-xl border-b border-primary-container/10 sticky top-0 z-30">
           <div className="flex items-center gap-4">
             <button
               onClick={() => setPlaying(false)}
@@ -354,7 +354,7 @@ export default function TournamentBracket({ mediaType = "movie" }) {
             </button>
           </div>
           <div className="text-center">
-            <span className="text-[10px] font-label uppercase tracking-[0.3em] text-[#E8A020]">
+            <span className="text-[10px] font-label uppercase tracking-[0.3em] text-primary-container">
               {roundLabel(nextMatch.round, totalRounds)} — Match {matchIndex + 1} of {totalInRound}
             </span>
           </div>
@@ -397,7 +397,7 @@ export default function TournamentBracket({ mediaType = "movie" }) {
           </div>
 
           {submitting && (
-            <p className="text-sm text-[#E8A020] font-headline font-medium uppercase tracking-widest animate-pulse">
+            <p className="text-sm text-primary-container font-headline font-medium uppercase tracking-widest animate-pulse">
               Submitting...
             </p>
           )}
@@ -407,10 +407,10 @@ export default function TournamentBracket({ mediaType = "movie" }) {
         {winnerFlash && (
           <div className="fixed inset-0 z-50 flex items-center justify-center bg-[#0F0E0D]/80 backdrop-blur-sm animate-fade-out">
             <div className="text-center">
-              <p className="text-[10px] font-label uppercase tracking-[0.3em] text-[#E8A020] mb-3">
+              <p className="text-[10px] font-label uppercase tracking-[0.3em] text-primary-container mb-3">
                 Winner
               </p>
-              <h3 className="text-3xl md:text-5xl font-headline font-black uppercase tracking-tighter text-[#E8A020] leading-none">
+              <h3 className="text-3xl md:text-5xl font-headline font-black uppercase tracking-tighter text-primary-container leading-none">
                 {winnerFlash.title}
               </h3>
               <p className="text-sm text-[#F5F0E8]/40 mt-2 font-label">advances to next round</p>
@@ -442,7 +442,7 @@ export default function TournamentBracket({ mediaType = "movie" }) {
           {tournament.name}
         </h2>
         {tournament.tagline && (
-          <p className="text-lg md:text-xl font-body text-[#E8A020]/80 italic mb-2">
+          <p className="text-lg md:text-xl font-body text-primary-container/80 italic mb-2">
             {tournament.tagline}
           </p>
         )}
@@ -457,7 +457,7 @@ export default function TournamentBracket({ mediaType = "movie" }) {
           </span>
           <span
             className={`text-[10px] font-label uppercase tracking-[0.3em] ${
-              isCompleted ? "text-[#E8A020]" : isAbandoned ? "text-[#C04A20]" : "text-[#6B6760]"
+              isCompleted ? "text-primary-container" : isAbandoned ? "text-[#C04A20]" : "text-[#6B6760]"
             }`}
           >
             {tournament.status}
@@ -472,7 +472,7 @@ export default function TournamentBracket({ mediaType = "movie" }) {
 
       {/* Champion Banner */}
       {isCompleted && champion && (
-        <div className="mb-10 bg-[#1d1b1a] border-l-4 border-[#E8A020] p-6 md:p-8 flex items-center gap-6 shadow-[inset_0_0_60px_rgba(232,160,32,0.05)]">
+        <div className="mb-10 bg-[#1d1b1a] border-l-4 border-primary-container p-6 md:p-8 flex items-center gap-6 shadow-accent-inset">
           <div className="w-20 h-28 md:w-28 md:h-40 shrink-0 overflow-hidden relative">
             {champion.poster_url && (
               <img
@@ -485,10 +485,10 @@ export default function TournamentBracket({ mediaType = "movie" }) {
           </div>
           <div>
             <span className="text-3xl md:text-4xl mb-2 block">&#127942;</span>
-            <p className="text-[10px] font-label uppercase tracking-[0.3em] text-[#E8A020] mb-1">
+            <p className="text-[10px] font-label uppercase tracking-[0.3em] text-primary-container mb-1">
               Champion
             </p>
-            <h3 className="text-2xl md:text-4xl font-headline font-black uppercase tracking-tighter text-[#E8A020] leading-none">
+            <h3 className="text-2xl md:text-4xl font-headline font-black uppercase tracking-tighter text-primary-container leading-none">
               {champion.title}
             </h3>
             {champion.year && (
@@ -509,7 +509,7 @@ export default function TournamentBracket({ mediaType = "movie" }) {
           <div className="mb-8 flex items-center gap-4 flex-wrap">
             <button
               onClick={() => setPlaying(true)}
-              className="bg-[#E8A020] text-[#0F0E0D] font-headline font-black uppercase py-4 px-8 tracking-widest text-sm hover:shadow-[0_0_30px_rgba(232,160,32,0.4)] active:scale-[0.98] transition-all"
+              className="bg-primary-container text-[#0F0E0D] font-headline font-black uppercase py-4 px-8 tracking-widest text-sm hover:shadow-accent-md active:scale-[0.98] transition-all"
             >
               {label}
             </button>
@@ -517,7 +517,7 @@ export default function TournamentBracket({ mediaType = "movie" }) {
               <button
                 onClick={handleRegenerate}
                 disabled={regenerating}
-                className="border border-[#E8A020]/30 text-[#E8A020] font-headline font-bold uppercase py-4 px-6 tracking-widest text-xs hover:bg-[#E8A020]/10 transition-all disabled:opacity-40 disabled:cursor-not-allowed"
+                className="border border-primary-container/30 text-primary-container font-headline font-bold uppercase py-4 px-6 tracking-widest text-xs hover:bg-primary-container/10 transition-all disabled:opacity-40 disabled:cursor-not-allowed"
               >
                 {regenerating ? "Regenerating..." : "Regenerate"}
               </button>
@@ -570,8 +570,8 @@ export default function TournamentBracket({ mediaType = "movie" }) {
 
           {/* Champion column */}
           <div className="min-w-[140px] md:min-w-[160px]">
-            <div className="mb-4 pb-2 border-b border-[#E8A020]/30">
-              <span className="text-[10px] font-label uppercase tracking-[0.3em] text-[#E8A020]">
+            <div className="mb-4 pb-2 border-b border-primary-container/30">
+              <span className="text-[10px] font-label uppercase tracking-[0.3em] text-primary-container">
                 Champion
               </span>
             </div>
@@ -582,11 +582,11 @@ export default function TournamentBracket({ mediaType = "movie" }) {
               }}
             >
               {champion ? (
-                <div className="bg-[#1d1b1a] border border-[#E8A020]/40 p-3 shadow-[0_0_20px_rgba(232,160,32,0.1)]">
+                <div className="bg-[#1d1b1a] border border-primary-container/40 p-3 shadow-accent-sm">
                   <div className="flex items-center gap-2">
                     <PosterThumb movie={champion} isWinner />
                     <div className="min-w-0">
-                      <span className="text-[11px] font-headline font-bold uppercase tracking-tight text-[#E8A020] truncate block">
+                      <span className="text-[11px] font-headline font-bold uppercase tracking-tight text-primary-container truncate block">
                         {champion.title}
                       </span>
                       <span className="text-[9px] text-[#F5F0E8]/40">
@@ -606,26 +606,6 @@ export default function TournamentBracket({ mediaType = "movie" }) {
           </div>
         </div>
       </div>
-
-      {/* Bracket connector lines via CSS (visual hint) */}
-      <style>{`
-        .animate-pulse-slow {
-          animation: pulse-slow 2s ease-in-out infinite;
-        }
-        @keyframes pulse-slow {
-          0%, 100% { box-shadow: 0 0 10px rgba(232,160,32,0.1); }
-          50% { box-shadow: 0 0 25px rgba(232,160,32,0.25); }
-        }
-        .animate-fade-out {
-          animation: fade-in-out 600ms ease-in-out forwards;
-        }
-        @keyframes fade-in-out {
-          0% { opacity: 0; transform: scale(0.95); }
-          20% { opacity: 1; transform: scale(1); }
-          80% { opacity: 1; transform: scale(1); }
-          100% { opacity: 0; transform: scale(1.02); }
-        }
-      `}</style>
 
       {/* Abandon button */}
       {!isCompleted && !isAbandoned && (

--- a/frontend/src/pages/Tournaments.jsx
+++ b/frontend/src/pages/Tournaments.jsx
@@ -1,7 +1,7 @@
 import { useState, useEffect } from "react";
 import { useNavigate } from "react-router-dom";
 import { getTournaments, createTournament, getTournamentGenres, getTournamentPoolCount } from "../api";
-import { mediaLabel } from "../lib/utils";
+import { mediaLabel, mediaLabelCap } from "../lib/utils";
 
 const BRACKET_SIZES = [8, 16, 32, 64];
 const DECADES = ["1970s", "1980s", "1990s", "2000s", "2010s", "2020s"];
@@ -91,12 +91,12 @@ export default function Tournaments({ mediaType = "movie" }) {
       {/* Header */}
       <header className="mb-12 flex items-start justify-between gap-4 flex-wrap">
         <h2 className="text-5xl md:text-7xl font-headline font-black uppercase tracking-tighter text-[#F5F0E8] leading-none">
-          Tour<span className="text-[#E8A020]">naments</span>
+          Tour<span className="text-primary-container">naments</span>
         </h2>
         {!showCreate && (
           <button
             onClick={handleOpenCreate}
-            className="bg-[#E8A020] text-[#0F0E0D] font-headline font-black uppercase py-4 px-8 tracking-widest text-sm hover:shadow-[0_0_30px_rgba(232,160,32,0.4)] active:scale-[0.98] transition-all shrink-0"
+            className="bg-primary-container text-[#0F0E0D] font-headline font-black uppercase py-4 px-8 tracking-widest text-sm hover:shadow-accent-md active:scale-[0.98] transition-all shrink-0"
           >
             Create Tournament
           </button>
@@ -105,7 +105,7 @@ export default function Tournaments({ mediaType = "movie" }) {
 
       {/* Create Form */}
       {showCreate && (
-        <div className="mb-12 bg-[#1d1b1a] p-6 md:p-8 border-l-4 border-[#E8A020]">
+        <div className="mb-12 bg-[#1d1b1a] p-6 md:p-8 border-l-4 border-primary-container">
           <h3 className="text-2xl font-headline font-black uppercase tracking-tight text-[#F5F0E8] mb-6">
             New Tournament
           </h3>
@@ -120,7 +120,7 @@ export default function Tournaments({ mediaType = "movie" }) {
               value={name}
               onChange={(e) => setName(e.target.value)}
               placeholder="Horror Showdown"
-              className="w-full max-w-md bg-[#0F0E0D] border border-[#F5F0E8]/10 text-[#F5F0E8] font-body px-4 py-3 placeholder:text-[#6B6760]/50 focus:border-[#E8A020]/50 focus:outline-none transition-colors"
+              className="w-full max-w-md bg-[#0F0E0D] border border-[#F5F0E8]/10 text-[#F5F0E8] font-body px-4 py-3 placeholder:text-[#6B6760]/50 focus:border-primary-container/50 focus:outline-none transition-colors"
             />
           </div>
 
@@ -134,8 +134,8 @@ export default function Tournaments({ mediaType = "movie" }) {
                 onClick={() => setAiCurated(false)}
                 className={
                   !aiCurated
-                    ? "px-6 py-2 bg-[#E8A020] text-[#0F0E0D] font-label font-bold uppercase text-xs tracking-widest border border-[#E8A020]"
-                    : "px-6 py-2 bg-transparent text-[#F5F0E8]/60 font-label font-bold uppercase text-xs tracking-widest border border-[#F5F0E8]/10 hover:border-[#E8A020]/40 transition-colors"
+                    ? "px-6 py-2 bg-primary-container text-[#0F0E0D] font-label font-bold uppercase text-xs tracking-widest border border-primary-container"
+                    : "px-6 py-2 bg-transparent text-[#F5F0E8]/60 font-label font-bold uppercase text-xs tracking-widest border border-[#F5F0E8]/10 hover:border-primary-container/40 transition-colors"
                 }
               >
                 Standard
@@ -144,15 +144,15 @@ export default function Tournaments({ mediaType = "movie" }) {
                 onClick={() => setAiCurated(true)}
                 className={
                   aiCurated
-                    ? "px-6 py-2 bg-[#E8A020] text-[#0F0E0D] font-label font-bold uppercase text-xs tracking-widest border border-[#E8A020]"
-                    : "px-6 py-2 bg-transparent text-[#F5F0E8]/60 font-label font-bold uppercase text-xs tracking-widest border border-[#F5F0E8]/10 hover:border-[#E8A020]/40 transition-colors"
+                    ? "px-6 py-2 bg-primary-container text-[#0F0E0D] font-label font-bold uppercase text-xs tracking-widest border border-primary-container"
+                    : "px-6 py-2 bg-transparent text-[#F5F0E8]/60 font-label font-bold uppercase text-xs tracking-widest border border-[#F5F0E8]/10 hover:border-primary-container/40 transition-colors"
                 }
               >
                 AI-Curated
               </button>
             </div>
             {aiCurated && (
-              <p className="mt-2 text-sm font-body text-[#E8A020]/70">
+              <p className="mt-2 text-sm font-body text-primary-container/70">
                 {`AI will select ${label}s and create a themed bracket`}
               </p>
             )}
@@ -170,8 +170,8 @@ export default function Tournaments({ mediaType = "movie" }) {
                   onClick={() => setBracketSize(size)}
                   className={
                     bracketSize === size
-                      ? "px-6 py-2 bg-[#E8A020] text-[#0F0E0D] font-label font-bold uppercase text-xs tracking-widest border border-[#E8A020]"
-                      : "px-6 py-2 bg-transparent text-[#F5F0E8]/60 font-label font-bold uppercase text-xs tracking-widest border border-[#F5F0E8]/10 hover:border-[#E8A020]/40 transition-colors"
+                      ? "px-6 py-2 bg-primary-container text-[#0F0E0D] font-label font-bold uppercase text-xs tracking-widest border border-primary-container"
+                      : "px-6 py-2 bg-transparent text-[#F5F0E8]/60 font-label font-bold uppercase text-xs tracking-widest border border-[#F5F0E8]/10 hover:border-primary-container/40 transition-colors"
                   }
                 >
                   {size}
@@ -196,11 +196,11 @@ export default function Tournaments({ mediaType = "movie" }) {
           {/* Filter Mode */}
           <div className="mb-6">
             <label className="text-[10px] font-label uppercase tracking-[0.3em] text-[#6B6760] block mb-2">
-              Filter Films
+              {`Filter ${mediaLabelCap(mediaType)}s`}
             </label>
             <div className="flex gap-2 mb-4">
               {[
-                { key: "all", label: "All Films" },
+                { key: "all", label: `All ${mediaLabelCap(mediaType)}s` },
                 { key: "genre", label: "By Genre" },
                 { key: "decade", label: "By Decade" },
               ].map((opt) => (
@@ -212,8 +212,8 @@ export default function Tournaments({ mediaType = "movie" }) {
                   }}
                   className={
                     filterMode === opt.key
-                      ? "px-6 py-2 bg-[#E8A020] text-[#0F0E0D] font-label font-bold uppercase text-xs tracking-widest border border-[#E8A020]"
-                      : "px-6 py-2 bg-transparent text-[#F5F0E8]/60 font-label font-bold uppercase text-xs tracking-widest border border-[#F5F0E8]/10 hover:border-[#E8A020]/40 transition-colors"
+                      ? "px-6 py-2 bg-primary-container text-[#0F0E0D] font-label font-bold uppercase text-xs tracking-widest border border-primary-container"
+                      : "px-6 py-2 bg-transparent text-[#F5F0E8]/60 font-label font-bold uppercase text-xs tracking-widest border border-[#F5F0E8]/10 hover:border-primary-container/40 transition-colors"
                   }
                 >
                   {opt.label}
@@ -230,8 +230,8 @@ export default function Tournaments({ mediaType = "movie" }) {
                     onClick={() => setFilterValue(g)}
                     className={
                       filterValue === g
-                        ? "px-4 py-1.5 bg-[#E8A020] text-[#0F0E0D] font-label font-bold uppercase text-[10px] tracking-widest border border-[#E8A020]"
-                        : "px-4 py-1.5 bg-transparent text-[#F5F0E8]/60 font-label font-bold uppercase text-[10px] tracking-widest border border-[#F5F0E8]/10 hover:border-[#E8A020]/40 transition-colors"
+                        ? "px-4 py-1.5 bg-primary-container text-[#0F0E0D] font-label font-bold uppercase text-[10px] tracking-widest border border-primary-container"
+                        : "px-4 py-1.5 bg-transparent text-[#F5F0E8]/60 font-label font-bold uppercase text-[10px] tracking-widest border border-[#F5F0E8]/10 hover:border-primary-container/40 transition-colors"
                     }
                   >
                     {g}
@@ -252,8 +252,8 @@ export default function Tournaments({ mediaType = "movie" }) {
                     onClick={() => setFilterValue(d)}
                     className={
                       filterValue === d
-                        ? "px-4 py-1.5 bg-[#E8A020] text-[#0F0E0D] font-label font-bold uppercase text-[10px] tracking-widest border border-[#E8A020]"
-                        : "px-4 py-1.5 bg-transparent text-[#F5F0E8]/60 font-label font-bold uppercase text-[10px] tracking-widest border border-[#F5F0E8]/10 hover:border-[#E8A020]/40 transition-colors"
+                        ? "px-4 py-1.5 bg-primary-container text-[#0F0E0D] font-label font-bold uppercase text-[10px] tracking-widest border border-primary-container"
+                        : "px-4 py-1.5 bg-transparent text-[#F5F0E8]/60 font-label font-bold uppercase text-[10px] tracking-widest border border-[#F5F0E8]/10 hover:border-primary-container/40 transition-colors"
                     }
                   >
                     {d}
@@ -273,7 +273,7 @@ export default function Tournaments({ mediaType = "movie" }) {
             <button
               onClick={handleCreate}
               disabled={creating || (!aiCurated && !name.trim()) || (filterMode !== "all" && !filterValue)}
-              className="bg-[#E8A020] text-[#0F0E0D] font-headline font-black uppercase py-4 px-8 tracking-widest text-sm hover:shadow-[0_0_30px_rgba(232,160,32,0.4)] active:scale-[0.98] transition-all disabled:opacity-40 disabled:cursor-not-allowed"
+              className="bg-primary-container text-[#0F0E0D] font-headline font-black uppercase py-4 px-8 tracking-widest text-sm hover:shadow-accent-md active:scale-[0.98] transition-all disabled:opacity-40 disabled:cursor-not-allowed"
             >
               {creating ? (aiCurated ? "Curating your bracket..." : "Creating...") : "Create & Seed"}
             </button>
@@ -282,7 +282,7 @@ export default function Tournaments({ mediaType = "movie" }) {
                 setShowCreate(false);
                 setError(null);
               }}
-              className="border border-[#F5F0E8]/10 hover:border-[#E8A020]/40 text-[#F5F0E8]/60 font-headline font-bold uppercase py-4 px-8 tracking-widest text-xs transition-colors"
+              className="border border-[#F5F0E8]/10 hover:border-primary-container/40 text-[#F5F0E8]/60 font-headline font-bold uppercase py-4 px-8 tracking-widest text-xs transition-colors"
             >
               Cancel
             </button>
@@ -305,9 +305,9 @@ export default function Tournaments({ mediaType = "movie" }) {
                 key={t.id}
                 className={`group relative flex items-center gap-4 md:gap-8 p-4 md:p-6 transition-colors ${
                   isActive
-                    ? "bg-[#1d1b1a] border-l-4 border-[#E8A020] shadow-[inset_0_0_40px_rgba(232,160,32,0.05)]"
+                    ? "bg-[#1d1b1a] border-l-4 border-primary-container shadow-accent-inset"
                     : isCompleted
-                    ? "bg-[#141312] border-l-4 border-[#E8A020]/40 hover:bg-[#1d1b1a]"
+                    ? "bg-[#141312] border-l-4 border-primary-container/40 hover:bg-[#1d1b1a]"
                     : "bg-[#141312] border-l-4 border-transparent hover:bg-[#1d1b1a] opacity-50"
                 }`}
               >
@@ -329,7 +329,7 @@ export default function Tournaments({ mediaType = "movie" }) {
                       <span
                         className={`font-headline font-bold text-sm uppercase ${
                           isActive
-                            ? "text-[#E8A020]"
+                            ? "text-primary-container"
                             : isCompleted
                             ? "text-[#F5F0E8]/60"
                             : "text-[#6B6760]"
@@ -353,7 +353,7 @@ export default function Tournaments({ mediaType = "movie" }) {
                 {isActive && (
                   <button
                     onClick={() => navigate(`/tournaments/${t.id}`)}
-                    className="bg-[#E8A020] text-[#0F0E0D] font-headline font-black uppercase py-3 px-6 tracking-widest text-xs hover:shadow-[0_0_20px_rgba(232,160,32,0.3)] active:scale-[0.98] transition-all shrink-0"
+                    className="bg-primary-container text-[#0F0E0D] font-headline font-black uppercase py-3 px-6 tracking-widest text-xs hover:shadow-accent-sm active:scale-[0.98] transition-all shrink-0"
                   >
                     Continue
                   </button>
@@ -361,7 +361,7 @@ export default function Tournaments({ mediaType = "movie" }) {
                 {isCompleted && (
                   <button
                     onClick={() => navigate(`/tournaments/${t.id}`)}
-                    className="border border-[#E8A020]/30 text-[#E8A020] font-headline font-bold uppercase py-3 px-6 tracking-widest text-xs hover:bg-[#E8A020]/10 transition-all shrink-0"
+                    className="border border-primary-container/30 text-primary-container font-headline font-bold uppercase py-3 px-6 tracking-widest text-xs hover:bg-primary-container/10 transition-all shrink-0"
                   >
                     View Bracket
                   </button>


### PR DESCRIPTION
## Summary

Replace ~120 hardcoded amber color references (`#E8A020`, `rgba(232,160,32,...)`) across 14 frontend source files with Tailwind CSS theme-token classes so the existing `.show-mode` CSS override takes effect everywhere. Also audit remaining hardcoded "film"/"movie" strings and convert them to use existing `mediaLabel()`/`mediaLabelCap()` helpers.

## Changes

| File | Action | Description |
|------|--------|-------------|
| `frontend/src/index.css` | UPDATE | Add `.shadow-accent-*` utilities, `pulse-slow`/`fade-in-out` keyframes, `--color-primary-foreground` to `.show-mode` |
| `frontend/src/App.jsx` | UPDATE | Replace 7x `#E8A020` + 1x `rgba` with theme tokens in mobile nav |
| `frontend/src/components/Nav.jsx` | UPDATE | Replace 6x `#E8A020` + 1x `rgba` with theme tokens |
| `frontend/src/components/MovieCard.jsx` | UPDATE | Replace 6x `#E8A020` + 3x `rgba` with theme tokens |
| `frontend/src/components/SwipeCard.jsx` | UPDATE | Replace 2x `#E8A020` with theme tokens |
| `frontend/src/components/ReportIssueModal.jsx` | UPDATE | Replace 7x `#E8A020` with theme tokens |
| `frontend/src/components/ScreenshotEditor.jsx` | UPDATE | Replace 2x `bg-[#E8A020]` with `bg-primary-container` |
| `frontend/src/components/ui/button.jsx` | UPDATE | Replace 4x `#E8A020`/`#ffbe5b`/`#442b00` + 1x `rgba` with theme tokens |
| `frontend/src/components/ui/badge.jsx` | UPDATE | Replace 2x `#E8A020`/`#442b00` with theme tokens |
| `frontend/src/pages/Duel.jsx` | UPDATE | Replace colors + convert hardcoded "movies" strings to `mediaLabel()` |
| `frontend/src/pages/Swipe.jsx` | UPDATE | Replace 9x `#E8A020` + 3x `rgba` with theme tokens |
| `frontend/src/pages/Rankings.jsx` | UPDATE | Replace 13x `#E8A020` + 2x `rgba` with theme tokens |
| `frontend/src/pages/Suggestions.jsx` | UPDATE | Replace colors + convert "Swipe Films" to dynamic string |
| `frontend/src/pages/Tournaments.jsx` | UPDATE | Replace colors + convert "Filter Films"/"All Films" to dynamic strings |
| `frontend/src/pages/TournamentBracket.jsx` | UPDATE | Replace colors + remove inline `<style>` block, move to CSS |
| `frontend/src/__tests__/Nav.test.jsx` | UPDATE | Update 3 assertions from `bg-[#E8A020]` to `bg-primary-container` |

## Tests

- `frontend/src/__tests__/Nav.test.jsx` - Updated 3 assertions to match new theme-token class names

No new test files needed — all 96 existing tests pass.

## Validation

- [x] Tests pass (96 passed, 0 failed across 11 test files)
- [x] Build succeeds (vite build, 1600 modules transformed)

## Implementation Notes

### Deviations from Plan

1. **Added `--color-primary-foreground` to `.show-mode`**: Components use `text-primary-foreground` on accent backgrounds — without this override, dark amber text would appear on teal buttons in show mode.
2. **Added `ScreenshotEditor.jsx`**: Not in original plan — found 2x `bg-[#E8A020]` during confirmation step.
3. **Updated `Nav.test.jsx`**: Tests asserted `bg-[#E8A020]` which no longer exists after Nav.jsx changes.

### Key Color Mapping

```
HARDCODED                    → TAILWIND THEME CLASS
bg-[#E8A020]                 → bg-primary-container
text-[#E8A020]               → text-primary-container
border-[#E8A020]             → border-primary-container
bg-[#ffbe5b]                 → bg-primary
text-[#442b00]               → text-primary-foreground
shadow rgba(232,160,32,...)  → .shadow-accent-{sm|md|lg} utilities
```

### Scope Exclusions

- **Login.jsx**: Intentionally unchanged — brand page with no `mediaType` context, keeps hardcoded amber for brand identity.

---

**Workflow ID**: `d265d9675590abe0d3868bc69fdff92e`
