### PR TITLE
security: prevent CSV formula injection in rankings export

### DIFF
--- a/backend/services/rankings.py
+++ b/backend/services/rankings.py
@@ -163,6 +163,16 @@ async def get_user_stats(
     }
 
 
+_FORMULA_PREFIXES = frozenset("=+-@\t\n")
+
+
+def _sanitize_csv_cell(value: str) -> str:
+    """Prevent CSV formula injection by prepending a single quote to dangerous prefixes."""
+    if value and value[0] in _FORMULA_PREFIXES:
+        return "'" + value
+    return value
+
+
 async def export_rankings_csv(
     db: AsyncSession, user_id: uuid.UUID, media_type: str = "movie"
 ) -> str:
@@ -192,9 +202,9 @@ async def export_rankings_csv(
         writer.writerow(
             [
                 i + 1,
-                movie.title,
+                _sanitize_csv_cell(movie.title),
                 movie.year or "",
-                movie.imdb_id or "",
+                _sanitize_csv_cell(movie.imdb_id or ""),
                 trakt_rating,
             ]
         )

--- a/backend/tests/test_rankings_service.py
+++ b/backend/tests/test_rankings_service.py
@@ -180,3 +180,33 @@ def test_csv_export_format():
     assert rows[1][3] == "tt0133093"
     assert rows[1][4] == "8"
     assert len(rows) == 3
+
+
+# --- CSV injection sanitization ---
+
+
+def test_sanitize_csv_cell_formula_prefixes():
+    """Cells starting with injection-trigger characters must be prefixed with a quote."""
+    from backend.services.rankings import _sanitize_csv_cell
+
+    dangerous = ["=CMD", "+1-1", "-1+1", "@SUM(A1)", "\t hidden", "\nhidden"]
+    for val in dangerous:
+        result = _sanitize_csv_cell(val)
+        assert result.startswith("'"), f"Expected quote prefix for: {val!r}"
+        assert result[1:] == val
+
+
+def test_sanitize_csv_cell_safe_values():
+    """Safe cell values must pass through unchanged."""
+    from backend.services.rankings import _sanitize_csv_cell
+
+    safe = ["The Matrix", "tt0133093", "", "Inception", "2001: A Space Odyssey"]
+    for val in safe:
+        assert _sanitize_csv_cell(val) == val
+
+
+def test_sanitize_csv_cell_empty():
+    """Empty string must not be modified."""
+    from backend.services.rankings import _sanitize_csv_cell
+
+    assert _sanitize_csv_cell("") == ""


### PR DESCRIPTION
## Summary

Fixes CSV formula injection vulnerability in the rankings export feature. Movie titles and IMDb IDs from the Trakt API are now sanitized before being written to CSV to prevent formula interpretation in spreadsheet applications.

## Changes

- **backend/services/rankings.py**: Added `_sanitize_csv_cell()` helper function that prepends a single quote (`'`) to any cell value starting with formula-injection trigger characters (`=`, `+`, `-`, `@`, tab, newline). Applied to `movie.title` and `movie.imdb_id` fields in `export_rankings_csv()`.
- **backend/tests/test_rankings_service.py**: Added 3 new unit tests covering formula-prefix sanitization, safe values pass-through, and empty string handling.

## Validation

- **Tests**: 186 passed (including 3 new sanitization tests), 0 failed
- **Lint**: ruff: 0 errors, 0 warnings
- **Build**: Frontend Vite build compiled successfully

## Details

The vulnerability allowed arbitrary formulas to be injected into exported CSV files through movie titles or IMDb IDs from the Trakt API. When a user opens the CSV in Excel or LibreOffice, cells starting with `=`, `+`, `-`, `@`, tab, or newline are interpreted as formulas and executed. The fix follows the standard CSV injection defense: prepending a single quote forces spreadsheet apps to treat the value as literal text.

Fixes #171