### PR TITLE
fix: guard HSTS and cookie secure flag on HTTPS

### DIFF
--- a/backend/config.py
+++ b/backend/config.py
@@ -36,6 +36,10 @@ class Settings(BaseSettings):
 
     model_config = {"env_file": ".env", "env_file_encoding": "utf-8"}
 
+    @property
+    def is_https(self) -> bool:
+        return self.BASE_URL.startswith("https://")
+
 
 @lru_cache
 def get_settings() -> Settings:

--- a/backend/main.py
+++ b/backend/main.py
@@ -78,9 +78,10 @@ async def add_security_headers(request: Request, call_next):
     response.headers["X-Content-Type-Options"] = "nosniff"
     response.headers["X-Frame-Options"] = "DENY"
     response.headers["Referrer-Policy"] = "strict-origin-when-cross-origin"
-    response.headers["Strict-Transport-Security"] = (
-        "max-age=31536000; includeSubDomains"
-    )
+    if settings.is_https:
+        response.headers["Strict-Transport-Security"] = (
+            "max-age=31536000; includeSubDomains; preload"
+        )
     response.headers["Content-Security-Policy"] = (
         "default-src 'self'; "
         "img-src 'self' https://image.tmdb.org data:; "

--- a/backend/routers/auth.py
+++ b/backend/routers/auth.py
@@ -59,7 +59,7 @@ def set_session_cookie(response: Response, user_id: str, settings: Settings) -> 
         COOKIE_NAME,
         create_jwt(user_id, settings),
         httponly=True,
-        secure=True,
+        secure=settings.is_https,
         samesite="lax",
         max_age=JWT_EXPIRY_HOURS * 3600,
     )
@@ -207,7 +207,7 @@ async def login(request: Request, settings: Settings = Depends(get_settings)):
         OAUTH_STATE_COOKIE,
         state,
         httponly=True,
-        secure=True,
+        secure=settings.is_https,
         samesite="lax",
         max_age=300,
     )

--- a/backend/tests/test_auth.py
+++ b/backend/tests/test_auth.py
@@ -158,8 +158,29 @@ class TestGetCurrentUserId:
         response.set_cookie.assert_called_once()
         kwargs = response.set_cookie.call_args.kwargs
         assert kwargs.get("httponly") is True
-        assert kwargs.get("secure") is True
+        assert kwargs.get("secure") is SETTINGS.is_https
         assert kwargs.get("samesite") == "lax"
+
+    @pytest.mark.asyncio
+    async def test_refreshes_old_token_https_sets_secure_cookie(self, monkeypatch):
+        """Cookie refresh sets secure=True when BASE_URL is HTTPS."""
+        https_settings = _make_settings(BASE_URL="https://filmduel.example.com")
+        monkeypatch.setattr("backend.routers.auth.get_settings", lambda: https_settings)
+        old_iat = datetime.now(timezone.utc) - REFRESH_INTERVAL - timedelta(hours=1)
+        payload = {
+            "sub": "550e8400-e29b-41d4-a716-446655440000",
+            "jti": "x",
+            "iss": "filmduel",
+            "aud": "filmduel",
+            "exp": datetime.now(timezone.utc) + timedelta(hours=1),
+            "iat": old_iat,
+        }
+        token = pyjwt.encode(payload, https_settings.SECRET_KEY, algorithm=JWT_ALGORITHM)
+        request = _make_request({COOKIE_NAME: token})
+        response = _make_response()
+        await get_current_user_id(request, response, _make_db())
+        kwargs = response.set_cookie.call_args.kwargs
+        assert kwargs.get("secure") is True
 
     @pytest.mark.asyncio
     async def test_no_cookie_raises_401(self, monkeypatch):


### PR DESCRIPTION
## Summary

Fixes security configuration issues in HTTP header and cookie handling:
- **HSTS header**: Added conditional guard (HTTPS-only) and `preload` directive for HSTS preload list eligibility
- **Session & OAuth cookies**: Made `secure` flag conditional on HTTPS to fix development (`localhost`) testing where secure cookies are silently rejected

**Closes #192**

## Root Cause

Security-sensitive flags were hardcoded without checking if the app is running over HTTPS:
- `secure=True` unconditionally broke local development and CI on `http://localhost`
- HSTS header was emitted on plain HTTP and missing `preload` directive

## Changes

| File | Changes |
|------|---------|
| `backend/config.py` | Added `is_https` property to detect HTTPS from `BASE_URL` |
| `backend/main.py` | Guarded HSTS header on `is_https`; added `preload` directive |
| `backend/routers/auth.py` | Made session and OAuth state cookie `secure` flag conditional on `is_https` |
| `backend/tests/test_auth.py` | Updated assertions; added HTTPS cookie test |

## Validation

- ✅ All 213 backend tests pass
- ✅ All 108 frontend tests pass  
- ✅ Build succeeds (`vite build`)
- ✅ No pre-existing issues introduced

## Testing Evidence

Behavior with default `BASE_URL=http://localhost:8000`:
- Session/OAuth cookies set `secure=False` (work on localhost)
- HSTS header not emitted (correct for HTTP)

Behavior with `BASE_URL=https://...`:
- Cookies set `secure=True` (enforced in production)
- HSTS header emitted with `preload` (ready for preload list)