### PR TITLE
fix: return 503 instead of 404 when index.html missing

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ WORKDIR /app/frontend
 COPY frontend/package.json frontend/package-lock.json* ./
 RUN npm install
 COPY frontend/ ./
-RUN npm run build && test -d dist
+RUN npm run build && test -f dist/index.html
 
 # Stage 2: Python backend + built frontend
 FROM python:3.12-slim

--- a/backend/main.py
+++ b/backend/main.py
@@ -113,4 +113,8 @@ async def spa_fallback(full_path: str):
     file_path = (STATIC_DIR / full_path).resolve()
     if file_path.is_file() and str(file_path).startswith(str(STATIC_DIR.resolve())):
         return FileResponse(file_path)
-    return FileResponse(STATIC_DIR / "index.html")
+    index_html = STATIC_DIR / "index.html"
+    if not index_html.is_file():
+        logger.warning("frontend/dist/index.html missing at %s — returning 503", index_html)
+        return JSONResponse({"detail": "Frontend not available"}, status_code=503)
+    return FileResponse(index_html)

--- a/backend/tests/test_spa.py
+++ b/backend/tests/test_spa.py
@@ -52,6 +52,16 @@ def test_spa_fallback_serves_static_file_when_it_exists(tmp_path):
     assert response.status_code == 200
 
 
+def test_root_returns_503_when_index_html_missing(tmp_path):
+    """Dist dir exists but no index.html must return 503, not 404."""
+    dist = tmp_path / "dist"
+    dist.mkdir()
+    with patch.object(main_module, "STATIC_DIR", dist):
+        response = client.get("/")
+    assert response.status_code == 503
+    assert response.json() == {"detail": "Frontend not available"}
+
+
 def test_path_traversal_is_blocked(tmp_path):
     """Path traversal attempts must not serve files outside frontend/dist."""
     dist = tmp_path / "dist"

--- a/railway.toml
+++ b/railway.toml
@@ -4,6 +4,6 @@ dockerfilePath = "./Dockerfile"
 
 [deploy]
 healthcheckPath = "/health"
-healthcheckTimeout = 10
+healthcheckTimeout = 300
 restartPolicyType = "ON_FAILURE"
 restartPolicyMaxRetries = 3


### PR DESCRIPTION
## Summary

- Fixed `spa_fallback` in `backend/main.py` to return HTTP 503 (not 404) when `dist/` exists but `index.html` is absent
- Tightened Dockerfile build validation from `test -d dist` to `test -f dist/index.html` so a broken build fails at image build time
- Increased `healthcheckTimeout` in `railway.toml` from 10 → 300 seconds to allow Alembic migrations to complete on cold start
- Added a new test case covering the "dist dir exists but index.html missing → 503" branch

## Root Causes

Three compounding issues produced the production 404:

1. **Dockerfile**: `test -d dist` only verified the directory was created, not that `index.html` was generated inside it — a partial frontend build could deploy silently.
2. **`backend/main.py:116`**: `spa_fallback` called `FileResponse(STATIC_DIR / "index.html")` without checking if the file exists, causing Starlette to emit an unhandled 404.
3. **`railway.toml`**: `healthcheckTimeout = 10` was too short for `alembic upgrade head` on cold start, causing Railway to kill the container before uvicorn was ready.

## Changes

| File | Change |
|------|--------|
| `Dockerfile` | `test -d dist` → `test -f dist/index.html` |
| `backend/main.py` | Add `index_html.is_file()` guard before `FileResponse`; return 503 with JSON body if missing |
| `railway.toml` | `healthcheckTimeout = 10` → `healthcheckTimeout = 300` |
| `backend/tests/test_spa.py` | Add `test_root_returns_503_when_index_html_missing` |

## Validation

- Backend tests: **6 passed, 0 failed** (`backend/tests/test_spa.py`)
- Frontend tests: **96 passed, 0 failed**
- Frontend build: compiled successfully (`dist/index.html` generated)
- No files modified during validation

```
test_root_returns_503_when_dist_missing          ✅
test_spa_fallback_returns_503_for_unknown_path_when_dist_missing  ✅
test_spa_fallback_serves_index_html_for_spa_route  ✅
test_spa_fallback_serves_static_file_when_it_exists  ✅
test_root_returns_503_when_index_html_missing    ✅
test_path_traversal_is_blocked                   ✅
```

Fixes #125