### PR TITLE
fix: refresh stale Trakt token in background watchlist sync

### DIFF
--- a/backend/routers/suggestions.py
+++ b/backend/routers/suggestions.py
@@ -12,10 +12,10 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import joinedload
 
 from backend.config import get_settings
-from backend.db import get_db
+from backend.db import async_session_factory, get_db
 from backend.rate_limit import limiter
 from backend.db_models import Movie, Suggestion, User, UserMovie
-from backend.routers.auth import get_current_user
+from backend.routers.auth import ensure_fresh_token, get_current_user
 from backend.schemas import (
     MediaType,
     MovieSchema,
@@ -246,11 +246,21 @@ async def add_to_watchlist(
 
     # Sync to Trakt watchlist in background
     trakt_id = suggestion.movie.trakt_id
-    access_token = current_user.trakt_access_token
+    user_id = current_user.id
     settings = get_settings()
 
     async def _sync_trakt_watchlist():
         try:
+            async with async_session_factory() as session:
+                result = await session.execute(
+                    select(User).where(User.id == user_id)
+                )
+                user = result.scalar_one_or_none()
+                if not user or not user.trakt_access_token:
+                    return
+                user = await ensure_fresh_token(user, session)
+                await session.commit()
+                access_token = user.trakt_access_token
             client = TraktClient(
                 client_id=settings.TRAKT_CLIENT_ID, access_token=access_token
             )


### PR DESCRIPTION
## Summary

Fixes #190 — Background task `_sync_trakt_watchlist` now refreshes the Trakt access token before syncing to prevent failures when the token expires.

## Changes

- **backend/routers/suggestions.py**: Refactored `_sync_trakt_watchlist` to open its own database session and call `ensure_fresh_token` before using the Trakt access token
- Added imports for `async_session_factory` (from `backend.db`) and `ensure_fresh_token` (from `backend.routers.auth`)
- Now mirrors the established pattern from `_sync_ratings_background` in `duels.py`

## How it Works

Previously, the background task captured `current_user.trakt_access_token` at request time and used it later, risking a 401 failure if the token had expired. Now:

1. Background task closes over `user_id` (stable UUID) instead of `access_token` (which can become stale)
2. Opens its own database session when executing
3. Re-fetches the user and calls `ensure_fresh_token` to proactively refresh tokens within 1 hour of expiry
4. Commits refreshed token to the database
5. Uses the fresh token for the Trakt API call

## Validation

✅ **Frontend tests**: 108 passed, 0 failed  
✅ **Build**: Compiled successfully  
✅ **Python syntax**: All modified Python files compile clean  
✅ **Pattern consistency**: Matches existing `_sync_ratings_background` pattern in `duels.py`

Edge cases handled:
- User deleted between request and background task → early return via `scalar_one_or_none()`
- User revoked Trakt authorization → early return when `trakt_access_token` is None/empty
- Network failures → propagated to exception handler and silently logged

Fixes #190