### PR TITLE
security: replace magic expires_in fallback with named constant

### DIFF
--- a/backend/routers/auth.py
+++ b/backend/routers/auth.py
@@ -32,6 +32,10 @@ from backend.services.trakt import TraktClient
 
 logger = logging.getLogger(__name__)
 
+# Trakt's documented token lifetime is 90 days (7776000 s).
+# Used as a fallback when expires_in is absent from the API response.
+_TRAKT_TOKEN_DEFAULT_TTL_SECONDS = 7776000
+
 router = APIRouter(tags=["auth"])
 
 COOKIE_NAME = "filmduel_session"
@@ -153,9 +157,11 @@ async def ensure_fresh_token(user: User, db: AsyncSession) -> User:
 
     user.trakt_access_token = tokens["access_token"]
     user.trakt_refresh_token = tokens.get("refresh_token", user.trakt_refresh_token)
-    user.trakt_token_expires_at = datetime.now(timezone.utc) + timedelta(
-        seconds=tokens.get("expires_in", 7776000)
-    )
+    ttl = tokens.get("expires_in")
+    if ttl is None:
+        logger.warning("Trakt refresh response missing expires_in; using default TTL")
+        ttl = _TRAKT_TOKEN_DEFAULT_TTL_SECONDS
+    user.trakt_token_expires_at = datetime.now(timezone.utc) + timedelta(seconds=ttl)
     user.last_seen_at = datetime.now(timezone.utc)
     await db.flush()
 
@@ -244,9 +250,11 @@ async def callback(
     profile = await authed_client.get_profile()
 
     trakt_user_id = str(profile["ids"]["slug"])
-    expires_at = datetime.now(timezone.utc) + timedelta(
-        seconds=tokens.get("expires_in", 7776000)
-    )
+    ttl = tokens.get("expires_in")
+    if ttl is None:
+        logger.warning("Trakt exchange_code response missing expires_in; using default TTL")
+        ttl = _TRAKT_TOKEN_DEFAULT_TTL_SECONDS
+    expires_at = datetime.now(timezone.utc) + timedelta(seconds=ttl)
 
     # Check if user exists
     stmt = select(User).where(User.trakt_user_id == trakt_user_id)

--- a/backend/tests/test_auth.py
+++ b/backend/tests/test_auth.py
@@ -13,7 +13,9 @@ from backend.routers.auth import (
     JWT_ALGORITHM,
     JWT_EXPIRY_HOURS,
     REFRESH_INTERVAL,
+    _TRAKT_TOKEN_DEFAULT_TTL_SECONDS,
     create_jwt,
+    ensure_fresh_token,
     get_current_user_id,
 )
 
@@ -246,3 +248,66 @@ class TestGetCurrentUserId:
             await get_current_user_id(request, response, _make_db(future_revocation))
         assert exc_info.value.status_code == 401
         assert "revoked" in exc_info.value.detail.lower()
+
+
+# ---------------------------------------------------------------------------
+# ensure_fresh_token — default TTL fallback
+# ---------------------------------------------------------------------------
+
+
+class TestEnsureFreshToken:
+    def _make_user(self, expires_soon: bool = True) -> MagicMock:
+        user = MagicMock()
+        if expires_soon:
+            user.trakt_token_expires_at = datetime.now(timezone.utc) - timedelta(hours=1)
+        else:
+            user.trakt_token_expires_at = datetime.now(timezone.utc) + timedelta(hours=2)
+        user.trakt_refresh_token = "refresh-tok"
+        user.trakt_access_token = "old-access"
+        return user
+
+    @pytest.mark.asyncio
+    async def test_uses_default_ttl_when_expires_in_missing(self, monkeypatch):
+        """When Trakt omits expires_in, token expiry uses the default TTL."""
+        monkeypatch.setattr("backend.routers.auth.get_settings", lambda: SETTINGS)
+        mock_client = AsyncMock()
+        mock_client.refresh_token.return_value = {
+            "access_token": "new-access",
+            "refresh_token": "new-refresh",
+            # No expires_in key
+        }
+        monkeypatch.setattr(
+            "backend.routers.auth.TraktClient", lambda **kw: mock_client
+        )
+        user = self._make_user(expires_soon=True)
+        db = AsyncMock()
+
+        now = datetime.now(timezone.utc)
+        await ensure_fresh_token(user, db)
+
+        expected = now + timedelta(seconds=_TRAKT_TOKEN_DEFAULT_TTL_SECONDS)
+        actual = user.trakt_token_expires_at
+        assert abs((actual - expected).total_seconds()) < 5
+
+    @pytest.mark.asyncio
+    async def test_uses_provided_expires_in(self, monkeypatch):
+        """When Trakt provides expires_in, that value is used."""
+        monkeypatch.setattr("backend.routers.auth.get_settings", lambda: SETTINGS)
+        mock_client = AsyncMock()
+        mock_client.refresh_token.return_value = {
+            "access_token": "new-access",
+            "refresh_token": "new-refresh",
+            "expires_in": 3600,
+        }
+        monkeypatch.setattr(
+            "backend.routers.auth.TraktClient", lambda **kw: mock_client
+        )
+        user = self._make_user(expires_soon=True)
+        db = AsyncMock()
+
+        now = datetime.now(timezone.utc)
+        await ensure_fresh_token(user, db)
+
+        expected = now + timedelta(seconds=3600)
+        actual = user.trakt_token_expires_at
+        assert abs((actual - expected).total_seconds()) < 5


### PR DESCRIPTION
## Summary

Replace hardcoded 7776000-second (90-day) token TTL magic number with a named constant `_TRAKT_TOKEN_DEFAULT_TTL_SECONDS` for better maintainability and security.

## Changes

**backend/routers/auth.py**
- Added `_TRAKT_TOKEN_DEFAULT_TTL_SECONDS = 7776000` constant at module level
- Replaced magic number in `ensure_fresh_token()` → uses constant + warning log when Trakt omits `expires_in`
- Replaced magic number in `callback()` → uses constant + warning log when Trakt omits `expires_in`

**backend/tests/test_auth.py**
- Added `test_uses_default_ttl_when_expires_in_missing()` — verifies default TTL fallback behavior
- Added `test_uses_provided_expires_in()` — verifies explicit `expires_in` is respected

## Validation

- **Lint**: ✅ ruff check passed, no issues
- **Tests**: ✅ 214 passed (2 new tests for default/provided TTL paths)
- **Coverage**: Default and provided TTL code paths both tested

Fixes #188