### PR TITLE
docs: add Lachesis-format requirements for all 12 features

### DIFF
--- a/requirements/001-trakt-oauth2-authentication.md
+++ b/requirements/001-trakt-oauth2-authentication.md
@@ -1,0 +1,13 @@
+---
+id: "001"
+title: "Trakt OAuth2 authentication"
+status: "done"
+github_issue: 204
+updated: 2026-05-12
+---
+
+## Why
+FilmDuel builds on the user's existing watch history and ratings. Trakt is the canonical source of that data, so authentication via Trakt is the right entry point — no separate account setup needed.
+
+## What
+Full Trakt OAuth2 Authorization Code flow. JWT issued as httpOnly cookie. Token refresh before every Trakt API call if expiry is within 1 hour. Login, callback, and logout endpoints.

--- a/requirements/002-movie-pool.md
+++ b/requirements/002-movie-pool.md
@@ -1,0 +1,13 @@
+---
+id: "002"
+title: "Movie pool (Trakt + TMDB data ingestion)"
+status: "done"
+github_issue: 204
+updated: 2026-05-12
+---
+
+## Why
+The app needs a broad, pre-populated pool of films so there is always something to swipe or duel. Combining popular, trending, recommended, and user watch history covers both breadth and personalisation.
+
+## What
+Five Trakt data sources ingested and cached: popular (weekly), trending (weekly), recommended (daily), user watch history (hourly), user ratings (on login). TMDB poster images fetched and stored. Community rating stored on 0–100 scale. Shared `movies` table + per-user `user_movies` state.

--- a/requirements/003-swipe-session.md
+++ b/requirements/003-swipe-session.md
@@ -1,0 +1,13 @@
+---
+id: "003"
+title: "Swipe session (seen/unseen classification)"
+status: "done"
+github_issue: 204
+updated: 2026-05-12
+---
+
+## Why
+Before ranking films, users need to classify which ones they've seen. Swipe is a fast, friction-free way to build that classification without interrupting the ranking flow.
+
+## What
+10-film swipe session drawn from unknown (`seen IS NULL`) films, weighted by community rating band matching the user's median ELO. Tinder-style cards with swipe gesture (80px drag threshold) or tap buttons. Progress indicator. Summary screen on completion. Single bulk upsert for all 10 results.

--- a/requirements/004-elo-ranking-system.md
+++ b/requirements/004-elo-ranking-system.md
@@ -1,0 +1,13 @@
+---
+id: "004"
+title: "ELO ranking system"
+status: "done"
+github_issue: 204
+updated: 2026-05-12
+---
+
+## Why
+Head-to-head comparisons produce a meaningful ranked list without asking users to assign explicit scores. ELO is the right model for this: it self-corrects over time and handles transitivity naturally.
+
+## What
+ELO with K=64 for the first 5 battles (provisional), K=32 thereafter. `elo` is NULL until `battles ≥ 1`. `seeded_elo` from imported Trakt ratings used as bootstrap value for the first duel only. ELO → Trakt rating mapping on a 1–10 scale.

--- a/requirements/005-duel-pair-selection.md
+++ b/requirements/005-duel-pair-selection.md
@@ -1,0 +1,13 @@
+---
+id: "005"
+title: "Duel pair selection algorithm"
+status: "done"
+github_issue: 204
+updated: 2026-05-12
+---
+
+## Why
+Random pairings produce boring, uninformative duels. Good matchups should compare films of similar quality. New, unranked films should enter the pool quickly but not dominate.
+
+## What
+Weighted selection using `weight = 1/(battles+1)`. Every duel requires an anchor (a film with `battles ≥ 1`). Challenger constrained to the same ELO quality band as the anchor. Within-band ranked pairs: 70% close matches (ELO diff < 150), 30% wide matches (diff > 300). Anti-repeat guard.

--- a/requirements/006-duel-ui.md
+++ b/requirements/006-duel-ui.md
@@ -1,0 +1,13 @@
+---
+id: "006"
+title: "Duel UI"
+status: "done"
+github_issue: 204
+updated: 2026-05-12
+---
+
+## Why
+The duel screen is the core user experience. It needs to feel fast and gamelike while surfacing enough information for the user to make a confident pick.
+
+## What
+Two tall poster cards side by side with a "vs" badge. Title, year, genres, ELO, and battle count displayed. Four action buttons: "I've seen both — pick a winner", "Only seen A", "Only seen B", "Haven't seen either". Next pair pre-fetched immediately on button tap. Swipe interstitial shown between duels when `next_action == "swipe"`.

