### PR TITLE
security: complete CSP directives and add Permissions-Policy

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -86,8 +86,15 @@ async def add_security_headers(request: Request, call_next):
         "default-src 'self'; "
         "img-src 'self' https://image.tmdb.org data:; "
         "script-src 'self'; "
-        "style-src 'self' 'unsafe-inline'; "
-        "connect-src 'self' https://*.sentry.io"
+        "style-src 'self'; "
+        "connect-src 'self' https://*.sentry.io; "
+        "frame-ancestors 'none'; "
+        "base-uri 'self'; "
+        "form-action 'self'; "
+        "object-src 'none'"
+    )
+    response.headers["Permissions-Policy"] = (
+        "geolocation=(), microphone=(), camera=()"
     )
     return response
 

--- a/backend/tests/test_security_headers.py
+++ b/backend/tests/test_security_headers.py
@@ -1,0 +1,43 @@
+"""Tests for security response headers set by the add_security_headers middleware."""
+from __future__ import annotations
+
+import pytest
+from fastapi.testclient import TestClient
+
+from backend.main import app
+
+client = TestClient(app)
+
+
+@pytest.fixture(scope="module")
+def response():
+    return client.get("/health")
+
+
+def test_csp_frame_ancestors(response):
+    assert "frame-ancestors 'none'" in response.headers["content-security-policy"]
+
+
+def test_csp_base_uri(response):
+    assert "base-uri 'self'" in response.headers["content-security-policy"]
+
+
+def test_csp_form_action(response):
+    assert "form-action 'self'" in response.headers["content-security-policy"]
+
+
+def test_csp_object_src(response):
+    assert "object-src 'none'" in response.headers["content-security-policy"]
+
+
+def test_csp_no_unsafe_inline_style(response):
+    csp = response.headers["content-security-policy"]
+    assert "'unsafe-inline'" not in csp
+
+
+def test_permissions_policy_present(response):
+    assert "permissions-policy" in response.headers
+
+
+def test_permissions_policy_disables_geolocation(response):
+    assert "geolocation=()" in response.headers["permissions-policy"]


### PR DESCRIPTION
## Summary

Fixes #187 by completing the Content-Security-Policy (CSP) header configuration and adding a Permissions-Policy header to the security headers middleware.

## Changes

### CSP Enhancements
- **Add missing directives:**
  - `frame-ancestors 'none'` — prevents clickjacking attacks (complements existing `X-Frame-Options: DENY`)
  - `base-uri 'self'` — prevents base-tag injection attacks
  - `form-action 'self'` — prevents form-hijacking to external origins
  - `object-src 'none'` — disables Flash/plugin content

- **Remove unsafe setting:**
  - Removed `'unsafe-inline'` from `style-src` to prevent inline style injection attacks

### New Header
- **Permissions-Policy:** Restricts browser feature access (geolocation, microphone, camera)

### Test Coverage
- Added 7 new tests in `backend/tests/test_security_headers.py` to validate all CSP directives and Permissions-Policy presence

## Files Modified
- `backend/main.py` — Updated security headers middleware (+9/-2 lines)
- `backend/tests/test_security_headers.py` — New test file (+43 lines)

## Validation

| Check | Result |
|-------|--------|
| Backend Tests | ✅ 219 passed (7 new security header tests) |
| Frontend Tests | ✅ 108 passed |
| Build | ✅ Succeeded |

All tests pass with no failures or new warnings.

Fixes #187