### PR TITLE
security: pin Docker base images to digest hashes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Stage 1: Build frontend
-FROM node:20-alpine AS frontend-build
+FROM node:20-alpine@sha256:fb4cd12c85ee03686f6af5362a0b0d56d50c58a04632e6c0fb8363f609372293 AS frontend-build
 WORKDIR /app/frontend
 COPY frontend/package.json frontend/package-lock.json* ./
 RUN npm install
@@ -7,7 +7,7 @@ COPY frontend/ ./
 RUN npm run build && test -f dist/index.html
 
 # Stage 2: Python backend + built frontend
-FROM python:3.12-slim
+FROM python:3.12-slim@sha256:401f6e1a67dad31a1bd78e9ad22d0ee0a3b52154e6bd30e90be696bb6a3d7461
 WORKDIR /app
 
 COPY backend/requirements.txt ./


### PR DESCRIPTION
## Summary

Pin Docker base image tags to immutable SHA256 digests to ensure reproducible builds and prevent silent supply-chain compromises from tag mutations.

## Changes

- Updated `Dockerfile` line 2: pinned `node:20-alpine` to `node:20-alpine@sha256:fb4cd12c85ee03686f6af5362a0b0d56d50c58a04632e6c0fb8363f609372293`
- Updated `Dockerfile` line 10: pinned `python:3.12-slim` to `python:3.12-slim@sha256:401f6e1a67dad31a1bd78e9ad22d0ee0a3b52154e6bd30e90be696bb6a3d7461`

Both digests are multi-arch manifest list hashes (content-addressed, not platform-specific) that resolve correctly on `linux/amd64` and `linux/arm64`.

## Validation

✅ Static analysis: 2 digest references found
✅ Docker build test: succeeded without errors
✅ All other Dockerfile lines unchanged

## Impact

- **Reproducibility**: Each build now pulls the exact same base image layers regardless of when it runs
- **Security**: Eliminates risk of silent base image replacement attacks targeting mutable tags
- **Compatibility**: No changes to build process, CI/CD, or runtime behavior

Fixes #193