### PR TITLE
refactor: architectural sweep — dedupe predicates, tighten types

### DIFF
--- a/backend/routers/suggestions.py
+++ b/backend/routers/suggestions.py
@@ -28,6 +28,24 @@ STALE_HOURS = 24
 MAX_REGENERATIONS_PER_DAY = 3
 
 
+async def _get_user_suggestion(
+    db: AsyncSession, suggestion_id: str, user_id: uuid.UUID
+) -> Suggestion:
+    stmt = (
+        select(Suggestion)
+        .options(joinedload(Suggestion.movie))
+        .where(
+            Suggestion.id == uuid.UUID(suggestion_id),
+            Suggestion.user_id == user_id,
+        )
+    )
+    result = await db.execute(stmt)
+    suggestion = result.unique().scalar_one_or_none()
+    if suggestion is None:
+        raise HTTPException(status_code=404, detail="Suggestion not found")
+    return suggestion
+
+
 def _build_suggestion_schema(s: Suggestion) -> SuggestionSchema:
     m = s.movie
     return SuggestionSchema(
@@ -206,19 +224,7 @@ async def dismiss_suggestion(
     db: AsyncSession = Depends(get_db),
 ):
     """Mark suggestion as dismissed."""
-    stmt = (
-        select(Suggestion)
-        .options(joinedload(Suggestion.movie))
-        .where(
-            Suggestion.id == uuid.UUID(suggestion_id),
-            Suggestion.user_id == current_user.id,
-        )
-    )
-    result = await db.execute(stmt)
-    suggestion = result.unique().scalar_one_or_none()
-
-    if not suggestion:
-        raise HTTPException(status_code=404, detail="Suggestion not found")
+    suggestion = await _get_user_suggestion(db, suggestion_id, current_user.id)
 
     suggestion.dismissed_at = datetime.now(timezone.utc)
     return _build_suggestion_schema(suggestion)
@@ -232,19 +238,7 @@ async def add_to_watchlist(
     db: AsyncSession = Depends(get_db),
 ):
     """Mark suggestion as added to watchlist and sync to Trakt."""
-    stmt = (
-        select(Suggestion)
-        .options(joinedload(Suggestion.movie))
-        .where(
-            Suggestion.id == uuid.UUID(suggestion_id),
-            Suggestion.user_id == current_user.id,
-        )
-    )
-    result = await db.execute(stmt)
-    suggestion = result.unique().scalar_one_or_none()
-
-    if not suggestion:
-        raise HTTPException(status_code=404, detail="Suggestion not found")
+    suggestion = await _get_user_suggestion(db, suggestion_id, current_user.id)
 
     suggestion.added_to_watchlist_at = datetime.now(timezone.utc)
 
@@ -273,19 +267,7 @@ async def mark_seen(
 ):
     """Mark the suggested film as seen and dismiss the suggestion."""
     uid = current_user.id
-    stmt = (
-        select(Suggestion)
-        .options(joinedload(Suggestion.movie))
-        .where(
-            Suggestion.id == uuid.UUID(suggestion_id),
-            Suggestion.user_id == uid,
-        )
-    )
-    result = await db.execute(stmt)
-    suggestion = result.unique().scalar_one_or_none()
-
-    if not suggestion:
-        raise HTTPException(status_code=404, detail="Suggestion not found")
+    suggestion = await _get_user_suggestion(db, suggestion_id, uid)
 
     # Update user_movies.seen = true
     um_stmt = select(UserMovie).where(

--- a/backend/routers/tournaments.py
+++ b/backend/routers/tournaments.py
@@ -23,6 +23,7 @@ from backend.schemas import (
     TournamentMatchSchema,
     TournamentSchema,
 )
+from backend.services.ranking import ranked_user_movies_stmt
 from backend.services.tournament import (
     create_tournament_bracket,
     curate_and_select_films,
@@ -121,17 +122,9 @@ async def get_available_genres(
 ):
     """Return distinct genres from user's seen films for tournament filtering."""
     stmt = (
-        select(func.unnest(Movie.genres).label("genre"))
-        .select_from(UserMovie)
-        .join(Movie, UserMovie.movie_id == Movie.id)
-        .where(
-            UserMovie.user_id == current_user.id,
-            UserMovie.seen.is_(True),
-            UserMovie.battles >= 1,
-            UserMovie.elo.isnot(None),
-            Movie.genres.isnot(None),
-            Movie.media_type == media_type,
-        )
+        ranked_user_movies_stmt(current_user.id, media_type)
+        .with_only_columns(func.unnest(Movie.genres).label("genre"))
+        .where(Movie.genres.isnot(None))
         .distinct()
         .order_by("genre")
     )

--- a/backend/schemas.py
+++ b/backend/schemas.py
@@ -17,6 +17,9 @@ class UserResponse(BaseModel):
 
 
 MediaType = Literal["movie", "show"]
+SwipeNextAction = Literal["duel", "swipe"]
+TournamentStatus = Literal["active", "completed", "abandoned"]
+SuggestionsStatus = Literal["ready", "not_enough_films", "no_candidates"]
 
 
 class MovieSchema(BaseModel):
@@ -119,7 +122,7 @@ class SwipeSubmit(BaseModel):
 class SwipeResponse(BaseModel):
     seen_count: int
     unseen_count: int
-    next_action: str = "duel"  # "duel" or "swipe" — whether user has enough seen films
+    next_action: SwipeNextAction = "duel"
 
 
 class StatsResponse(BaseModel):
@@ -160,7 +163,7 @@ class TournamentSchema(BaseModel):
     filter_type: Optional[str] = None
     filter_value: Optional[str] = None
     bracket_size: int
-    status: str
+    status: TournamentStatus
     champion_movie_id: Optional[str] = None
     tagline: Optional[str] = None
     theme_description: Optional[str] = None
@@ -183,7 +186,7 @@ class TournamentListItem(BaseModel):
     id: str
     name: str
     bracket_size: int
-    status: str
+    status: TournamentStatus
     created_at: datetime
     progress: str = ""
 
@@ -202,7 +205,7 @@ class SuggestionSchema(BaseModel):
 
 class SuggestionsResponse(BaseModel):
     suggestions: list[SuggestionSchema]
-    status: str = "ready"  # "ready" | "generating" | "not_enough_films"
+    status: SuggestionsStatus = "ready"
 
 
 # ── Feedback schemas ──────────────────────────────────────────────

--- a/backend/services/ranking.py
+++ b/backend/services/ranking.py
@@ -1,0 +1,31 @@
+"""Shared SQL: base SELECT for a user's ranked films."""
+
+from __future__ import annotations
+
+import uuid
+
+from sqlalchemy import Select, select
+
+from backend.db_models import Movie, UserMovie
+
+
+def ranked_user_movies_stmt(
+    user_id: uuid.UUID, media_type: str | None = None
+) -> Select:
+    """Base SELECT for a user's ranked films (seen, battled, elo set).
+
+    Joins Movie. Caller adds .order_by / .limit / additional .where as needed.
+    """
+    stmt = (
+        select(UserMovie)
+        .join(Movie, UserMovie.movie_id == Movie.id)
+        .where(
+            UserMovie.user_id == user_id,
+            UserMovie.seen.is_(True),
+            UserMovie.battles >= 1,
+            UserMovie.elo.isnot(None),
+        )
+    )
+    if media_type is not None:
+        stmt = stmt.where(Movie.media_type == media_type)
+    return stmt

--- a/backend/services/suggest.py
+++ b/backend/services/suggest.py
@@ -16,6 +16,7 @@ from sqlalchemy.orm import joinedload
 
 from backend.db_models import Movie, UserMovie
 from backend.services.llm import chat_completion, parse_json_response
+from backend.services.ranking import ranked_user_movies_stmt
 
 logger = logging.getLogger(__name__)
 
@@ -29,16 +30,8 @@ async def _build_taste_profile(
 ) -> dict | None:
     """Return taste profile dict, or None if the user has < MIN_RANKED films."""
     ranked_stmt = (
-        select(UserMovie)
+        ranked_user_movies_stmt(user_id, media_type)
         .options(joinedload(UserMovie.movie))
-        .join(Movie, UserMovie.movie_id == Movie.id)
-        .where(
-            UserMovie.user_id == user_id,
-            UserMovie.seen.is_(True),
-            UserMovie.battles >= 1,
-            UserMovie.elo.isnot(None),
-            Movie.media_type == media_type,
-        )
         .order_by(UserMovie.elo.desc())
         .limit(500)
     )
@@ -51,16 +44,8 @@ async def _build_taste_profile(
     top_10 = ranked[:10]
 
     bottom_stmt = (
-        select(UserMovie)
+        ranked_user_movies_stmt(user_id, media_type)
         .options(joinedload(UserMovie.movie))
-        .join(Movie, UserMovie.movie_id == Movie.id)
-        .where(
-            UserMovie.user_id == user_id,
-            UserMovie.seen.is_(True),
-            UserMovie.battles >= 1,
-            UserMovie.elo.isnot(None),
-            Movie.media_type == media_type,
-        )
         .order_by(UserMovie.elo.asc())
         .limit(5)
     )
@@ -240,17 +225,8 @@ async def generate_suggestions(
 
 async def has_enough_ranked(user_id: uuid.UUID, db: AsyncSession, media_type: str = "movie") -> bool:
     """Check if user has at least MIN_RANKED ranked films of the given type."""
-    count_stmt = (
-        select(func.count())
-        .select_from(UserMovie)
-        .join(Movie, UserMovie.movie_id == Movie.id)
-        .where(
-            UserMovie.user_id == user_id,
-            UserMovie.seen.is_(True),
-            UserMovie.battles >= 1,
-            UserMovie.elo.isnot(None),
-            Movie.media_type == media_type,
-        )
+    count_stmt = ranked_user_movies_stmt(user_id, media_type).with_only_columns(
+        func.count()
     )
     result = await db.execute(count_stmt)
     count = result.scalar() or 0

--- a/backend/services/tournament.py
+++ b/backend/services/tournament.py
@@ -14,6 +14,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from backend.db_models import Tournament, TournamentMatch, UserMovie
 from backend.services.curator import curate_tournament
 from backend.services.duel import apply_elo_result
+from backend.services.ranking import ranked_user_movies_stmt
 
 logger = logging.getLogger(__name__)
 
@@ -119,19 +120,8 @@ async def get_filtered_ranked_films(
     """
     from sqlalchemy.orm import joinedload
 
-    from backend.db_models import Movie
-
-    stmt = (
-        select(UserMovie)
-        .options(joinedload(UserMovie.movie))
-        .join(Movie, UserMovie.movie_id == Movie.id)
-        .where(
-            UserMovie.user_id == user_id,
-            UserMovie.seen.is_(True),
-            UserMovie.battles >= 1,
-            UserMovie.elo.isnot(None),
-            Movie.media_type == media_type,
-        )
+    stmt = ranked_user_movies_stmt(user_id, media_type).options(
+        joinedload(UserMovie.movie)
     )
     result = await db.execute(stmt)
     user_movies = list(result.unique().scalars().all())

--- a/backend/services/tournament.py
+++ b/backend/services/tournament.py
@@ -256,12 +256,22 @@ async def create_tournament_bracket(
                 TournamentMatch.position == next_pos,
             )
             next_match_obj = (await db.execute(next_round_stmt)).scalar_one()
-            if bye_match.position % 2 == 0:
-                next_match_obj.movie_a_id = bye_match.winner_movie_id
-            else:
-                next_match_obj.movie_b_id = bye_match.winner_movie_id
+            _advance_winner_to_next_round(
+                next_match_obj, bye_match.winner_movie_id, bye_match.position
+            )
 
         await db.flush()
+
+
+def _advance_winner_to_next_round(
+    next_match: TournamentMatch,
+    winner_movie_id: uuid.UUID,
+    current_position: int,
+) -> None:
+    if current_position % 2 == 0:
+        next_match.movie_a_id = winner_movie_id
+    else:
+        next_match.movie_b_id = winner_movie_id
 
 
 def validate_match(tournament: Tournament, match_id: uuid.UUID, winner_id: uuid.UUID) -> uuid.UUID:
@@ -325,10 +335,7 @@ async def record_match_winner(
                 TournamentMatch.position == next_pos,
             )
         )).scalar_one()
-        if match_obj.position % 2 == 0:
-            next_match.movie_a_id = winner_id
-        else:
-            next_match.movie_b_id = winner_id
+        _advance_winner_to_next_round(next_match, winner_id, match_obj.position)
 
     if round_num == num_rounds:
         t = (await db.execute(


### PR DESCRIPTION
## Architectural Sweep

**Focus**: Analyze the codebase architecture — identify complexity hotspots, unnecessary abstractions, and opportunities for simplification

### Assessment

The codebase is healthy overall (clean schemas/ORM split, no `eslint-disable`, ELO logic properly consolidated), but a handful of duplicated patterns are starting to drift. The strongest Rule-of-Three trigger is the "ranked user movies" SQL predicate, which appears in five locations across two services and a router. Smaller hotspots include triplicated suggestion-lookup blocks, the bracket-position parity rule duplicated within `services/tournament.py`, and `status` discriminants typed as plain `str` while the value sets live only in trailing comments. This PR addresses four low-risk, behavior-preserving cleanups; larger architectural smells (`TournamentBracket.jsx` splitting, `curator.py` HTTPException layering, `llm_response` JSONB control-state extraction) are left for future passes.

### Changes

- **`backend/routers/suggestions.py`** — extracted `_get_user_suggestion(db, suggestion_id, user_id)` helper. Three endpoints (`dismiss_suggestion`, `add_to_watchlist`, `mark_seen`) repeated the same `select(Suggestion).options(joinedload(...)).where(id, user_id).scalar_one_or_none()` + 404 block; now a single helper.
- **`backend/services/tournament.py`** — extracted `_advance_winner_to_next_round(...)` helper. The `position % 2 == 0 → movie_a else movie_b` parity rule appeared in both bye-propagation and post-match-propagation paths; consolidated to one place.
- **`backend/schemas.py`** — tightened `status` discriminants to `Literal[...]` types (`SwipeNextAction`, `TournamentStatus`, `SuggestionsStatus`). Replaces `str` + trailing-comment value sets in `SwipeResponse.next_action`, `TournamentSchema.status`, `TournamentListItem.status`, and `SuggestionsResponse.status`. Same runtime values; better OpenAPI schema and IDE hints.
- **`backend/services/ranking.py` (new)** — extracted `ranked_user_movies_stmt(user_id, media_type)` query helper. Replaces the 5-clause predicate (`user_id`, `seen`, `battles >= 1`, `elo IS NOT NULL`, `media_type`) duplicated across `services/suggest.py` (3×), `services/tournament.py:get_filtered_ranked_films`, and `routers/tournaments.py:get_available_genres`.

### Validation

- [x] Type check passes
- [x] Lint passes
- [x] Tests pass
- [x] Each change preserves existing behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)