### PR TITLE
security: prevent LLM metadata from API responses

### DIFF
--- a/backend/db_models.py
+++ b/backend/db_models.py
@@ -44,22 +44,27 @@ class User(Base):
     @property
     def trakt_access_token(self) -> str:
         from backend.services.token_crypto import decrypt_token
+
         return decrypt_token(self.trakt_access_token_enc)
 
     @trakt_access_token.setter
     def trakt_access_token(self, value: str) -> None:
         from backend.services.token_crypto import encrypt_token
+
         self.trakt_access_token_enc = encrypt_token(value)
 
     @property
     def trakt_refresh_token(self) -> str:
         from backend.services.token_crypto import decrypt_token
+
         return decrypt_token(self.trakt_refresh_token_enc)
 
     @trakt_refresh_token.setter
     def trakt_refresh_token(self, value: str) -> None:
         from backend.services.token_crypto import encrypt_token
+
         self.trakt_refresh_token_enc = encrypt_token(value)
+
     trakt_token_expires_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), nullable=False
     )
@@ -75,14 +80,20 @@ class User(Base):
         server_default="1970-01-01T00:00:00+00:00",
     )
 
-    user_movies: Mapped[list[UserMovie]] = relationship(back_populates="user", cascade="all, delete-orphan")
-    duels: Mapped[list[Duel]] = relationship(back_populates="user", cascade="all, delete-orphan")
+    user_movies: Mapped[list[UserMovie]] = relationship(
+        back_populates="user", cascade="all, delete-orphan"
+    )
+    duels: Mapped[list[Duel]] = relationship(
+        back_populates="user", cascade="all, delete-orphan"
+    )
 
 
 class Movie(Base):
     __tablename__ = "movies"
     __table_args__ = (
-        UniqueConstraint("trakt_id", "media_type", name="uq_movies_trakt_id_media_type"),
+        UniqueConstraint(
+            "trakt_id", "media_type", name="uq_movies_trakt_id_media_type"
+        ),
     )
 
     id: Mapped[uuid.UUID] = mapped_column(
@@ -100,7 +111,9 @@ class Movie(Base):
     overview: Mapped[Optional[str]] = mapped_column(Text, nullable=True)
     runtime: Mapped[Optional[int]] = mapped_column(Integer, nullable=True)
     poster_url: Mapped[Optional[str]] = mapped_column(Text, nullable=True)
-    community_rating: Mapped[Optional[float]] = mapped_column(Numeric(4, 1), nullable=True)
+    community_rating: Mapped[Optional[float]] = mapped_column(
+        Numeric(4, 1), nullable=True
+    )
     cached_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), default=lambda: datetime.now(timezone.utc)
     )
@@ -166,9 +179,7 @@ class Tournament(Base):
     filter_type: Mapped[Optional[str]] = mapped_column(Text, nullable=True)
     filter_value: Mapped[Optional[str]] = mapped_column(Text, nullable=True)
     bracket_size: Mapped[int] = mapped_column(Integer, nullable=False)
-    status: Mapped[str] = mapped_column(
-        Text, nullable=False, server_default="active"
-    )
+    status: Mapped[str] = mapped_column(Text, nullable=False, server_default="active")
     champion_movie_id: Mapped[Optional[uuid.UUID]] = mapped_column(
         UUID(as_uuid=True), ForeignKey("movies.id"), nullable=True
     )
@@ -223,7 +234,9 @@ class TournamentMatch(Base):
     duel_id: Mapped[Optional[uuid.UUID]] = mapped_column(
         UUID(as_uuid=True), ForeignKey("duels.id"), nullable=True
     )
-    is_bye: Mapped[bool] = mapped_column(Boolean, nullable=False, server_default="false")
+    is_bye: Mapped[bool] = mapped_column(
+        Boolean, nullable=False, server_default="false"
+    )
     played_at: Mapped[Optional[datetime]] = mapped_column(
         DateTime(timezone=True), nullable=True
     )
@@ -231,9 +244,7 @@ class TournamentMatch(Base):
     tournament: Mapped[Tournament] = relationship(back_populates="matches")
     movie_a: Mapped[Optional[Movie]] = relationship(foreign_keys=[movie_a_id])
     movie_b: Mapped[Optional[Movie]] = relationship(foreign_keys=[movie_b_id])
-    winner_movie: Mapped[Optional[Movie]] = relationship(
-        foreign_keys=[winner_movie_id]
-    )
+    winner_movie: Mapped[Optional[Movie]] = relationship(foreign_keys=[winner_movie_id])
     duel: Mapped[Optional[Duel]] = relationship()
 
 

--- a/backend/main.py
+++ b/backend/main.py
@@ -17,7 +17,16 @@ from slowapi.errors import RateLimitExceeded
 
 from backend.config import get_settings
 from backend.rate_limit import limiter
-from backend.routers import auth, movies, duels, rankings, suggestions, swipe, tournaments, feedback
+from backend.routers import (
+    auth,
+    movies,
+    duels,
+    rankings,
+    suggestions,
+    swipe,
+    tournaments,
+    feedback,
+)
 from backend.schemas import SELF_DUEL_ERROR_MSG
 
 logger = logging.getLogger(__name__)
@@ -69,7 +78,9 @@ async def add_security_headers(request: Request, call_next):
     response.headers["X-Content-Type-Options"] = "nosniff"
     response.headers["X-Frame-Options"] = "DENY"
     response.headers["Referrer-Policy"] = "strict-origin-when-cross-origin"
