### PR TITLE
security: replace Trakt username PII with user UUID in logs

### DIFF
--- a/backend/routers/auth.py
+++ b/backend/routers/auth.py
@@ -384,8 +384,8 @@ async def sync_trakt(
     background_tasks.add_task(_backfill_posters_background)
 
     logger.info(
-        "Manual sync for %s: %d new movies (total: %d)",
-        current_user.trakt_username,
+        "Manual sync user_id=%s: %d new movies (total: %d)",
+        current_user.id,
         new_movies,
         after_count,
     )

--- a/backend/services/pool.py
+++ b/backend/services/pool.py
@@ -70,7 +70,7 @@ async def populate_movie_pool(user: User, db: AsyncSession) -> None:
     if last_seen and last_seen.tzinfo is None:
         last_seen = last_seen.replace(tzinfo=timezone.utc)
     if last_seen and (now - last_seen) < SYNC_COOLDOWN:
-        logger.info("Skipping pool sync for %s — synced recently", user.trakt_username)
+        logger.info("Skipping pool sync user_id=%s — synced recently", user.id)
         return
 
     settings = get_settings()
@@ -123,8 +123,8 @@ async def populate_movie_pool(user: User, db: AsyncSession) -> None:
     await db.flush()
 
     logger.info(
-        "Pool sync complete for %s",
-        user.trakt_username,
+        "Pool sync complete user_id=%s",
+        user.id,
     )
 
 


### PR DESCRIPTION
## Summary

Fixes #185 — removes Trakt username (PII) from three INFO-level log calls, replacing with internal user UUID to prevent exposure in application logs.

## Changes

| File | Lines | Change |
|------|-------|--------|
| `backend/services/pool.py` | 73 | Replace `user.trakt_username` with `user.id` in skip log |
| `backend/services/pool.py` | 125-128 | Replace `user.trakt_username` with `user.id` in sync complete log |
| `backend/routers/auth.py` | 386-391 | Replace `current_user.trakt_username` with `current_user.id` in manual sync log |

## Implementation Details

- Replaces externally-visible Trakt username with internal UUID across all three call sites
- Aligns with existing PII-safe logging convention used in `swipe.py` and `feedback.py`
- No logic changes — purely cosmetic string replacements in log messages

## Validation Results

✅ **Lint**: ruff check passed on changed files  
✅ **Backend Tests**: 212 passed, 0 failed  
✅ **Frontend Tests**: 108 passed, 0 failed  
✅ **Build**: Frontend vite build succeeded

Fixes #185