### PR TITLE
security: encrypt pair tokens with Fernet instead of base64

### DIFF
--- a/backend/routers/movies.py
+++ b/backend/routers/movies.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import base64
 import logging
 from typing import Optional
 
@@ -14,6 +13,7 @@ from backend.db_models import User, UserMovie
 from backend.schemas import MediaType, MovieWithStateSchema, MoviePairResponse
 from backend.routers.auth import get_current_user
 from backend.services.pair_selection import select_pair
+from backend.services.token_crypto import decrypt_token, encrypt_token
 
 logger = logging.getLogger(__name__)
 
@@ -45,13 +45,12 @@ def _user_movie_to_schema(um: UserMovie) -> MovieWithStateSchema:
 
 
 def _encode_pair_token(id_a: str, id_b: str) -> str:
-    raw = f"{id_a},{id_b}"
-    return base64.urlsafe_b64encode(raw.encode()).decode()
+    return encrypt_token(f"{id_a},{id_b}")
 
 
 def _decode_pair_token(token: str) -> set[str] | None:
     try:
-        raw = base64.urlsafe_b64decode(token.encode()).decode()
+        raw = decrypt_token(token)
         parts = raw.split(",")
         if len(parts) == 2:
             return {parts[0], parts[1]}

--- a/backend/tests/test_movies_router.py
+++ b/backend/tests/test_movies_router.py
@@ -1,0 +1,46 @@
+"""Tests for pair token encoding in routers/movies.py."""
+
+from __future__ import annotations
+
+import os
+import uuid
+
+import pytest
+
+
+# Provide a test TOKEN_ENC_KEY so Fernet doesn't raise at import time
+os.environ.setdefault("TOKEN_ENC_KEY", "test-secret-key-for-unit-tests-32b")
+os.environ.setdefault("SECRET_KEY", "test-secret-key")
+
+from backend.routers.movies import _decode_pair_token, _encode_pair_token
+
+
+def test_pair_token_round_trips():
+    id_a = str(uuid.uuid4())
+    id_b = str(uuid.uuid4())
+    token = _encode_pair_token(id_a, id_b)
+    result = _decode_pair_token(token)
+    assert result == {id_a, id_b}
+
+
+def test_pair_token_is_opaque():
+    """Token must not contain the raw UUIDs in plaintext (base64 or otherwise)."""
+    id_a = str(uuid.uuid4())
+    id_b = str(uuid.uuid4())
+    token = _encode_pair_token(id_a, id_b)
+    # Strip any base64 padding and check neither UUID appears in the token
+    assert id_a not in token
+    assert id_b not in token
+
+
+def test_pair_token_invalid_returns_none():
+    assert _decode_pair_token("not-a-valid-token") is None
+    assert _decode_pair_token("") is None
+
+
+def test_pair_token_tampered_returns_none():
+    id_a = str(uuid.uuid4())
+    id_b = str(uuid.uuid4())
+    token = _encode_pair_token(id_a, id_b)
+    tampered = token[:-4] + "XXXX"
+    assert _decode_pair_token(tampered) is None

--- a/backend/tests/test_movies_router.py
+++ b/backend/tests/test_movies_router.py
@@ -5,14 +5,22 @@ from __future__ import annotations
 import os
 import uuid
 
-import pytest
-
-
-# Provide a test TOKEN_ENC_KEY so Fernet doesn't raise at import time
+# Provide a test TOKEN_ENC_KEY so Fernet doesn't raise at import time.
+# Must set env vars AND clear the settings cache before importing backend modules
+# because get_settings() is lru_cache'd and may already be populated (with
+# TOKEN_ENC_KEY="") by earlier test modules that import backend.
 os.environ.setdefault("TOKEN_ENC_KEY", "test-secret-key-for-unit-tests-32b")
 os.environ.setdefault("SECRET_KEY", "test-secret-key")
 
-from backend.routers.movies import _decode_pair_token, _encode_pair_token
+from backend.config import get_settings  # noqa: E402
+
+get_settings.cache_clear()
+
+from backend.services.token_crypto import _fernet  # noqa: E402
+
+_fernet.cache_clear()
+
+from backend.routers.movies import _decode_pair_token, _encode_pair_token  # noqa: E402
 
 
 def test_pair_token_round_trips():


### PR DESCRIPTION
## Summary

Fix security vulnerability where movie UUIDs are exposed in browser history via the `?last_pair_token=` query parameter. Replace base64 encoding with authenticated Fernet encryption to make the token opaque to observers.

- **Severity**: LOW (feature not currently active but would leak data if wired up)
- **Root cause**: `_encode_pair_token` uses base64 instead of encryption, making UUIDs trivially decodable
- **Fix**: Use existing `encrypt_token`/`decrypt_token` from `token_crypto.py` (Fernet AES-128-CBC + HMAC-SHA256)

## Changes

### backend/routers/movies.py
- Removed `import base64` (no longer needed)
- Added `from backend.services.token_crypto import decrypt_token, encrypt_token`
- Updated `_encode_pair_token()`: Replace base64 encoding with `encrypt_token()`
- Updated `_decode_pair_token()`: Replace base64 decoding with `decrypt_token()`

**Why**: Fernet produces URL-safe base64 output, so the token continues to work as a query parameter but is now cryptographically opaque.

### backend/tests/test_movies_router.py
- Added test file with 4 test cases:
  - `test_pair_token_round_trips()`: Verify token can be encoded and decoded
  - `test_pair_token_is_opaque()`: Verify UUIDs don't appear in plaintext in the token
  - `test_pair_token_invalid_returns_none()`: Invalid tokens safely return None
  - `test_pair_token_tampered_returns_none()`: Tampered tokens safely return None (Fernet HMAC validation)

## Validation

✅ 211 tests passed, 0 failed
✅ Lint check passed (0 new errors)
✅ Token round-trip works with Fernet encryption
✅ UUIDs no longer appear in token plaintext
✅ Invalid/tampered tokens safely ignored (backwards compatible)

## Backwards Compatibility

- Old base64 tokens in client cache: `_decode_pair_token` returns `None`, endpoint falls back to `last_pair_ids=None` (safe)
- Token output is still URL-safe base64, works unchanged in query parameters
- No schema changes; no frontend changes required

Fixes #203