-    response.headers["Strict-Transport-Security"] = "max-age=31536000; includeSubDomains"
+    response.headers["Strict-Transport-Security"] = (
+        "max-age=31536000; includeSubDomains"
+    )
     response.headers["Content-Security-Policy"] = (
         "default-src 'self'; "
         "img-src 'self' https://image.tmdb.org data:; "
@@ -112,7 +123,9 @@ async def spa_fallback(full_path: str):
         return JSONResponse({"detail": "Frontend not available"}, status_code=503)
     index_html = STATIC_DIR / "index.html"
     if not index_html.is_file():
-        logger.error("frontend/dist/index.html missing at %s — returning 503", index_html)
+        logger.error(
+            "frontend/dist/index.html missing at %s — returning 503", index_html
+        )
         return JSONResponse({"detail": "Frontend not available"}, status_code=503)
     file_path = (STATIC_DIR / full_path).resolve()
     if file_path.is_file() and str(file_path).startswith(str(STATIC_DIR.resolve())):

--- a/backend/migrations/versions/001_initial_schema.py
+++ b/backend/migrations/versions/001_initial_schema.py
@@ -4,6 +4,7 @@ Revision ID: 001
 Revises:
 Create Date: 2026-04-11
 """
+
 from typing import Sequence, Union
 
 from alembic import op

--- a/backend/migrations/versions/002_add_seeded_elo_nullable_elo_mode.py
+++ b/backend/migrations/versions/002_add_seeded_elo_nullable_elo_mode.py
@@ -4,6 +4,7 @@ Revision ID: 002
 Revises: 001
 Create Date: 2026-04-11
 """
+
 from typing import Sequence, Union
 
 from alembic import op
@@ -34,8 +35,8 @@ def upgrade() -> None:
     # Drop old non-partial index, recreate as partial (WHERE elo IS NOT NULL)
     op.drop_index("ix_user_movies_user_elo", table_name="user_movies")
     op.execute(
-        'CREATE INDEX ix_user_movies_user_elo ON user_movies (user_id, elo) '
-        'WHERE elo IS NOT NULL'
+        "CREATE INDEX ix_user_movies_user_elo ON user_movies (user_id, elo) "
+        "WHERE elo IS NOT NULL"
     )
 
     # Add mode column to duels

--- a/backend/migrations/versions/003_community_rating_swipe_results.py
+++ b/backend/migrations/versions/003_community_rating_swipe_results.py
@@ -4,6 +4,7 @@ Revision ID: 003
 Revises: 002
 Create Date: 2026-04-11
 """
+
 from typing import Sequence, Union
 
 from alembic import op

--- a/backend/migrations/versions/004_add_pair_type_to_duels.py
+++ b/backend/migrations/versions/004_add_pair_type_to_duels.py
@@ -4,6 +4,7 @@ Revision ID: 004
 Revises: 003
 Create Date: 2026-04-11
 """
+
 from typing import Sequence, Union
 
 from alembic import op

--- a/backend/migrations/versions/005_add_tournament_tables.py
+++ b/backend/migrations/versions/005_add_tournament_tables.py
@@ -4,6 +4,7 @@ Revision ID: 005
 Revises: 004
 Create Date: 2026-04-11
 """
+
 from typing import Sequence, Union
 
 from alembic import op

--- a/backend/migrations/versions/006_add_pool_expansions.py
+++ b/backend/migrations/versions/006_add_pool_expansions.py
@@ -4,6 +4,7 @@ Revision ID: 006
 Revises: 005
 Create Date: 2026-04-12
 """
+
 from typing import Sequence, Union
 
 from alembic import op

--- a/backend/migrations/versions/007_add_tournament_byes.py
+++ b/backend/migrations/versions/007_add_tournament_byes.py
@@ -4,6 +4,7 @@ Revision ID: 007
 Revises: 005
 Create Date: 2026-04-12
 """
+
 from typing import Sequence, Union
 
 from alembic import op
@@ -18,7 +19,9 @@ depends_on: Union[str, Sequence[str], None] = None
 def upgrade() -> None:
     op.add_column(
         "tournament_matches",
-        sa.Column("is_bye", sa.Boolean(), nullable=False, server_default=sa.text("false")),
+        sa.Column(
+            "is_bye", sa.Boolean(), nullable=False, server_default=sa.text("false")
+        ),
     )
 
 

--- a/backend/migrations/versions/009_add_suggestions.py
+++ b/backend/migrations/versions/009_add_suggestions.py
@@ -4,6 +4,7 @@ Revision ID: 009
 Revises: 006, 007
 Create Date: 2026-04-12
 """
+
 from typing import Sequence, Union
 
 from alembic import op
@@ -19,11 +20,31 @@ depends_on: Union[str, Sequence[str], None] = None
 def upgrade() -> None:
     op.create_table(
         "suggestions",
-        sa.Column("id", UUID(as_uuid=True), primary_key=True, server_default=sa.text("gen_random_uuid()")),
-        sa.Column("user_id", UUID(as_uuid=True), sa.ForeignKey("users.id", ondelete="CASCADE"), nullable=False),
-        sa.Column("movie_id", UUID(as_uuid=True), sa.ForeignKey("movies.id", ondelete="CASCADE"), nullable=False),
+        sa.Column(
+            "id",
+            UUID(as_uuid=True),
+            primary_key=True,
+            server_default=sa.text("gen_random_uuid()"),
+        ),
+        sa.Column(
+            "user_id",
+            UUID(as_uuid=True),
+            sa.ForeignKey("users.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column(
+            "movie_id",
+            UUID(as_uuid=True),
+            sa.ForeignKey("movies.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
         sa.Column("reason", sa.Text(), nullable=False),
-        sa.Column("generated_at", sa.DateTime(timezone=True), nullable=False, server_default=sa.text("now()")),
+        sa.Column(
+            "generated_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("now()"),
+        ),
         sa.Column("dismissed_at", sa.DateTime(timezone=True), nullable=True),
         sa.Column("added_to_watchlist_at", sa.DateTime(timezone=True), nullable=True),
     )

--- a/backend/migrations/versions/010_add_ai_tournament_fields.py
+++ b/backend/migrations/versions/010_add_ai_tournament_fields.py
@@ -4,6 +4,7 @@ Revision ID: 010
 Revises: 009
 Create Date: 2026-04-12
 """
+
 from typing import Sequence, Union
 
 from alembic import op
@@ -18,10 +19,17 @@ depends_on: Union[str, Sequence[str], None] = None
 
 def upgrade() -> None:
     op.add_column("tournaments", sa.Column("tagline", sa.Text(), nullable=True))
-    op.add_column("tournaments", sa.Column("theme_description", sa.Text(), nullable=True))
+    op.add_column(
+        "tournaments", sa.Column("theme_description", sa.Text(), nullable=True)
+    )
     op.add_column(
         "tournaments",
-        sa.Column("is_ai_curated", sa.Boolean(), nullable=False, server_default=sa.text("false")),
+        sa.Column(
+            "is_ai_curated",
+            sa.Boolean(),
+            nullable=False,
+            server_default=sa.text("false"),
+        ),
     )
     op.add_column("tournaments", sa.Column("llm_response", JSONB(), nullable=True))
 

--- a/backend/migrations/versions/011_add_feedback_reports.py
+++ b/backend/migrations/versions/011_add_feedback_reports.py
@@ -4,6 +4,7 @@ Revision ID: 011
 Revises: 010
 Create Date: 2026-04-13
 """
+
 from typing import Sequence, Union
 
 from alembic import op

--- a/backend/migrations/versions/012_add_media_type.py
+++ b/backend/migrations/versions/012_add_media_type.py
@@ -4,6 +4,7 @@ Revision ID: 012
 Revises: 011
 Create Date: 2026-04-13
 """
+
 from typing import Sequence, Union
 
 from alembic import op

--- a/backend/migrations/versions/013_encrypt_trakt_tokens.py
+++ b/backend/migrations/versions/013_encrypt_trakt_tokens.py
@@ -4,6 +4,7 @@ Revision ID: 013
 Revises: 012
 Create Date: 2026-05-05
 """
+
 from typing import Sequence, Union
 
 from alembic import op
@@ -23,6 +24,7 @@ def upgrade() -> None:
     if not rows:
         return
     from backend.services.token_crypto import encrypt_token
+
     for row in rows:
         conn.execute(
             sa.text(
@@ -44,6 +46,7 @@ def downgrade() -> None:
         sa.text("SELECT id, trakt_access_token, trakt_refresh_token FROM users")
     ).fetchall()
     from backend.services.token_crypto import decrypt_token
+
     for row in rows:
         conn.execute(
             sa.text(

--- a/backend/migrations/versions/014_user_tokens_invalid_before.py
+++ b/backend/migrations/versions/014_user_tokens_invalid_before.py
@@ -4,6 +4,7 @@ Revision ID: 014
 Revises: 013
 Create Date: 2026-05-05
 """
+
 from typing import Sequence, Union
 
 from alembic import op

--- a/backend/routers/auth.py
+++ b/backend/routers/auth.py
@@ -9,7 +9,14 @@ from datetime import datetime, timedelta, timezone
 from urllib.parse import urlencode
 
 import jwt
-from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException, Request, Response
+from fastapi import (
+    APIRouter,
+    BackgroundTasks,
+    Depends,
+    HTTPException,
+    Request,
+    Response,
+)
 from fastapi.responses import RedirectResponse
 from sqlalchemy import delete, func, select, update
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -75,7 +82,8 @@ async def get_current_user_id(
         raise HTTPException(status_code=401, detail="Not authenticated")
     try:
         payload = jwt.decode(
-            token, settings.SECRET_KEY,
+            token,
+            settings.SECRET_KEY,
             algorithms=[JWT_ALGORITHM],
             issuer="filmduel",
             audience="filmduel",
@@ -83,7 +91,9 @@ async def get_current_user_id(
         user_id = payload.get("sub")
         iat = datetime.fromtimestamp(payload["iat"], tz=timezone.utc)
         if not user_id:
-            raise HTTPException(status_code=401, detail="Invalid session — missing subject")
+            raise HTTPException(
+                status_code=401, detail="Invalid session — missing subject"
+            )
     except jwt.ExpiredSignatureError:
         raise HTTPException(status_code=401, detail="Session expired")
     except jwt.InvalidTokenError:
@@ -345,9 +355,9 @@ async def sync_trakt(
 
     # Count movies before sync so we can report new additions
     before_count_result = await db.execute(
-        select(func.count()).select_from(UserMovie).where(
-            UserMovie.user_id == current_user.id
-        )
+        select(func.count())
+        .select_from(UserMovie)
+        .where(UserMovie.user_id == current_user.id)
     )
     before_count = before_count_result.scalar() or 0
 
@@ -363,9 +373,9 @@ async def sync_trakt(
 
     # Count movies after sync
     after_count_result = await db.execute(
-        select(func.count()).select_from(UserMovie).where(
-            UserMovie.user_id == current_user.id
-        )
+        select(func.count())
+        .select_from(UserMovie)
+        .where(UserMovie.user_id == current_user.id)
     )
     after_count = after_count_result.scalar() or 0
     new_movies = max(0, after_count - before_count)

--- a/backend/routers/duels.py
+++ b/backend/routers/duels.py
@@ -79,7 +79,11 @@ async def submit_duel(
 
     logger.info(
         "duel_submitted user_id=%s movie_a=%s movie_b=%s outcome=%s mode=%s",
-        uid, movie_a_id, movie_b_id, outcome, mode,
+        uid,
+        movie_a_id,
+        movie_b_id,
+        outcome,
+        mode,
     )
 
     try:

--- a/backend/routers/feedback.py
+++ b/backend/routers/feedback.py
@@ -22,19 +22,19 @@ ALLOWED_IMAGE_TYPES = {"image/jpeg", "image/png", "image/gif", "image/webp"}
 
 # Magic bytes for allowed image types
 _IMAGE_SIGNATURES = {
-    b'\x89PNG\r\n\x1a\n': "image/png",
-    b'\xff\xd8\xff': "image/jpeg",
-    b'GIF87a': "image/gif",
-    b'GIF89a': "image/gif",
-    b'RIFF': "image/webp",  # WebP starts with RIFF....WEBP
+    b"\x89PNG\r\n\x1a\n": "image/png",
+    b"\xff\xd8\xff": "image/jpeg",
+    b"GIF87a": "image/gif",
+    b"GIF89a": "image/gif",
+    b"RIFF": "image/webp",  # WebP starts with RIFF....WEBP
 }
 
 
 def _detect_image_type(data: bytes) -> str | None:
     """Detect image type from magic bytes. Returns MIME type or None."""
     for sig, mime in _IMAGE_SIGNATURES.items():
-        if data[:len(sig)] == sig:
-            if mime == "image/webp" and data[8:12] != b'WEBP':
+        if data[: len(sig)] == sig:
+            if mime == "image/webp" and data[8:12] != b"WEBP":
                 continue
             return mime
     return None
@@ -72,8 +72,6 @@ async def submit_feedback(
     db.add(report)
     await db.flush()
 
-    logger.info(
-        "feedback_submitted user_id=%s title=%r", current_user.id, title[:50]
-    )
+    logger.info("feedback_submitted user_id=%s title=%r", current_user.id, title[:50])
 
     return FeedbackReportResponse(id=str(report.id), created_at=report.created_at)

--- a/backend/routers/rankings.py
+++ b/backend/routers/rankings.py
@@ -11,7 +11,13 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from backend.db import get_db
 from backend.db_models import User, UserMovie
-from backend.schemas import MediaType, MovieSchema, RankedMovie, RankingsResponse, StatsResponse
+from backend.schemas import (
+    MediaType,
+    MovieSchema,
+    RankedMovie,
+    RankingsResponse,
+    StatsResponse,
+)
 from backend.routers.auth import get_current_user
 from backend.services.elo import elo_to_trakt_rating
 from backend.services.rankings import (
@@ -57,12 +63,16 @@ async def get_rankings(
 ):
     """Return the user's ranked movies/shows sorted by ELO descending."""
     user_movies, total = await get_user_rankings(
-        db, current_user.id, genre=genre, decade=decade, limit=limit, offset=offset,
+        db,
+        current_user.id,
+        genre=genre,
+        decade=decade,
+        limit=limit,
+        offset=offset,
         media_type=media_type,
     )
     rankings = [
-        _build_ranked_movie(um, rank=offset + i + 1)
-        for i, um in enumerate(user_movies)
+        _build_ranked_movie(um, rank=offset + i + 1) for i, um in enumerate(user_movies)
     ]
     return RankingsResponse(rankings=rankings, total=total)
 

--- a/backend/routers/suggestions.py
+++ b/backend/routers/suggestions.py
@@ -16,7 +16,12 @@ from backend.db import get_db
 from backend.rate_limit import limiter
 from backend.db_models import Movie, Suggestion, User, UserMovie
 from backend.routers.auth import get_current_user
-from backend.schemas import MediaType, MovieSchema, SuggestionSchema, SuggestionsResponse
+from backend.schemas import (
+    MediaType,
+    MovieSchema,
+    SuggestionSchema,
+    SuggestionsResponse,
+)
 from backend.services.suggest import generate_suggestions, has_enough_ranked
 from backend.services.trakt import TraktClient
 
@@ -177,12 +182,9 @@ async def regenerate_suggestions(
 
     # Count regenerations in last 24h (by counting distinct generated_at timestamps)
     cutoff = datetime.now(timezone.utc) - timedelta(hours=24)
-    count_stmt = (
-        select(func.count(func.distinct(Suggestion.generated_at)))
-        .where(
-            Suggestion.user_id == uid,
-            Suggestion.generated_at > cutoff,
-        )
+    count_stmt = select(func.count(func.distinct(Suggestion.generated_at))).where(
+        Suggestion.user_id == uid,
+        Suggestion.generated_at > cutoff,
     )
     result = await db.execute(count_stmt)
     regen_count = result.scalar() or 0
@@ -249,7 +251,9 @@ async def add_to_watchlist(
 
     async def _sync_trakt_watchlist():
         try:
-            client = TraktClient(client_id=settings.TRAKT_CLIENT_ID, access_token=access_token)
+            client = TraktClient(
+                client_id=settings.TRAKT_CLIENT_ID, access_token=access_token
+            )
             await client.add_to_watchlist(trakt_id)
         except Exception:
             logger.exception("Failed to sync watchlist to Trakt for movie %s", trakt_id)

--- a/backend/routers/swipe.py
+++ b/backend/routers/swipe.py
@@ -85,9 +85,11 @@ async def get_swipe_cards(
     if median_elo is None:
         logger.info("swipe_band_selection user_id=%s band=none (no ranked films)", uid)
         # No ranked films yet — pick randomly from rated films
-        stmt = base.where(Movie.community_rating.isnot(None)).order_by(
-            func.random()
-        ).limit(10)
+        stmt = (
+            base.where(Movie.community_rating.isnot(None))
+            .order_by(func.random())
+            .limit(10)
+        )
         result = await db.execute(stmt)
         rows = result.all()
         # Backfill with random if not enough rated films
@@ -101,7 +103,12 @@ async def get_swipe_cards(
     else:
         # Band-weighted selection: 60% target, 20% above, 20% below
         band_idx = _elo_to_band_index(int(median_elo))
-        logger.info("swipe_band_selection user_id=%s median_elo=%s band=%s", uid, median_elo, BANDS[band_idx][0])
+        logger.info(
+            "swipe_band_selection user_id=%s median_elo=%s band=%s",
+            uid,
+            median_elo,
+            BANDS[band_idx][0],
+        )
 
         target_range = _community_rating_range(band_idx)
         above_idx = max(0, band_idx - 1)
@@ -204,7 +211,12 @@ async def submit_swipe_results(
         select(func.count())
         .select_from(UserMovie)
         .join(Movie, UserMovie.movie_id == Movie.id)
-        .where(UserMovie.user_id == uid, UserMovie.seen.is_(True), UserMovie.battles == 0, Movie.media_type == media_type)
+        .where(
+            UserMovie.user_id == uid,
+            UserMovie.seen.is_(True),
+            UserMovie.battles == 0,
+            Movie.media_type == media_type,
+        )
     )
     seen_unranked = (await db.execute(seen_unranked_stmt)).scalar() or 0
 
@@ -213,7 +225,11 @@ async def submit_swipe_results(
         select(func.count())
         .select_from(UserMovie)
         .join(Movie, UserMovie.movie_id == Movie.id)
-        .where(UserMovie.user_id == uid, UserMovie.seen.is_(True), Movie.media_type == media_type)
+        .where(
+            UserMovie.user_id == uid,
+            UserMovie.seen.is_(True),
+            Movie.media_type == media_type,
+        )
     )
     total_seen = (await db.execute(total_seen_stmt)).scalar() or 0
 
@@ -221,7 +237,12 @@ async def submit_swipe_results(
 
     logger.info(
         "swipe_submit user_id=%s seen_count=%d unseen_count=%d next_action=%s total_seen=%d seen_unranked=%d",
-        uid, seen_count, unseen_count, next_action, total_seen, seen_unranked,
+        uid,
+        seen_count,
+        unseen_count,
+        next_action,
+        total_seen,
+        seen_unranked,
     )
 
     # Check if pool needs expansion (scoped by media_type)
@@ -229,12 +250,22 @@ async def submit_swipe_results(
         select(func.count())
         .select_from(UserMovie)
         .join(Movie, UserMovie.movie_id == Movie.id)
-        .where(UserMovie.user_id == uid, UserMovie.seen.is_(None), Movie.media_type == media_type)
+        .where(
+            UserMovie.user_id == uid,
+            UserMovie.seen.is_(None),
+            Movie.media_type == media_type,
+        )
     )
     unknown_count = (await db.execute(unknown_stmt)).scalar() or 0
 
     if unknown_count < 50:
-        logger.info("swipe_pool_low user_id=%s unknown_count=%d triggering_expansion", uid, unknown_count)
+        logger.info(
+            "swipe_pool_low user_id=%s unknown_count=%d triggering_expansion",
+            uid,
+            unknown_count,
+        )
         background_tasks.add_task(expand_pool, uid, media_type)
 
-    return SwipeResponse(seen_count=seen_count, unseen_count=unseen_count, next_action=next_action)
+    return SwipeResponse(
+        seen_count=seen_count, unseen_count=unseen_count, next_action=next_action
+    )

--- a/backend/routers/tournaments.py
+++ b/backend/routers/tournaments.py
@@ -80,7 +80,6 @@ def _tournament_schema(t: Tournament) -> TournamentSchema:
         tagline=t.tagline,
         theme_description=t.theme_description,
         is_ai_curated=t.is_ai_curated,
-        llm_response=t.llm_response,
         created_at=t.created_at,
         completed_at=t.completed_at,
         matches=[_match_schema(m) for m in sorted_matches],

--- a/backend/routers/tournaments.py
+++ b/backend/routers/tournaments.py
@@ -13,7 +13,7 @@ from sqlalchemy.orm import joinedload
 
 from backend.db import get_db
 from backend.rate_limit import limiter
-from backend.db_models import Movie, Tournament, TournamentMatch, User, UserMovie
+from backend.db_models import Movie, Tournament, TournamentMatch, User
 from backend.routers.auth import get_current_user
 from backend.schemas import (
     MediaType,
@@ -142,7 +142,11 @@ async def get_pool_count(
     """Return number of ranked films matching the given filter."""
     try:
         user_movies = await get_filtered_ranked_films(
-            db, current_user.id, filter_type, filter_value, media_type=media_type,
+            db,
+            current_user.id,
+            filter_type,
+            filter_value,
+            media_type=media_type,
         )
     except ValueError:
         return {"count": 0}
@@ -162,7 +166,11 @@ async def create_tournament(
 
     try:
         user_movies = await get_filtered_ranked_films(
-            db, uid, body.filter_type, body.filter_value, media_type=body.media_type,
+            db,
+            uid,
+            body.filter_type,
+            body.filter_value,
+            media_type=body.media_type,
         )
     except ValueError:
         raise HTTPException(status_code=400, detail="Invalid decade format")
@@ -236,29 +244,41 @@ async def regenerate_tournament(
     tournament = await _load_tournament(tournament_id, uid, db)
 
     if not tournament.is_ai_curated:
-        raise HTTPException(status_code=400, detail="Only AI-curated tournaments can be regenerated")
+        raise HTTPException(
+            status_code=400, detail="Only AI-curated tournaments can be regenerated"
+        )
 
     played_matches = [
-        m for m in tournament.matches
-        if m.winner_movie_id is not None and not m.is_bye
+        m for m in tournament.matches if m.winner_movie_id is not None and not m.is_bye
     ]
     if played_matches:
-        raise HTTPException(status_code=400, detail="Cannot regenerate after matches have been played")
+        raise HTTPException(
+            status_code=400, detail="Cannot regenerate after matches have been played"
+        )
 
     regen_count = 0
     if tournament.llm_response and isinstance(tournament.llm_response, dict):
         regen_count = tournament.llm_response.get("_regen_count", 0)
     if regen_count >= 3:
-        raise HTTPException(status_code=400, detail="Maximum regeneration attempts (3) reached")
+        raise HTTPException(
+            status_code=400, detail="Maximum regeneration attempts (3) reached"
+        )
 
     try:
         user_movies = await get_filtered_ranked_films(
-            db, uid, tournament.filter_type, tournament.filter_value,
+            db,
+            uid,
+            tournament.filter_type,
+            tournament.filter_value,
         )
     except ValueError:
         raise HTTPException(status_code=400, detail="Invalid decade format")
 
-    original_hint = tournament.llm_response.get("_theme_hint", "") if tournament.llm_response else ""
+    original_hint = (
+        tournament.llm_response.get("_theme_hint", "")
+        if tournament.llm_response
+        else ""
+    )
     try:
         selected_ums, llm_result = await curate_and_select_films(
             user_movies=user_movies,
@@ -287,7 +307,9 @@ async def regenerate_tournament(
     t.theme_description = llm_result.get("theme_description")
     t.llm_response = llm_result
 
-    await create_tournament_bracket(db, tournament_id, tournament.bracket_size, selected_ums)
+    await create_tournament_bracket(
+        db, tournament_id, tournament.bracket_size, selected_ums
+    )
 
     tournament = await _load_tournament(tournament_id, uid, db)
     return _tournament_schema(tournament)
@@ -332,7 +354,9 @@ async def list_tournaments(
                 played = 0
                 total_in_round = 0
 
-            progress = f"Round {current_round} \u2014 {played}/{total_in_round} matches played"
+            progress = (
+                f"Round {current_round} \u2014 {played}/{total_in_round} matches played"
+            )
 
         items.append(
             TournamentListItem(
@@ -408,8 +432,13 @@ async def submit_match_result_endpoint(
         raise HTTPException(status_code=400, detail=str(e))
 
     await record_match_winner(
-        db, tournament_id, tournament.bracket_size,
-        match_id, winner_id, loser_id, uid,
+        db,
+        tournament_id,
+        tournament.bracket_size,
+        match_id,
+        winner_id,
+        loser_id,
+        uid,
     )
 
     tournament = await _load_tournament(tournament_id, uid, db)

--- a/backend/schemas.py
+++ b/backend/schemas.py
@@ -168,7 +168,6 @@ class TournamentSchema(BaseModel):
     tagline: Optional[str] = None
     theme_description: Optional[str] = None
     is_ai_curated: bool = False
-    llm_response: Optional[dict] = None
     created_at: datetime
     completed_at: Optional[datetime] = None
     matches: list[TournamentMatchSchema] = []

--- a/backend/services/curator.py
+++ b/backend/services/curator.py
@@ -15,8 +15,9 @@ logger = logging.getLogger(__name__)
 def _sanitize_theme_hint(hint: str) -> str:
     """Strip potential prompt injection from user theme hints."""
     hint = hint[:100]  # max length
-    hint = re.sub(r'[{}\[\]<>]', '', hint)  # remove structural chars
+    hint = re.sub(r"[{}\[\]<>]", "", hint)  # remove structural chars
     return hint.strip()
+
 
 SYSTEM_PROMPT = """\
 You are a film curator for a movie ranking app. Given a list of candidate films \
@@ -75,13 +76,19 @@ async def curate_tournament(
     system_prompt = SYSTEM_PROMPT.format(bracket_size=bracket_size)
     user_prompt = USER_PROMPT_TEMPLATE.format(
         bracket_size=bracket_size,
-        filter_context=f"Active filter: {filter_context}" if filter_context else "No filter applied",
-        theme_hint=f'User theme (use as inspiration): "{_sanitize_theme_hint(theme_hint)}"' if theme_hint else "",
+        filter_context=f"Active filter: {filter_context}"
+        if filter_context
+        else "No filter applied",
+        theme_hint=f'User theme (use as inspiration): "{_sanitize_theme_hint(theme_hint)}"'
+        if theme_hint
+        else "",
         candidates_text=candidates_text,
     )
 
     try:
-        text_content = await chat_completion(system_prompt, user_prompt, max_tokens=2000)
+        text_content = await chat_completion(
+            system_prompt, user_prompt, max_tokens=2000
+        )
     except ValueError as exc:
         # LLM_API_KEY not configured
         raise HTTPException(
@@ -104,6 +111,7 @@ async def curate_tournament(
         if match:
             try:
                 import json
+
                 result = json.loads(match.group(1))
             except Exception:
                 logger.error("Failed to parse LLM JSON output: %s", text_content[:500])

--- a/backend/services/duel.py
+++ b/backend/services/duel.py
@@ -117,8 +117,12 @@ async def process_duel(
     now = datetime.now(timezone.utc)
 
     if outcome in ("a_wins", "b_wins"):
-        elo_a_before = um_a.elo if um_a.elo is not None else get_initial_elo(um_a.seeded_elo)
-        elo_b_before = um_b.elo if um_b.elo is not None else get_initial_elo(um_b.seeded_elo)
+        elo_a_before = (
+            um_a.elo if um_a.elo is not None else get_initial_elo(um_a.seeded_elo)
+        )
+        elo_b_before = (
+            um_b.elo if um_b.elo is not None else get_initial_elo(um_b.seeded_elo)
+        )
 
         if outcome == "a_wins":
             winner_id, loser_id = movie_a_id, movie_b_id
@@ -129,7 +133,9 @@ async def process_duel(
 
         um_a.seen = True
         um_b.seen = True
-        duel = await apply_elo_result(db, user_id, winner_id, loser_id, um_w, um_l, mode)
+        duel = await apply_elo_result(
+            db, user_id, winner_id, loser_id, um_w, um_l, mode
+        )
         duel.pair_type = pair_type
 
         new_elo_a = um_a.elo
@@ -160,7 +166,11 @@ async def process_duel(
 
     logger.info(
         "duel_processed user_id=%s outcome=%s pair_type=%s elo_delta_a=%+d elo_delta_b=%+d",
-        user_id, outcome, pair_type, delta_a, delta_b,
+        user_id,
+        outcome,
+        pair_type,
+        delta_a,
+        delta_b,
     )
 
     # ── next_action ─────────────────────────────────────────────────
@@ -183,7 +193,9 @@ async def process_duel(
 
     logger.info(
         "duel_next_action user_id=%s next_action=%s seen_unranked=%d",
-        user_id, next_action, seen_unranked,
+        user_id,
+        next_action,
+        seen_unranked,
     )
 
     return ProcessDuelResult(

--- a/backend/services/expand.py
+++ b/backend/services/expand.py
@@ -54,12 +54,9 @@ async def _expand_pool_inner(user_id: uuid.UUID, media_type: str = "movie") -> i
         cutoff = now - EXPANSION_COOLDOWN
 
         # Get recent expansion sources to skip
-        recent_stmt = (
-            select(PoolExpansion.source, PoolExpansion.source_key)
-            .where(
-                PoolExpansion.user_id == user_id,
-                PoolExpansion.ran_at >= cutoff,
-            )
+        recent_stmt = select(PoolExpansion.source, PoolExpansion.source_key).where(
+            PoolExpansion.user_id == user_id,
+            PoolExpansion.ran_at >= cutoff,
         )
         result = await db.execute(recent_stmt)
         recent_keys: set[tuple[str, str | None]] = {
@@ -71,23 +68,32 @@ async def _expand_pool_inner(user_id: uuid.UUID, media_type: str = "movie") -> i
             added = await _expand_from_recommendations(
                 db, user_id, user, settings, recent_keys, now, media_type
             )
-            logger.info("expand_source user_id=%s source=trakt_recommendations added=%d", user_id, added)
+            logger.info(
+                "expand_source user_id=%s source=trakt_recommendations added=%d",
+                user_id,
+                added,
+            )
             total_added += added
 
         # Source B: TMDB similar films from top-ranked items (movies only)
         if total_added < TARGET_ADDED and media_type == "movie":
-            added = await _expand_from_similar(
-                db, user_id, settings, recent_keys, now
+            added = await _expand_from_similar(db, user_id, settings, recent_keys, now)
+            logger.info(
+                "expand_source user_id=%s source=tmdb_similar added=%d", user_id, added
             )
-            logger.info("expand_source user_id=%s source=tmdb_similar added=%d", user_id, added)
             total_added += added
 
         # Source C: Trakt anticipated
-        if total_added < TARGET_ADDED and ("anticipated", media_type) not in recent_keys:
+        if (
+            total_added < TARGET_ADDED
+            and ("anticipated", media_type) not in recent_keys
+        ):
             added = await _expand_from_anticipated(
                 db, user_id, user, settings, recent_keys, now, media_type
             )
-            logger.info("expand_source user_id=%s source=anticipated added=%d", user_id, added)
+            logger.info(
+                "expand_source user_id=%s source=anticipated added=%d", user_id, added
+            )
             total_added += added
 
         # Source D: Deeper popular pages
@@ -95,7 +101,9 @@ async def _expand_pool_inner(user_id: uuid.UUID, media_type: str = "movie") -> i
             added = await _expand_from_popular_pages(
                 db, user_id, user, settings, recent_keys, now, media_type
             )
-            logger.info("expand_source user_id=%s source=popular_pages added=%d", user_id, added)
+            logger.info(
+                "expand_source user_id=%s source=popular_pages added=%d", user_id, added
+            )
             total_added += added
 
         await db.commit()
@@ -141,13 +149,15 @@ async def _expand_from_recommendations(
         if ok:
             added += 1
 
-    db.add(PoolExpansion(
-        user_id=user_id,
-        source="trakt_recommendations",
-        source_key=source_key,
-        films_added=added,
-        ran_at=now,
-    ))
+    db.add(
+        PoolExpansion(
+            user_id=user_id,
+            source="trakt_recommendations",
+            source_key=source_key,
+            films_added=added,
+            ran_at=now,
+        )
+    )
     await db.flush()
     return added
 
@@ -192,13 +202,15 @@ async def _expand_from_similar(
                 added += 1
 
         # Record expansion
-        db.add(PoolExpansion(
-            user_id=user_id,
-            source="tmdb_similar",
-            source_key=source_key,
-            films_added=added,
-            ran_at=now,
-        ))
+        db.add(
+            PoolExpansion(
+                user_id=user_id,
+                source="tmdb_similar",
+                source_key=source_key,
+                films_added=added,
+                ran_at=now,
+            )
+        )
         total += added
 
         # Rate-limit TMDB calls
@@ -247,13 +259,15 @@ async def _expand_from_anticipated(
         if ok:
             added += 1
 
-    db.add(PoolExpansion(
-        user_id=user_id,
-        source="anticipated",
-        source_key=media_type,
-        films_added=added,
-        ran_at=now,
-    ))
+    db.add(
+        PoolExpansion(
+            user_id=user_id,
+            source="anticipated",
+            source_key=media_type,
+            films_added=added,
+            ran_at=now,
+        )
+    )
     await db.flush()
     return added
 
@@ -299,13 +313,15 @@ async def _expand_from_popular_pages(
             if ok:
                 added += 1
 
-        db.add(PoolExpansion(
-            user_id=user_id,
-            source=source,
-            source_key=source_key,
-            films_added=added,
-            ran_at=now,
-        ))
+        db.add(
+            PoolExpansion(
+                user_id=user_id,
+                source=source,
+                source_key=source_key,
+                films_added=added,
+                ran_at=now,
+            )
+        )
         total += added
 
         if total >= TARGET_ADDED:
@@ -332,21 +348,27 @@ async def _upsert_film_from_trakt(
     await db.flush()
 
     result = await db.execute(
-        select(Movie.id).where(Movie.trakt_id == trakt_id, Movie.media_type == media_type)
+        select(Movie.id).where(
+            Movie.trakt_id == trakt_id, Movie.media_type == media_type
+        )
     )
     movie_uuid = result.scalar_one_or_none()
     if not movie_uuid:
         return False
 
-    um_stmt = insert(UserMovie.__table__).values(
-        user_id=user_id,
-        movie_id=movie_uuid,
-        seen=None,
-        elo=None,
-        battles=0,
-        updated_at=now,
-    ).on_conflict_do_nothing(
-        index_elements=["user_id", "movie_id"],
+    um_stmt = (
+        insert(UserMovie.__table__)
+        .values(
+            user_id=user_id,
+            movie_id=movie_uuid,
+            seen=None,
+            elo=None,
+            battles=0,
+            updated_at=now,
+        )
+        .on_conflict_do_nothing(
+            index_elements=["user_id", "movie_id"],
+        )
     )
     result = await db.execute(um_stmt)
     return result.rowcount > 0
@@ -373,15 +395,19 @@ async def _upsert_film_from_tmdb(
 
     if row:
         # Movie exists, just ensure user_movie
-        um_stmt = insert(UserMovie.__table__).values(
-            user_id=user_id,
-            movie_id=row.id,
-            seen=None,
-            elo=None,
-            battles=0,
-            updated_at=now,
-        ).on_conflict_do_nothing(
-            index_elements=["user_id", "movie_id"],
+        um_stmt = (
+            insert(UserMovie.__table__)
+            .values(
+                user_id=user_id,
+                movie_id=row.id,
+                seen=None,
+                elo=None,
+                battles=0,
+                updated_at=now,
+            )
+            .on_conflict_do_nothing(
+                index_elements=["user_id", "movie_id"],
+            )
         )
         result = await db.execute(um_stmt)
         return result.rowcount > 0
@@ -392,25 +418,29 @@ async def _upsert_film_from_tmdb(
         return False
 
     # Upsert the movie (TMDB expansion is movies-only, so media_type="movie")
-    stmt = insert(Movie.__table__).values(
-        trakt_id=trakt_id,
-        media_type="movie",
-        tmdb_id=tmdb_id,
-        title=film.get("title", "Unknown"),
-        year=film.get("year"),
-        genres=film.get("genres"),
-        overview=film.get("overview"),
-        cached_at=now,
-    ).on_conflict_do_update(
-        index_elements=["trakt_id", "media_type"],
-        set_={
-            "tmdb_id": tmdb_id,
-            "title": film.get("title", "Unknown"),
-            "year": film.get("year"),
-            "genres": film.get("genres"),
-            "overview": film.get("overview"),
-            "cached_at": now,
-        },
+    stmt = (
+        insert(Movie.__table__)
+        .values(
+            trakt_id=trakt_id,
+            media_type="movie",
+            tmdb_id=tmdb_id,
+            title=film.get("title", "Unknown"),
+            year=film.get("year"),
+            genres=film.get("genres"),
+            overview=film.get("overview"),
+            cached_at=now,
+        )
+        .on_conflict_do_update(
+            index_elements=["trakt_id", "media_type"],
+            set_={
+                "tmdb_id": tmdb_id,
+                "title": film.get("title", "Unknown"),
+                "year": film.get("year"),
+                "genres": film.get("genres"),
+                "overview": film.get("overview"),
+                "cached_at": now,
+            },
+        )
     )
     await db.execute(stmt)
     await db.flush()
@@ -422,15 +452,19 @@ async def _upsert_film_from_tmdb(
     if not movie_uuid:
         return False
 
-    um_stmt = insert(UserMovie.__table__).values(
-        user_id=user_id,
-        movie_id=movie_uuid,
-        seen=None,
-        elo=None,
-        battles=0,
-        updated_at=now,
-    ).on_conflict_do_nothing(
-        index_elements=["user_id", "movie_id"],
+    um_stmt = (
+        insert(UserMovie.__table__)
+        .values(
+            user_id=user_id,
+            movie_id=movie_uuid,
+            seen=None,
+            elo=None,
+            battles=0,
+            updated_at=now,
+        )
+        .on_conflict_do_nothing(
+            index_elements=["user_id", "movie_id"],
+        )
     )
     result = await db.execute(um_stmt)
     return result.rowcount > 0

--- a/backend/services/llm.py
+++ b/backend/services/llm.py
@@ -41,13 +41,20 @@ async def chat_completion(
             ],
         )
     except Exception:
-        logger.error("llm_error model=%s elapsed=%.2fs", model_name, time.monotonic() - t0)
+        logger.error(
+            "llm_error model=%s elapsed=%.2fs", model_name, time.monotonic() - t0
+        )
         raise
 
     elapsed = time.monotonic() - t0
     usage = getattr(response, "usage", None)
     total_tokens = usage.total_tokens if usage else None
-    logger.info("llm_response model=%s elapsed=%.2fs tokens=%s", model_name, elapsed, total_tokens)
+    logger.info(
+        "llm_response model=%s elapsed=%.2fs tokens=%s",
+        model_name,
+        elapsed,
+        total_tokens,
+    )
 
     return response.choices[0].message.content
 
@@ -57,5 +64,9 @@ def parse_json_response(text: str) -> dict:
     text = text.strip()
     if text.startswith("```"):
         lines = text.split("\n")
-        text = "\n".join(lines[1:-1]) if lines[-1].strip() == "```" else "\n".join(lines[1:])
+        text = (
+            "\n".join(lines[1:-1])
+            if lines[-1].strip() == "```"
+            else "\n".join(lines[1:])
+        )
     return json.loads(text)

--- a/backend/services/pair_selection.py
+++ b/backend/services/pair_selection.py
@@ -16,11 +16,11 @@ from backend.db_models import Movie, UserMovie
 
 # (name, elo_low, elo_high, community_rating_low, community_rating_high)
 BANDS = [
-    ("elite",  1300, 9999, 80, 100),
+    ("elite", 1300, 9999, 80, 100),
     ("strong", 1100, 1299, 65, 79),
-    ("mid",     900, 1099, 45, 64),
-    ("weak",    700,  899, 25, 44),
-    ("poor",      0,  699,  0, 24),
+    ("mid", 900, 1099, 45, 64),
+    ("weak", 700, 899, 25, 44),
+    ("poor", 0, 699, 0, 24),
 ]
 
 BAND_ORDER = [b[0] for b in BANDS]
@@ -58,7 +58,9 @@ def _film_band(um: UserMovie) -> str:
     if um.battles >= 1:
         return elo_to_band(um.elo)
     return community_rating_to_band(
-        float(um.movie.community_rating) if um.movie.community_rating is not None else None
+        float(um.movie.community_rating)
+        if um.movie.community_rating is not None
+        else None
     )
 
 
@@ -100,7 +102,9 @@ async def select_pair(
     seen_films = list(seen_result.unique().scalars().all())
 
     if len(seen_films) < 2:
-        raise ValueError(f"Need more seen {media_type}s to duel. Swipe to classify some {media_type}s first!")
+        raise ValueError(
+            f"Need more seen {media_type}s to duel. Swipe to classify some {media_type}s first!"
+        )
 
     # Split into anchors (ranked, battles >= 1) and full pool
     anchor_pool = [f for f in seen_films if f.battles >= 1 and f.elo is not None]

--- a/backend/services/pool.py
+++ b/backend/services/pool.py
@@ -37,10 +37,16 @@ def build_movie_upsert(movie_data: dict, now: datetime, media_type: str = "movie
         community_rating=community_rating,
         cached_at=now,
     )
-    update_set = {k: v for k, v in values.items() if k not in ("trakt_id", "media_type")}
-    stmt = insert(Movie.__table__).values(**values).on_conflict_do_update(
-        index_elements=["trakt_id", "media_type"],
-        set_=update_set,
+    update_set = {
+        k: v for k, v in values.items() if k not in ("trakt_id", "media_type")
+    }
+    stmt = (
+        insert(Movie.__table__)
+        .values(**values)
+        .on_conflict_do_update(
+            index_elements=["trakt_id", "media_type"],
+            set_=update_set,
+        )
     )
     return stmt
 
@@ -74,11 +80,21 @@ async def populate_movie_pool(user: User, db: AsyncSession) -> None:
     )
 
     for media_type in ("movie", "show"):
-        popular = await _safe_fetch(client.get_popular, limit=100, media_type=media_type)
-        trending = await _safe_fetch(client.get_trending, limit=100, media_type=media_type)
-        recommended = await _safe_fetch(client.get_recommendations, limit=100, media_type=media_type)
-        watched = await _safe_fetch(client.get_user_watched, user.trakt_user_id, media_type=media_type)
-        ratings_list = await _safe_fetch(client.get_user_ratings, user.trakt_user_id, media_type=media_type)
+        popular = await _safe_fetch(
+            client.get_popular, limit=100, media_type=media_type
+        )
+        trending = await _safe_fetch(
+            client.get_trending, limit=100, media_type=media_type
+        )
+        recommended = await _safe_fetch(
+            client.get_recommendations, limit=100, media_type=media_type
+        )
+        watched = await _safe_fetch(
+            client.get_user_watched, user.trakt_user_id, media_type=media_type
+        )
+        ratings_list = await _safe_fetch(
+            client.get_user_ratings, user.trakt_user_id, media_type=media_type
+        )
 
         ratings_by_trakt_id: dict[int, int] = {
             r["trakt_id"]: r["rating"] for r in ratings_list
@@ -98,7 +114,9 @@ async def populate_movie_pool(user: User, db: AsyncSession) -> None:
             if trakt_id not in pool:
                 pool[trakt_id] = item
 
-        await _upsert_pool(db, user, pool, seen_trakt_ids, ratings_by_trakt_id, media_type, now)
+        await _upsert_pool(
+            db, user, pool, seen_trakt_ids, ratings_by_trakt_id, media_type, now
+        )
 
     # Update last_seen_at
     user.last_seen_at = now
@@ -148,27 +166,31 @@ async def _upsert_pool(
         rating = ratings_by_trakt_id.get(trakt_id)
         seeded_elo = trakt_rating_to_seeded_elo(rating) if rating is not None else None
 
-        stmt = insert(UserMovie.__table__).values(
-            user_id=user.id,
-            movie_id=movie_uuid,
-            seen=seen,
-            elo=None,
-            seeded_elo=seeded_elo,
-            battles=0,
-            trakt_rating=rating,
-            updated_at=now,
-        ).on_conflict_do_update(
-            index_elements=["user_id", "movie_id"],
-            set_={
-                "seen": seen if seen is True else UserMovie.__table__.c.seen,
-                "seeded_elo": seeded_elo
-                if seeded_elo is not None
-                else UserMovie.__table__.c.seeded_elo,
-                "trakt_rating": rating
-                if rating is not None
-                else UserMovie.__table__.c.trakt_rating,
-                "updated_at": now,
-            },
+        stmt = (
+            insert(UserMovie.__table__)
+            .values(
+                user_id=user.id,
+                movie_id=movie_uuid,
+                seen=seen,
+                elo=None,
+                seeded_elo=seeded_elo,
+                battles=0,
+                trakt_rating=rating,
+                updated_at=now,
+            )
+            .on_conflict_do_update(
+                index_elements=["user_id", "movie_id"],
+                set_={
+                    "seen": seen if seen is True else UserMovie.__table__.c.seen,
+                    "seeded_elo": seeded_elo
+                    if seeded_elo is not None
+                    else UserMovie.__table__.c.seeded_elo,
+                    "trakt_rating": rating
+                    if rating is not None
+                    else UserMovie.__table__.c.trakt_rating,
+                    "updated_at": now,
+                },
+            )
         )
         await db.execute(stmt)
 

--- a/backend/services/rankings.py
+++ b/backend/services/rankings.py
@@ -66,7 +66,9 @@ async def get_user_rankings(
     if decade:
         decade_start, decade_end = parse_decade(decade)
         stmt = stmt.where(Movie.year >= decade_start, Movie.year <= decade_end)
-        count_stmt = count_stmt.where(Movie.year >= decade_start, Movie.year <= decade_end)
+        count_stmt = count_stmt.where(
+            Movie.year >= decade_start, Movie.year <= decade_end
+        )
 
     stmt = stmt.order_by(UserMovie.elo.desc()).offset(offset).limit(limit)
 
@@ -79,7 +81,9 @@ async def get_user_rankings(
     return user_movies, total
 
 
-async def get_user_stats(db: AsyncSession, user_id: uuid.UUID, media_type: str = "movie") -> dict:
+async def get_user_stats(
+    db: AsyncSession, user_id: uuid.UUID, media_type: str = "movie"
+) -> dict:
     """Return aggregate stats for the user's rankings.
 
     Returns dict with keys: total_duels, total_movies_ranked, unseen_count,
@@ -109,7 +113,11 @@ async def get_user_stats(db: AsyncSession, user_id: uuid.UUID, media_type: str =
         select(func.count())
         .select_from(UserMovie)
         .join(Movie, UserMovie.movie_id == Movie.id)
-        .where(UserMovie.user_id == user_id, UserMovie.seen.is_(False), Movie.media_type == media_type)
+        .where(
+            UserMovie.user_id == user_id,
+            UserMovie.seen.is_(False),
+            Movie.media_type == media_type,
+        )
     )
     unseen_count = (await db.execute(unseen_stmt)).scalar() or 0
 
@@ -155,7 +163,9 @@ async def get_user_stats(db: AsyncSession, user_id: uuid.UUID, media_type: str =
     }
 
 
-async def export_rankings_csv(db: AsyncSession, user_id: uuid.UUID, media_type: str = "movie") -> str:
+async def export_rankings_csv(
+    db: AsyncSession, user_id: uuid.UUID, media_type: str = "movie"
+) -> str:
     """Return CSV string content for Letterboxd export."""
     stmt = (
         select(UserMovie)
@@ -179,12 +189,14 @@ async def export_rankings_csv(db: AsyncSession, user_id: uuid.UUID, media_type: 
     for i, um in enumerate(user_movies):
         movie = um.movie
         trakt_rating = elo_to_letterboxd_rating(um.elo)
-        writer.writerow([
-            i + 1,
-            movie.title,
-            movie.year or "",
-            movie.imdb_id or "",
-            trakt_rating,
-        ])
+        writer.writerow(
+            [
+                i + 1,
+                movie.title,
+                movie.year or "",
+                movie.imdb_id or "",
+                trakt_rating,
+            ]
+        )
 
     return output.getvalue()

--- a/backend/services/suggest.py
+++ b/backend/services/suggest.py
@@ -112,14 +112,18 @@ async def _get_candidates(
     candidates = []
     for um in user_movies:
         m = um.movie
-        candidates.append({
-            "trakt_id": m.trakt_id,
-            "movie_id": str(m.id),
-            "title": m.title,
-            "year": m.year,
-            "genres": m.genres or [],
-            "community_rating": float(m.community_rating) if m.community_rating else None,
-        })
+        candidates.append(
+            {
+                "trakt_id": m.trakt_id,
+                "movie_id": str(m.id),
+                "title": m.title,
+                "year": m.year,
+                "genres": m.genres or [],
+                "community_rating": float(m.community_rating)
+                if m.community_rating
+                else None,
+            }
+        )
 
     return candidates
 
@@ -142,18 +146,18 @@ async def _call_llm(taste_profile: dict, candidates: list[dict]) -> list[dict]:
     )
 
     user_message = (
-        f"## User Taste Profile\n\n"
-        f"**Top 10 favorites (highest ELO):**\n"
+        "## User Taste Profile\n\n"
+        "**Top 10 favorites (highest ELO):**\n"
         + "\n".join(
             f"- {f['title']} ({f['year']}) [{', '.join(f['genres'])}] ELO: {f['elo']}"
             for f in taste_profile["top_10"]
         )
-        + f"\n\n**Bottom 5 (lowest ELO):**\n"
+        + "\n\n**Bottom 5 (lowest ELO):**\n"
         + "\n".join(
             f"- {f['title']} ({f['year']}) [{', '.join(f['genres'])}] ELO: {f['elo']}"
             for f in taste_profile["bottom_5"]
         )
-        + f"\n\n**Genre affinities (avg ELO):**\n"
+        + "\n\n**Genre affinities (avg ELO):**\n"
         + "\n".join(
             f"- {g}: {elo}" for g, elo in taste_profile["genre_affinities"].items()
         )
@@ -183,21 +187,31 @@ async def generate_suggestions(
     """
     taste_profile = await _build_taste_profile(user_id, db, media_type)
     if taste_profile is None:
-        logger.info("suggest_skip user_id=%s reason=insufficient_ranked (need %d)", user_id, MIN_RANKED)
+        logger.info(
+            "suggest_skip user_id=%s reason=insufficient_ranked (need %d)",
+            user_id,
+            MIN_RANKED,
+        )
         return []
 
     top_genre = next(iter(taste_profile["genre_affinities"]), None)
     logger.info(
         "suggest_taste_profile user_id=%s num_ranked=%d top_genre=%s",
-        user_id, taste_profile["total_ranked"], top_genre,
+        user_id,
+        taste_profile["total_ranked"],
+        top_genre,
     )
 
     candidates = await _get_candidates(user_id, db, media_type)
-    logger.info("suggest_candidates user_id=%s candidate_count=%d", user_id, len(candidates))
+    logger.info(
+        "suggest_candidates user_id=%s candidate_count=%d", user_id, len(candidates)
+    )
     if len(candidates) < NUM_PICKS:
         logger.warning(
             "User %s has only %d candidate films, need at least %d",
-            user_id, len(candidates), NUM_PICKS,
+            user_id,
+            len(candidates),
+            NUM_PICKS,
         )
         return []
 
@@ -205,7 +219,9 @@ async def generate_suggestions(
     trakt_to_movie = {c["trakt_id"]: c["movie_id"] for c in candidates}
 
     picks = await _call_llm(taste_profile, candidates)
-    logger.info("suggest_llm_response user_id=%s picks_returned=%d", user_id, len(picks))
+    logger.info(
+        "suggest_llm_response user_id=%s picks_returned=%d", user_id, len(picks)
+    )
 
     # Validate and map picks
     results = []
@@ -213,17 +229,21 @@ async def generate_suggestions(
         trakt_id = pick.get("trakt_id")
         reason = pick.get("reason", "Recommended for you.")
         if trakt_id in trakt_to_movie:
-            results.append({
-                "movie_id": trakt_to_movie[trakt_id],
-                "reason": reason,
-            })
+            results.append(
+                {
+                    "movie_id": trakt_to_movie[trakt_id],
+                    "reason": reason,
+                }
+            )
         if len(results) >= NUM_PICKS:
             break
 
     return results
 
 
-async def has_enough_ranked(user_id: uuid.UUID, db: AsyncSession, media_type: str = "movie") -> bool:
+async def has_enough_ranked(
+    user_id: uuid.UUID, db: AsyncSession, media_type: str = "movie"
+) -> bool:
     """Check if user has at least MIN_RANKED ranked films of the given type."""
     count_stmt = ranked_user_movies_stmt(user_id, media_type).with_only_columns(
         func.count()

--- a/backend/services/sync.py
+++ b/backend/services/sync.py
@@ -19,7 +19,9 @@ from backend.services.trakt import TraktClient
 logger = logging.getLogger(__name__)
 
 
-async def _rate_with_retry(client: TraktClient, trakt_id: int, rating: int, media_type: str = "movie") -> None:
+async def _rate_with_retry(
+    client: TraktClient, trakt_id: int, rating: int, media_type: str = "movie"
+) -> None:
     """Submit a single rating to Trakt, retrying once on 5xx."""
     for attempt in range(2):
         try:
@@ -93,12 +95,12 @@ async def sync_ratings_to_trakt(
     for um in user_movies:
         trakt_rating = elo_to_trakt_rating(um.elo)
         try:
-            await client.rate(um.movie.trakt_id, trakt_rating, media_type=um.movie.media_type)
+            await client.rate(
+                um.movie.trakt_id, trakt_rating, media_type=um.movie.media_type
+            )
             synced += 1
         except Exception:
-            logger.exception(
-                "Failed to sync rating for trakt_id=%s", um.movie.trakt_id
-            )
+            logger.exception("Failed to sync rating for trakt_id=%s", um.movie.trakt_id)
             failed += 1
 
     return {"synced": synced, "failed": failed}

--- a/backend/services/tmdb.py
+++ b/backend/services/tmdb.py
@@ -25,7 +25,9 @@ async def fetch_poster_url(tmdb_id: int) -> str | None:
             params={"api_key": settings.TMDB_API_KEY},
         )
         if resp.status_code != 200:
-            logger.warning("TMDB API returned %d for tmdb_id=%d", resp.status_code, tmdb_id)
+            logger.warning(
+                "TMDB API returned %d for tmdb_id=%d", resp.status_code, tmdb_id
+            )
             return None
         data = resp.json()
         poster_path = data.get("poster_path")
@@ -36,10 +38,24 @@ async def fetch_poster_url(tmdb_id: int) -> str | None:
 
 # TMDB genre_id -> genre name mapping (from TMDB API /genre/movie/list)
 TMDB_GENRE_MAP: dict[int, str] = {
-    28: "action", 12: "adventure", 16: "animation", 35: "comedy", 80: "crime",
-    99: "documentary", 18: "drama", 10751: "family", 14: "fantasy", 36: "history",
-    27: "horror", 10402: "music", 9648: "mystery", 10749: "romance",
-    878: "science-fiction", 10770: "tv movie", 53: "thriller", 10752: "war",
+    28: "action",
+    12: "adventure",
+    16: "animation",
+    35: "comedy",
+    80: "crime",
+    99: "documentary",
+    18: "drama",
+    10751: "family",
+    14: "fantasy",
+    36: "history",
+    27: "horror",
+    10402: "music",
+    9648: "mystery",
+    10749: "romance",
+    878: "science-fiction",
+    10770: "tv movie",
+    53: "thriller",
+    10752: "war",
     37: "western",
 }
 
@@ -55,7 +71,9 @@ async def fetch_tv_poster_url(tmdb_id: int) -> str | None:
             params={"api_key": settings.TMDB_API_KEY},
         )
         if resp.status_code != 200:
-            logger.warning("TMDB TV API returned %d for tmdb_id=%d", resp.status_code, tmdb_id)
+            logger.warning(
+                "TMDB TV API returned %d for tmdb_id=%d", resp.status_code, tmdb_id
+            )
             return None
         data = resp.json()
         poster_path = data.get("poster_path")
@@ -81,25 +99,33 @@ async def fetch_similar_films(tmdb_id: int, api_key: str) -> list[dict]:
             if resp.status_code != 200:
                 logger.warning(
                     "TMDB recommendations returned %d for tmdb_id=%d",
-                    resp.status_code, tmdb_id,
+                    resp.status_code,
+                    tmdb_id,
                 )
                 return []
             data = resp.json()
             results = []
             for item in data.get("results", []):
                 release_date = item.get("release_date", "")
-                year = int(release_date[:4]) if release_date and len(release_date) >= 4 else None
+                year = (
+                    int(release_date[:4])
+                    if release_date and len(release_date) >= 4
+                    else None
+                )
                 genres = [
-                    TMDB_GENRE_MAP[gid] for gid in item.get("genre_ids", [])
+                    TMDB_GENRE_MAP[gid]
+                    for gid in item.get("genre_ids", [])
                     if gid in TMDB_GENRE_MAP
                 ]
-                results.append({
-                    "tmdb_id": item["id"],
-                    "title": item.get("title", "Unknown"),
-                    "year": year,
-                    "overview": item.get("overview"),
-                    "genres": genres,
-                })
+                results.append(
+                    {
+                        "tmdb_id": item["id"],
+                        "title": item.get("title", "Unknown"),
+                        "year": year,
+                        "overview": item.get("overview"),
+                        "genres": genres,
+                    }
+                )
             return results
     except Exception:
         logger.exception("Failed to fetch TMDB recommendations for tmdb_id=%d", tmdb_id)

--- a/backend/services/tournament.py
+++ b/backend/services/tournament.py
@@ -34,7 +34,7 @@ async def curate_and_select_films(
     Returns (selected_user_movies_sorted_by_elo, llm_result_dict).
     Raises ValueError if LLM returns IDs not in the candidate pool.
     """
-    candidate_pool = user_movies[:bracket_size * 3]
+    candidate_pool = user_movies[: bracket_size * 3]
     candidates = [
         {
             "id": str(um.movie_id),
@@ -87,8 +87,14 @@ def generate_seeded_bracket(n: int) -> list[tuple[int, int]]:
         return [(1, 8), (4, 5), (2, 7), (3, 6)]
     if n == 16:
         return [
-            (1, 16), (8, 9), (4, 13), (5, 12),
-            (2, 15), (7, 10), (3, 14), (6, 11),
+            (1, 16),
+            (8, 9),
+            (4, 13),
+            (5, 12),
+            (2, 15),
+            (7, 10),
+            (3, 14),
+            (6, 11),
         ]
     if n == 32:
         top = generate_seeded_bracket(16)
@@ -129,8 +135,10 @@ async def get_filtered_ranked_films(
     if filter_type == "genre" and filter_value:
         genre_lower = filter_value.lower()
         user_movies = [
-            um for um in user_movies
-            if um.movie.genres and any(g.lower() == genre_lower for g in um.movie.genres)
+            um
+            for um in user_movies
+            if um.movie.genres
+            and any(g.lower() == genre_lower for g in um.movie.genres)
         ]
     elif filter_type == "decade" and filter_value:
         decade_str = filter_value.rstrip("s")
@@ -139,7 +147,8 @@ async def get_filtered_ranked_films(
         except ValueError:
             raise ValueError("Invalid decade format")
         user_movies = [
-            um for um in user_movies
+            um
+            for um in user_movies
             if um.movie.year and decade_start <= um.movie.year <= decade_start + 9
         ]
 
@@ -166,7 +175,11 @@ async def create_tournament_bracket(
 
     logger.info(
         "bracket_created tournament_id=%s bracket_size=%d num_films=%d num_byes=%d num_rounds=%d",
-        tournament_id, bracket_size, actual_films, num_byes, num_rounds,
+        tournament_id,
+        bracket_size,
+        actual_films,
+        num_byes,
+        num_rounds,
     )
 
     # Round 1 matches with seeded pairings (including byes)
@@ -214,7 +227,7 @@ async def create_tournament_bracket(
 
     # Empty matches for subsequent rounds
     for round_num in range(2, num_rounds + 1):
-        matches_in_round = bracket_size // (2 ** round_num)
+        matches_in_round = bracket_size // (2**round_num)
         for position in range(matches_in_round):
             match = TournamentMatch(
                 tournament_id=tournament_id,
@@ -227,13 +240,10 @@ async def create_tournament_bracket(
 
     # Propagate bye winners to round 2 slots
     if num_byes > 0:
-        r1_stmt = (
-            select(TournamentMatch)
-            .where(
-                TournamentMatch.tournament_id == tournament_id,
-                TournamentMatch.round == 1,
-                TournamentMatch.is_bye.is_(True),
-            )
+        r1_stmt = select(TournamentMatch).where(
+            TournamentMatch.tournament_id == tournament_id,
+            TournamentMatch.round == 1,
+            TournamentMatch.is_bye.is_(True),
         )
         r1_result = await db.execute(r1_stmt)
         bye_matches = r1_result.scalars().all()
@@ -264,7 +274,9 @@ def _advance_winner_to_next_round(
         next_match.movie_b_id = winner_movie_id
 
 
-def validate_match(tournament: Tournament, match_id: uuid.UUID, winner_id: uuid.UUID) -> uuid.UUID:
+def validate_match(
+    tournament: Tournament, match_id: uuid.UUID, winner_id: uuid.UUID
+) -> uuid.UUID:
     """Validate a match is playable. Returns the loser_id.
 
     Raises ValueError on validation failure.
@@ -300,9 +312,13 @@ async def record_match_winner(
     now = datetime.now(timezone.utc)
 
     # Mark winner + propagate (lock row to prevent double-submit)
-    match_obj = (await db.execute(
-        select(TournamentMatch).where(TournamentMatch.id == match_id).with_for_update()
-    )).scalar_one()
+    match_obj = (
+        await db.execute(
+            select(TournamentMatch)
+            .where(TournamentMatch.id == match_id)
+            .with_for_update()
+        )
+    ).scalar_one()
     if match_obj.winner_movie_id is not None:
         raise ValueError("Match already played")
     match_obj.winner_movie_id = winner_id
@@ -310,7 +326,10 @@ async def record_match_winner(
 
     logger.info(
         "match_result tournament_id=%s match_id=%s winner=%s round=%d",
-        tournament_id, match_id, winner_id, match_obj.round,
+        tournament_id,
+        match_id,
+        winner_id,
+        match_obj.round,
     )
 
     round_num = match_obj.round
@@ -318,37 +337,47 @@ async def record_match_winner(
 
     if round_num < num_rounds:
         next_pos = match_obj.position // 2
-        next_match = (await db.execute(
-            select(TournamentMatch).where(
-                TournamentMatch.tournament_id == tournament_id,
-                TournamentMatch.round == round_num + 1,
-                TournamentMatch.position == next_pos,
+        next_match = (
+            await db.execute(
+                select(TournamentMatch).where(
+                    TournamentMatch.tournament_id == tournament_id,
+                    TournamentMatch.round == round_num + 1,
+                    TournamentMatch.position == next_pos,
+                )
             )
-        )).scalar_one()
+        ).scalar_one()
         _advance_winner_to_next_round(next_match, winner_id, match_obj.position)
 
     if round_num == num_rounds:
-        t = (await db.execute(
-            select(Tournament).where(Tournament.id == tournament_id)
-        )).scalar_one()
+        t = (
+            await db.execute(select(Tournament).where(Tournament.id == tournament_id))
+        ).scalar_one()
         t.champion_movie_id = winner_id
         t.status = "completed"
         t.completed_at = now
-        logger.info("champion_crowned tournament_id=%s champion=%s", tournament_id, winner_id)
+        logger.info(
+            "champion_crowned tournament_id=%s champion=%s", tournament_id, winner_id
+        )
 
     # ELO update + duel record (same session, 2 extra queries)
-    um_w = (await db.execute(
-        select(UserMovie).where(
-            UserMovie.user_id == user_id, UserMovie.movie_id == winner_id
-        ).with_for_update()
-    )).scalar_one()
-    um_l = (await db.execute(
-        select(UserMovie).where(
-            UserMovie.user_id == user_id, UserMovie.movie_id == loser_id
-        ).with_for_update()
-    )).scalar_one()
+    um_w = (
+        await db.execute(
+            select(UserMovie)
+            .where(UserMovie.user_id == user_id, UserMovie.movie_id == winner_id)
+            .with_for_update()
+        )
+    ).scalar_one()
+    um_l = (
+        await db.execute(
+            select(UserMovie)
+            .where(UserMovie.user_id == user_id, UserMovie.movie_id == loser_id)
+            .with_for_update()
+        )
+    ).scalar_one()
 
-    duel = await apply_elo_result(db, user_id, winner_id, loser_id, um_w, um_l, "tournament")
+    duel = await apply_elo_result(
+        db, user_id, winner_id, loser_id, um_w, um_l, "tournament"
+    )
     await db.flush()
 
     match_obj.duel_id = duel.id

--- a/backend/services/trakt.py
+++ b/backend/services/trakt.py
@@ -73,7 +73,9 @@ class TraktClient:
             resp.raise_for_status()
             return resp.json()
 
-    async def get_popular(self, limit: int = 100, media_type: str = "movie") -> list[dict]:
+    async def get_popular(
+        self, limit: int = 100, media_type: str = "movie"
+    ) -> list[dict]:
         """Fetch popular movies or shows."""
         async with self._client() as client:
             resp = await client.get(
@@ -83,7 +85,9 @@ class TraktClient:
             resp.raise_for_status()
             return resp.json()
 
-    async def get_trending(self, limit: int = 100, media_type: str = "movie") -> list[dict]:
+    async def get_trending(
+        self, limit: int = 100, media_type: str = "movie"
+    ) -> list[dict]:
         """Fetch trending movies or shows.
 
         Trending returns [{watchers, movie/show}, ...] — this extracts the
@@ -97,7 +101,9 @@ class TraktClient:
             resp.raise_for_status()
             return [item[media_type] for item in resp.json()]
 
-    async def get_user_watched(self, username: str, media_type: str = "movie") -> list[dict]:
+    async def get_user_watched(
+        self, username: str, media_type: str = "movie"
+    ) -> list[dict]:
         """Fetch a user's watched movies or shows.
 
         Returns [{plays, last_watched_at, movie/show}, ...] — this extracts
@@ -111,7 +117,9 @@ class TraktClient:
             resp.raise_for_status()
             return [item[media_type] for item in resp.json()]
 
-    async def get_user_ratings(self, username: str, media_type: str = "movie") -> list[dict]:
+    async def get_user_ratings(
+        self, username: str, media_type: str = "movie"
+    ) -> list[dict]:
         """Fetch a user's movie or show ratings.
 
         Returns [{rating, trakt_id}, ...].
@@ -142,7 +150,9 @@ class TraktClient:
             )
             resp.raise_for_status()
 
-    async def get_recommendations(self, limit: int = 100, media_type: str = "movie") -> list[dict]:
+    async def get_recommendations(
+        self, limit: int = 100, media_type: str = "movie"
+    ) -> list[dict]:
         """Get personalized recommendations for the authenticated user."""
         async with self._client() as client:
             resp = await client.get(
@@ -157,9 +167,7 @@ class TraktClient:
         async with self._client() as client:
             resp = await client.post(
                 "/sync/watchlist",
-                json={
-                    f"{media_type}s": [{"ids": {"trakt": trakt_id}}]
-                },
+                json={f"{media_type}s": [{"ids": {"trakt": trakt_id}}]},
             )
             resp.raise_for_status()
 

--- a/backend/tests/test_auth.py
+++ b/backend/tests/test_auth.py
@@ -68,8 +68,11 @@ class TestCreateJWT:
         user_id = "550e8400-e29b-41d4-a716-446655440000"
         token = create_jwt(user_id, SETTINGS)
         payload = pyjwt.decode(
-            token, SETTINGS.SECRET_KEY, algorithms=[JWT_ALGORITHM],
-            issuer="filmduel", audience="filmduel",
+            token,
+            SETTINGS.SECRET_KEY,
+            algorithms=[JWT_ALGORITHM],
+            issuer="filmduel",
+            audience="filmduel",
         )
         assert payload["sub"] == user_id
         assert payload["iss"] == "filmduel"
@@ -79,8 +82,11 @@ class TestCreateJWT:
     def test_payload_has_exp_and_iat(self):
         token = create_jwt("user-1", SETTINGS)
         payload = pyjwt.decode(
-            token, SETTINGS.SECRET_KEY, algorithms=[JWT_ALGORITHM],
-            issuer="filmduel", audience="filmduel",
+            token,
+            SETTINGS.SECRET_KEY,
+            algorithms=[JWT_ALGORITHM],
+            issuer="filmduel",
+            audience="filmduel",
         )
         assert "exp" in payload
         assert "iat" in payload
@@ -88,8 +94,11 @@ class TestCreateJWT:
     def test_expiry_is_in_future(self):
         token = create_jwt("user-1", SETTINGS)
         payload = pyjwt.decode(
-            token, SETTINGS.SECRET_KEY, algorithms=[JWT_ALGORITHM],
-            issuer="filmduel", audience="filmduel",
+            token,
+            SETTINGS.SECRET_KEY,
+            algorithms=[JWT_ALGORITHM],
+            issuer="filmduel",
+            audience="filmduel",
         )
         exp = datetime.fromtimestamp(payload["exp"], tz=timezone.utc)
         now = datetime.now(timezone.utc)

--- a/backend/tests/test_duel_router.py
+++ b/backend/tests/test_duel_router.py
@@ -65,7 +65,9 @@ class TestSubmitDuel:
             new_elo_b=985,
         )
 
-        with patch("backend.routers.duels.process_duel", new_callable=AsyncMock) as mock_pd:
+        with patch(
+            "backend.routers.duels.process_duel", new_callable=AsyncMock
+        ) as mock_pd:
             mock_pd.return_value = fake_result
             client = TestClient(app)
             response = client.post(

--- a/backend/tests/test_duel_service.py
+++ b/backend/tests/test_duel_service.py
@@ -32,7 +32,9 @@ def _make_user_movie(
     return um
 
 
-def _make_fake_execute(um_a: MagicMock, um_b: MagicMock, seen_unranked: int = 5, total_seen: int = 20):
+def _make_fake_execute(
+    um_a: MagicMock, um_b: MagicMock, seen_unranked: int = 5, total_seen: int = 20
+):
     """Build a fake db.execute that dispatches by SQL statement content, not call order."""
     returned_a = False
     returned_b = False
@@ -44,7 +46,9 @@ def _make_fake_execute(um_a: MagicMock, um_b: MagicMock, seen_unranked: int = 5,
         # Count queries (contain 'count')
         if "count" in stmt_str.lower():
             # Distinguish seen_unranked (battles == 0) from total_seen
-            if "battles" in stmt_str.lower() or (not returned_a and "count" in stmt_str.lower()):
+            if "battles" in stmt_str.lower() or (
+                not returned_a and "count" in stmt_str.lower()
+            ):
                 result.scalar_one.return_value = seen_unranked
             else:
                 result.scalar_one.return_value = total_seen
@@ -183,9 +187,7 @@ async def test_process_duel_creates_duel_record():
     from backend.db_models import Duel
 
     duel_adds = [
-        call.args[0]
-        for call in db.add.call_args_list
-        if isinstance(call.args[0], Duel)
+        call.args[0] for call in db.add.call_args_list if isinstance(call.args[0], Duel)
     ]
     assert len(duel_adds) == 1
     duel = duel_adds[0]
@@ -368,9 +370,7 @@ async def test_pair_type_ranked_vs_ranked():
     from backend.db_models import Duel
 
     duel_adds = [
-        call.args[0]
-        for call in db.add.call_args_list
-        if isinstance(call.args[0], Duel)
+        call.args[0] for call in db.add.call_args_list if isinstance(call.args[0], Duel)
     ]
     assert len(duel_adds) == 1
     assert duel_adds[0].pair_type == "ranked_vs_ranked"
@@ -394,9 +394,7 @@ async def test_pair_type_ranked_vs_unranked():
     from backend.db_models import Duel
 
     duel_adds = [
-        call.args[0]
-        for call in db.add.call_args_list
-        if isinstance(call.args[0], Duel)
+        call.args[0] for call in db.add.call_args_list if isinstance(call.args[0], Duel)
     ]
     assert len(duel_adds) == 1
     assert duel_adds[0].pair_type == "ranked_vs_unranked"

--- a/backend/tests/test_elo.py
+++ b/backend/tests/test_elo.py
@@ -129,4 +129,3 @@ def test_get_initial_elo_with_seed():
 
 def test_get_initial_elo_without_seed():
     assert get_initial_elo(None) == 1000
-

--- a/backend/tests/test_expand_service.py
+++ b/backend/tests/test_expand_service.py
@@ -3,12 +3,11 @@
 from __future__ import annotations
 
 import uuid
-from datetime import datetime, timedelta, timezone
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
-from backend.services.expand import EXPANSION_COOLDOWN, _expand_pool_inner
+from backend.services.expand import _expand_pool_inner
 
 
 def _mock_session_factory(db):
@@ -74,7 +73,10 @@ class TestExpandPoolInner:
         trakt_mock.get_recommendations.return_value = fake_recs
 
         with (
-            patch("backend.services.expand.async_session_factory", return_value=_mock_session_factory(db)),
+            patch(
+                "backend.services.expand.async_session_factory",
+                return_value=_mock_session_factory(db),
+            ),
             patch("backend.services.expand.TraktClient", return_value=trakt_mock),
             patch("backend.services.expand.get_settings") as mock_settings,
             patch("backend.services.expand.backfill_posters", new_callable=AsyncMock),
@@ -122,7 +124,10 @@ class TestExpandPoolInner:
         trakt_mock.get_recommendations.return_value = []
 
         with (
-            patch("backend.services.expand.async_session_factory", return_value=_mock_session_factory(db)),
+            patch(
+                "backend.services.expand.async_session_factory",
+                return_value=_mock_session_factory(db),
+            ),
             patch("backend.services.expand.TraktClient", return_value=trakt_mock),
             patch("backend.services.expand.get_settings") as mock_settings,
             patch("backend.services.expand.backfill_posters", new_callable=AsyncMock),
@@ -142,7 +147,10 @@ class TestExpandPoolInner:
         db.get = AsyncMock(return_value=None)
 
         with (
-            patch("backend.services.expand.async_session_factory", return_value=_mock_session_factory(db)),
+            patch(
+                "backend.services.expand.async_session_factory",
+                return_value=_mock_session_factory(db),
+            ),
             patch("backend.services.expand.get_settings") as mock_settings,
         ):
             mock_settings.return_value = MagicMock(TRAKT_CLIENT_ID="fake")

--- a/backend/tests/test_feedback.py
+++ b/backend/tests/test_feedback.py
@@ -1,4 +1,5 @@
 """Tests for POST /api/feedback endpoint."""
+
 from __future__ import annotations
 
 import io
@@ -44,7 +45,16 @@ def client():
 
 
 class TestSubmitFeedback:
-    def _post(self, client, title="Bug", description="Details", screenshot=None, content_type="image/jpeg", user=None, db=None):
+    def _post(
+        self,
+        client,
+        title="Bug",
+        description="Details",
+        screenshot=None,
+        content_type="image/jpeg",
+        user=None,
+        db=None,
+    ):
         user = user or _make_user()
         db = db or _make_db()
 
@@ -65,7 +75,9 @@ class TestSubmitFeedback:
             if screenshot is not None:
                 files = {"screenshot": ("screenshot.jpg", screenshot, content_type)}
 
-            with patch("backend.routers.feedback.FeedbackReport", side_effect=make_report):
+            with patch(
+                "backend.routers.feedback.FeedbackReport", side_effect=make_report
+            ):
                 response = client.post("/api/feedback", data=data, files=files)
 
             response._created_reports = created_reports
@@ -91,7 +103,7 @@ class TestSubmitFeedback:
         assert report.description == "Details"
 
     def test_accepts_screenshot_within_size_limit(self, client):
-        small_image = b'\xff\xd8\xff' + b'\x00' * 100  # valid JPEG magic bytes
+        small_image = b"\xff\xd8\xff" + b"\x00" * 100  # valid JPEG magic bytes
         response = self._post(client, screenshot=io.BytesIO(small_image))
         assert response.status_code == 201
 
@@ -111,14 +123,18 @@ class TestSubmitFeedback:
         assert "image" in response.json()["detail"].lower()
 
     def test_screenshot_stored_as_base64_data_url_with_correct_mime(self, client):
-        jpeg_data = b'\xff\xd8\xff' + b'\x00' * 10  # valid JPEG magic bytes
-        response = self._post(client, screenshot=io.BytesIO(jpeg_data), content_type="image/jpeg")
+        jpeg_data = b"\xff\xd8\xff" + b"\x00" * 10  # valid JPEG magic bytes
+        response = self._post(
+            client, screenshot=io.BytesIO(jpeg_data), content_type="image/jpeg"
+        )
         report = response._created_reports[0]
         assert report.screenshot_data.startswith("data:image/jpeg;base64,")
 
     def test_png_screenshot_stored_with_png_mime(self, client):
-        png_data = b'\x89PNG\r\n\x1a\n' + b'\x00' * 10  # valid PNG magic bytes
-        response = self._post(client, screenshot=io.BytesIO(png_data), content_type="image/png")
+        png_data = b"\x89PNG\r\n\x1a\n" + b"\x00" * 10  # valid PNG magic bytes
+        response = self._post(
+            client, screenshot=io.BytesIO(png_data), content_type="image/png"
+        )
         report = response._created_reports[0]
         assert report.screenshot_data.startswith("data:image/png;base64,")
 

--- a/backend/tests/test_media_type_filtering.py
+++ b/backend/tests/test_media_type_filtering.py
@@ -131,8 +131,12 @@ async def test_sync_ratings_background_refreshes_expired_token():
 
     with (
         patch("backend.routers.duels.async_session_factory") as mock_factory,
-        patch("backend.routers.duels.ensure_fresh_token", new_callable=AsyncMock) as mock_refresh,
-        patch("backend.routers.duels.sync_post_duel", new_callable=AsyncMock) as mock_sync,
+        patch(
+            "backend.routers.duels.ensure_fresh_token", new_callable=AsyncMock
+        ) as mock_refresh,
+        patch(
+            "backend.routers.duels.sync_post_duel", new_callable=AsyncMock
+        ) as mock_sync,
     ):
         mock_session = AsyncMock()
         mock_factory.return_value.__aenter__ = AsyncMock(return_value=mock_session)
@@ -166,7 +170,9 @@ async def test_sync_ratings_background_skips_if_user_not_found():
 
     with (
         patch("backend.routers.duels.async_session_factory") as mock_factory,
-        patch("backend.routers.duels.ensure_fresh_token", new_callable=AsyncMock) as mock_refresh,
+        patch(
+            "backend.routers.duels.ensure_fresh_token", new_callable=AsyncMock
+        ) as mock_refresh,
     ):
         mock_session = AsyncMock()
         mock_factory.return_value.__aenter__ = AsyncMock(return_value=mock_session)
@@ -175,7 +181,9 @@ async def test_sync_ratings_background_skips_if_user_not_found():
         mock_exec_result.scalar_one_or_none.return_value = None
         mock_session.execute.return_value = mock_exec_result
 
-        await _sync_ratings_background(uuid.uuid4(), uuid.uuid4(), 1100, uuid.uuid4(), 900)
+        await _sync_ratings_background(
+            uuid.uuid4(), uuid.uuid4(), 1100, uuid.uuid4(), 900
+        )
 
         mock_refresh.assert_not_awaited()
 
@@ -190,7 +198,9 @@ async def test_sync_ratings_background_skips_if_no_trakt_token():
 
     with (
         patch("backend.routers.duels.async_session_factory") as mock_factory,
-        patch("backend.routers.duels.ensure_fresh_token", new_callable=AsyncMock) as mock_refresh,
+        patch(
+            "backend.routers.duels.ensure_fresh_token", new_callable=AsyncMock
+        ) as mock_refresh,
     ):
         mock_session = AsyncMock()
         mock_factory.return_value.__aenter__ = AsyncMock(return_value=mock_session)
@@ -199,7 +209,9 @@ async def test_sync_ratings_background_skips_if_no_trakt_token():
         mock_exec_result.scalar_one_or_none.return_value = mock_user
         mock_session.execute.return_value = mock_exec_result
 
-        await _sync_ratings_background(uuid.uuid4(), uuid.uuid4(), 1100, uuid.uuid4(), 900)
+        await _sync_ratings_background(
+            uuid.uuid4(), uuid.uuid4(), 1100, uuid.uuid4(), 900
+        )
 
         mock_refresh.assert_not_awaited()
 
@@ -226,7 +238,9 @@ async def test_sync_ratings_background_refresh_failure_is_swallowed():
                 "401", request=MagicMock(), response=MagicMock(status_code=401)
             ),
         ),
-        patch("backend.routers.duels.sync_post_duel", new_callable=AsyncMock) as mock_sync,
+        patch(
+            "backend.routers.duels.sync_post_duel", new_callable=AsyncMock
+        ) as mock_sync,
     ):
         mock_session = AsyncMock()
         mock_factory.return_value.__aenter__ = AsyncMock(return_value=mock_session)

--- a/backend/tests/test_pair_selection.py
+++ b/backend/tests/test_pair_selection.py
@@ -3,7 +3,6 @@
 import random
 import unittest.mock
 import uuid
-from types import SimpleNamespace
 from unittest.mock import MagicMock
 
 import pytest
@@ -206,13 +205,19 @@ class TestWeightedSample:
         """Films with fewer battles should have higher weight = 1/(battles+1)."""
         low_battles = _make_user_movie(battles=0)  # weight=1.0
         high_battles = _make_user_movie(battles=99)  # weight=0.01
-        with unittest.mock.patch("backend.services.pair_selection.random.choices") as mock_choices:
+        with unittest.mock.patch(
+            "backend.services.pair_selection.random.choices"
+        ) as mock_choices:
             mock_choices.return_value = [low_battles]
             result = _weighted_sample([low_battles, high_battles])
             assert result is low_battles
             # Verify weights passed to random.choices
             call_args = mock_choices.call_args
-            weights = call_args[1]["weights"] if "weights" in call_args[1] else call_args[0][1]
+            weights = (
+                call_args[1]["weights"]
+                if "weights" in call_args[1]
+                else call_args[0][1]
+            )
             # weight for low_battles = 1/(0+1) = 1.0, for high_battles = 1/(99+1) = 0.01
             assert weights[0] == pytest.approx(1.0)
             assert weights[1] == pytest.approx(0.01)
@@ -244,7 +249,9 @@ class TestPickChallenger:
         anchor = _make_user_movie(elo=1000, battles=5)
         close = _make_user_movie(elo=1020, battles=5)
         far = _make_user_movie(elo=1500, battles=5)
-        with unittest.mock.patch("backend.services.pair_selection.random.random", return_value=0.3):
+        with unittest.mock.patch(
+            "backend.services.pair_selection.random.random", return_value=0.3
+        ):
             with unittest.mock.patch(
                 "backend.services.pair_selection.random.choices",
                 side_effect=lambda population, weights, k: [population[0]],
@@ -272,9 +279,15 @@ class TestPickBootstrapPair:
         assert a is not b
 
     def test_avoids_last_pair(self):
-        f1 = _make_user_movie(movie_id=uuid.UUID("00000000-0000-0000-0000-000000000001"))
-        f2 = _make_user_movie(movie_id=uuid.UUID("00000000-0000-0000-0000-000000000002"))
-        f3 = _make_user_movie(movie_id=uuid.UUID("00000000-0000-0000-0000-000000000003"))
+        f1 = _make_user_movie(
+            movie_id=uuid.UUID("00000000-0000-0000-0000-000000000001")
+        )
+        f2 = _make_user_movie(
+            movie_id=uuid.UUID("00000000-0000-0000-0000-000000000002")
+        )
+        f3 = _make_user_movie(
+            movie_id=uuid.UUID("00000000-0000-0000-0000-000000000003")
+        )
         last_ids = {str(f1.movie_id), str(f2.movie_id)}
         # With 3 films and one pair excluded, should find a different pair
         random.seed(42)

--- a/backend/tests/test_pool_service.py
+++ b/backend/tests/test_pool_service.py
@@ -8,7 +8,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
-from backend.services.pool import SYNC_COOLDOWN, populate_movie_pool
+from backend.services.pool import populate_movie_pool
 
 
 def _make_user(last_seen_at=None):

--- a/backend/tests/test_rankings_service.py
+++ b/backend/tests/test_rankings_service.py
@@ -5,7 +5,11 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
-from backend.services.rankings import elo_to_letterboxd_rating, get_user_stats, parse_decade
+from backend.services.rankings import (
+    elo_to_letterboxd_rating,
+    get_user_stats,
+    parse_decade,
+)
 
 
 # --- get_user_stats ---

--- a/backend/tests/test_schemas.py
+++ b/backend/tests/test_schemas.py
@@ -269,9 +269,7 @@ class TestResponseModels:
         assert sr.next_action == "swipe"
 
     def test_stats_response_minimal(self):
-        st = StatsResponse(
-            total_duels=0, total_movies_ranked=0, average_elo=0.0
-        )
+        st = StatsResponse(total_duels=0, total_movies_ranked=0, average_elo=0.0)
         assert st.unseen_count == 0
         assert st.highest_rated is None
         assert st.lowest_rated is None

--- a/backend/tests/test_swipe.py
+++ b/backend/tests/test_swipe.py
@@ -1,7 +1,5 @@
 """Tests for swipe logic — band indexing, community rating range, next_action."""
 
-import pytest
-
 from backend.routers.swipe import (
     BANDS,
     _community_rating_range,
@@ -43,8 +41,8 @@ class TestEloToBandIndex:
         # Check each boundary value
         assert _elo_to_band_index(1300) == 0  # elite lower bound
         assert _elo_to_band_index(1100) == 1  # strong lower bound
-        assert _elo_to_band_index(900) == 2   # mid lower bound
-        assert _elo_to_band_index(700) == 3   # weak lower bound
+        assert _elo_to_band_index(900) == 2  # mid lower bound
+        assert _elo_to_band_index(700) == 3  # weak lower bound
 
 
 # ---------------------------------------------------------------------------
@@ -101,13 +99,17 @@ class TestBandsStructure:
         """ELO lower bounds should be strictly descending from elite to low."""
         lows = [b[1] for b in BANDS]
         for i in range(len(lows) - 1):
-            assert lows[i] > lows[i + 1], f"Band {i} low={lows[i]} not > band {i+1} low={lows[i+1]}"
+            assert lows[i] > lows[i + 1], (
+                f"Band {i} low={lows[i]} not > band {i + 1} low={lows[i + 1]}"
+            )
 
     def test_community_rating_ranges_descending(self):
         """CR lower bounds should be strictly descending from elite to low."""
         cr_lows = [b[3] for b in BANDS]
         for i in range(len(cr_lows) - 1):
-            assert cr_lows[i] > cr_lows[i + 1], f"Band {i} cr_low={cr_lows[i]} not > band {i+1} cr_low={cr_lows[i+1]}"
+            assert cr_lows[i] > cr_lows[i + 1], (
+                f"Band {i} cr_low={cr_lows[i]} not > band {i + 1} cr_low={cr_lows[i + 1]}"
+            )
 
 
 # ---------------------------------------------------------------------------

--- a/backend/tests/test_tournament_service.py
+++ b/backend/tests/test_tournament_service.py
@@ -279,3 +279,18 @@ class TestValidateMatch:
 
         with pytest.raises(ValueError, match="not active"):
             validate_match(tournament, uuid.uuid4(), uuid.uuid4())
+
+
+# ---------------------------------------------------------------------------
+# TournamentSchema field exposure regression
+# ---------------------------------------------------------------------------
+
+
+class TestTournamentSchemaFields:
+    def test_tournament_schema_does_not_expose_llm_response(self):
+        """TournamentSchema must not surface internal LLM metadata."""
+        from backend.schemas import TournamentSchema
+
+        assert "llm_response" not in TournamentSchema.model_fields, (
+            "llm_response must not be part of the public TournamentSchema"
+        )

--- a/backend/tests/test_tournament_service.py
+++ b/backend/tests/test_tournament_service.py
@@ -121,7 +121,9 @@ class TestCreateTournamentBracketWithByes:
             result = MagicMock()
             if "round" in stmt_str and "is_bye" in stmt_str:
                 # Return bye matches from round 1
-                bye_matches = [obj for obj in added_objects if getattr(obj, "is_bye", False)]
+                bye_matches = [
+                    obj for obj in added_objects if getattr(obj, "is_bye", False)
+                ]
                 result.scalars.return_value.all.return_value = bye_matches
                 return result
             # Round 2 position lookup
@@ -136,8 +138,10 @@ class TestCreateTournamentBracketWithByes:
         await create_tournament_bracket(db, tournament_id, 8, films)
 
         from backend.db_models import TournamentMatch
+
         round1_matches = [
-            obj for obj in added_objects
+            obj
+            for obj in added_objects
             if isinstance(obj, TournamentMatch) and obj.round == 1
         ]
         assert len(round1_matches) == 4
@@ -160,8 +164,10 @@ class TestCreateTournamentBracketWithByes:
         await create_tournament_bracket(db, tournament_id, 8, films)
 
         from backend.db_models import TournamentMatch
+
         round1_matches = [
-            obj for obj in added_objects
+            obj
+            for obj in added_objects
             if isinstance(obj, TournamentMatch) and obj.round == 1
         ]
         bye_matches = [m for m in round1_matches if getattr(m, "is_bye", False)]
@@ -187,7 +193,9 @@ class TestCreateTournamentBracketWithByes:
             result = MagicMock()
             stmt_str = str(stmt)
             if "is_bye" in stmt_str:
-                bye_matches = [obj for obj in added_objects if getattr(obj, "is_bye", False)]
+                bye_matches = [
+                    obj for obj in added_objects if getattr(obj, "is_bye", False)
+                ]
                 result.scalars.return_value.all.return_value = bye_matches
             else:
                 result.scalar_one.return_value = round2_mock
@@ -198,8 +206,10 @@ class TestCreateTournamentBracketWithByes:
         await create_tournament_bracket(db, tournament_id, 8, films)
 
         from backend.db_models import TournamentMatch
+
         bye_matches = [
-            obj for obj in added_objects
+            obj
+            for obj in added_objects
             if isinstance(obj, TournamentMatch) and getattr(obj, "is_bye", False)
         ]
         for bm in bye_matches:

--- a/backend/tests/test_trakt_client.py
+++ b/backend/tests/test_trakt_client.py
@@ -27,7 +27,11 @@ class TestTraktClientExchangeCode:
     @pytest.mark.asyncio
     async def test_exchange_code_posts_correct_payload(self):
         """exchange_code sends correct JSON body and returns token dict."""
-        expected_tokens = {"access_token": "abc", "refresh_token": "def", "expires_in": 7776000}
+        expected_tokens = {
+            "access_token": "abc",
+            "refresh_token": "def",
+            "expires_in": 7776000,
+        }
         mock_resp = _mock_response(expected_tokens)
 
         mock_client = AsyncMock()
@@ -37,7 +41,9 @@ class TestTraktClientExchangeCode:
 
         client = TraktClient(client_id="test-client-id")
         with patch.object(client, "_client", return_value=mock_client):
-            result = await client.exchange_code("auth-code", "secret", "http://redirect")
+            result = await client.exchange_code(
+                "auth-code", "secret", "http://redirect"
+            )
 
         assert result == expected_tokens
         call_args = mock_client.post.call_args


### PR DESCRIPTION
## Summary

Fixes #202 — removes internal LLM metadata fields (`_theme_hint`, `_regen_count`) from being exposed in API responses. These private implementation details were being round-tripped to clients via the `llm_response` field in `TournamentSchema`, despite never being used by the frontend.

## Changes

- **backend/schemas.py** (line 171): Removed `llm_response: Optional[dict] = None` from `TournamentSchema`
- **backend/routers/tournaments.py** (line 83): Removed `llm_response=t.llm_response` kwarg from `_tournament_schema()` helper
- **backend/tests/test_tournament_service.py**: Added regression test `test_tournament_schema_does_not_expose_llm_response` to prevent future leaks

## Validation

- ✅ All backend tests pass (212 passed)
- ✅ All frontend tests pass (96 passed)
- ✅ Frontend build succeeds
- ✅ Type checking and linting clean
- ✅ Regression test confirms `llm_response` field is not in the public schema

## Scope

This change only affects the API schema serialization layer. The DB column and ORM field remain intact for internal use (debugging, regen logic).

Fixes #202