--- a/requirements/007-duel-outcome-handling.md
+++ b/requirements/007-duel-outcome-handling.md
@@ -1,0 +1,13 @@
+---
+id: "007"
+title: "Duel outcome handling and film state transitions"
+status: "done"
+github_issue: 204
+updated: 2026-05-12
+---
+
+## Why
+Different outcomes (`a_wins`, `b_wins`, `a_only`, `b_only`, `neither`) have different implications for ELO and film visibility. The state machine needs to be precise.
+
+## What
+Five outcome types. `a_wins`/`b_wins`: update ELO for both, set both to Ranked. `a_only`/`b_only`: mark winner as Seen-unranked, loser as Unseen. `neither`: both → Unseen. `seen=false` films never appear in swipe or duel again. `next_action` (`duel`/`swipe`) included in every duel response.

--- a/requirements/008-rankings-page.md
+++ b/requirements/008-rankings-page.md
@@ -1,0 +1,13 @@
+---
+id: "008"
+title: "Rankings page"
+status: "done"
+github_issue: 204
+updated: 2026-05-12
+---
+
+## Why
+Users want to see the fruit of their dueling effort: an ordered list of the films they've ranked, filterable by genre and decade.
+
+## What
+Paginated leaderboard (50 per page) showing rank, poster, title, year, ELO, and battle count. Filter pills for All / Genre / Decade. Top film gets accent decoration. Only films with `seen=true AND battles≥1` shown.

--- a/requirements/009-letterboxd-csv-export.md
+++ b/requirements/009-letterboxd-csv-export.md
@@ -1,0 +1,13 @@
+---
+id: "009"
+title: "Letterboxd CSV export"
+status: "done"
+github_issue: 204
+updated: 2026-05-12
+---
+
+## Why
+Letterboxd is the social layer many film fans use. Exporting rankings keeps the data portable and useful outside the app.
+
+## What
+`GET /api/rankings/export/csv` returns a Letterboxd-compatible CSV of ranked films. Floating export button on the Rankings page.

--- a/requirements/010-trakt-rating-sync.md
+++ b/requirements/010-trakt-rating-sync.md
@@ -1,0 +1,13 @@
+---
+id: "010"
+title: "Trakt rating sync"
+status: "done"
+github_issue: 204
+updated: 2026-05-12
+---
+
+## Why
+The user's Trakt profile is where their film data lives long-term. Syncing ELO-derived ratings back to Trakt (1–10 scale) keeps the two systems in sync.
+
+## What
+Fire-and-forget Trakt rating sync after every `a_wins` or `b_wins` outcome. ELO mapped to 1–10 scale. Retry once on 5xx; refresh token on 401. Failures logged to Sentry.

--- a/requirements/011-tv-show-support.md
+++ b/requirements/011-tv-show-support.md
@@ -1,0 +1,13 @@
+---
+id: "011"
+title: "TV show support"
+status: "in_progress"
+github_issue: 204
+updated: 2026-05-12
+---
+
+## Why
+TV shows are a major part of what people watch and want to rank. The same ELO/swipe mechanics should work for both film and TV.
+
+## What
+Nav bar toggle between Movies and TV Shows. Separate pool, user_movies-equivalent, and ranking list for TV. Trakt TV show endpoints integrated in parallel with movie endpoints.

--- a/requirements/012-sentry-error-tracking.md
+++ b/requirements/012-sentry-error-tracking.md
@@ -1,0 +1,13 @@
+---
+id: "012"
+title: "Sentry error tracking"
+status: "done"
+github_issue: 204
+updated: 2026-05-12
+---
+
+## Why
+Deployed apps have bugs that only appear in production. Sentry catches exceptions at runtime and surfaces them with full context.
+
+## What
+Sentry FastAPI integration via `SENTRY_DSN` env var. Trakt sync failures, unhandled exceptions, and token refresh failures all captured.


### PR DESCRIPTION
## Summary

Created comprehensive documentation for all 12 core features in Lachesis format. Each requirement file includes structured frontmatter (ID, title, status) and sections for **Why** (motivation/context) and **What** (behavior/acceptance criteria).

## Changes

Created 12 requirement files in `requirements/` directory:

- `001-trakt-oauth2-authentication.md` — OAuth2 integration with Trakt
- `002-movie-pool.md` — Movie pool initialization and management
- `003-swipe-session.md` — Swipe session creation and state management
- `004-elo-ranking-system.md` — Elo ranking algorithm and scoring
- `005-duel-pair-selection.md` — Movie pair selection logic for duels
- `006-duel-ui.md` — Duel interface and user interaction
- `007-duel-outcome-handling.md` — Recording duel results and rating updates
- `008-rankings-page.md` — Rankings display and filtering
- `009-letterboxd-csv-export.md` — Letterboxd CSV export functionality
- `010-trakt-rating-sync.md` — Background sync of Trakt ratings
- `011-tv-show-support.md` — TV show support across features
- `012-sentry-error-tracking.md` — Error tracking and monitoring

## Validation

All requirements files validated successfully:
- ✅ 12 files created
- ✅ Frontmatter with `status:` field on all files
- ✅ `## Why` and `## What` sections on all 12 files
- ✅ Status fields correctly set (11 done, 1 in_progress)

Fixes #204