### PR TITLE
fix: use environment-scoped Railway tokens in staging pipeline (#115)

### DIFF
--- a/.github/workflows/staging-pipeline.yml
+++ b/.github/workflows/staging-pipeline.yml
@@ -34,7 +34,7 @@ jobs:
 
       - name: Deploy to staging
         env:
-          RAILWAY_TOKEN: ${{ secrets.RAILWAY_TOKEN }}
+          RAILWAY_TOKEN: ${{ secrets.RAILWAY_STAGING_TOKEN }}
         run: |
           railway up \
             --service web \
@@ -107,7 +107,7 @@ jobs:
 
       - name: Deploy to production
         env:
-          RAILWAY_TOKEN: ${{ secrets.RAILWAY_TOKEN }}
+          RAILWAY_TOKEN: ${{ secrets.RAILWAY_PRODUCTION_TOKEN }}
         run: |
           railway up \
             --service web \


### PR DESCRIPTION
## Summary

- Replace single `RAILWAY_TOKEN` secret with `RAILWAY_STAGING_TOKEN` (staging deploy step) and `RAILWAY_PRODUCTION_TOKEN` (production deploy step)
- Fixes CI failure where `RAILWAY_TOKEN` resolved to empty string, causing deploy to fail with "Invalid RAILWAY_TOKEN"

## Changes

- `.github/workflows/staging-pipeline.yml`: Line 37 — `RAILWAY_STAGING_TOKEN`, Line 110 — `RAILWAY_PRODUCTION_TOKEN`

## Infrastructure Setup (completed)

- All 4 GitHub secrets set: `RAILWAY_STAGING_TOKEN`, `RAILWAY_PRODUCTION_TOKEN`, `STAGING_URL`, `PRODUCTION_URL`
- Railway staging environment recreated with `web` service instance (domain: `web-staging-68e8.up.railway.app`)
- Staging service bootstrap deploy completed — `/health` returns `{"status":"ok"}`

## Test plan

- [ ] Verify `grep -n 'RAILWAY_TOKEN' .github/workflows/staging-pipeline.yml` shows only scoped tokens
- [ ] Confirm all 4 GitHub secrets listed via `gh secret list`
- [ ] Merge and verify staging pipeline run succeeds end-to-end

Closes #115

🤖 Generated with [Claude Code](https://claude.com/claude-code)