### PR TITLE
security: handle ValueError on malformed user input

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -93,9 +93,7 @@ async def add_security_headers(request: Request, call_next):
         "form-action 'self'; "
         "object-src 'none'"
     )
-    response.headers["Permissions-Policy"] = (
-        "geolocation=(), microphone=(), camera=()"
-    )
+    response.headers["Permissions-Policy"] = "geolocation=(), microphone=(), camera=()"
     return response
 
 

--- a/backend/routers/auth.py
+++ b/backend/routers/auth.py
@@ -252,7 +252,9 @@ async def callback(
     trakt_user_id = str(profile["ids"]["slug"])
     ttl = tokens.get("expires_in")
     if ttl is None:
-        logger.warning("Trakt exchange_code response missing expires_in; using default TTL")
+        logger.warning(
+            "Trakt exchange_code response missing expires_in; using default TTL"
+        )
         ttl = _TRAKT_TOKEN_DEFAULT_TTL_SECONDS
     expires_at = datetime.now(timezone.utc) + timedelta(seconds=ttl)
 

--- a/backend/routers/rankings.py
+++ b/backend/routers/rankings.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import io
 from typing import Optional
 
-from fastapi import APIRouter, Depends, Query
+from fastapi import APIRouter, Depends, HTTPException, Query
 from fastapi.responses import StreamingResponse
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -62,15 +62,18 @@ async def get_rankings(
     media_type: MediaType = Query(default="movie"),
 ):
     """Return the user's ranked movies/shows sorted by ELO descending."""
-    user_movies, total = await get_user_rankings(
-        db,
-        current_user.id,
-        genre=genre,
-        decade=decade,
-        limit=limit,
-        offset=offset,
-        media_type=media_type,
-    )
+    try:
+        user_movies, total = await get_user_rankings(
+            db,
+            current_user.id,
+            genre=genre,
+            decade=decade,
+            limit=limit,
+            offset=offset,
+            media_type=media_type,
+        )
+    except ValueError:
+        raise HTTPException(status_code=400, detail="Invalid decade format")
     rankings = [
         _build_ranked_movie(um, rank=offset + i + 1) for i, um in enumerate(user_movies)
     ]

--- a/backend/routers/suggestions.py
+++ b/backend/routers/suggestions.py
@@ -36,11 +36,15 @@ MAX_REGENERATIONS_PER_DAY = 3
 async def _get_user_suggestion(
     db: AsyncSession, suggestion_id: str, user_id: uuid.UUID
 ) -> Suggestion:
+    try:
+        sid = uuid.UUID(suggestion_id)
+    except ValueError:
+        raise HTTPException(status_code=400, detail="Invalid suggestion ID")
     stmt = (
         select(Suggestion)
         .options(joinedload(Suggestion.movie))
         .where(
-            Suggestion.id == uuid.UUID(suggestion_id),
+            Suggestion.id == sid,
             Suggestion.user_id == user_id,
         )
     )
@@ -103,9 +107,14 @@ async def _create_suggestions(
 
     suggestions = []
     for pick in picks:
+        try:
+            movie_id = uuid.UUID(pick["movie_id"])
+        except ValueError:
+            logger.warning("AI returned malformed movie_id: %s — skipping", pick.get("movie_id"))
+            continue
         s = Suggestion(
             user_id=user_id,
-            movie_id=uuid.UUID(pick["movie_id"]),
+            movie_id=movie_id,
             reason=pick["reason"],
             generated_at=datetime.now(timezone.utc),
         )

--- a/backend/routers/suggestions.py
+++ b/backend/routers/suggestions.py
@@ -110,7 +110,9 @@ async def _create_suggestions(
         try:
             movie_id = uuid.UUID(pick["movie_id"])
         except ValueError:
-            logger.warning("AI returned malformed movie_id: %s — skipping", pick.get("movie_id"))
+            logger.warning(
+                "AI returned malformed movie_id: %s — skipping", pick.get("movie_id")
+            )
             continue
         s = Suggestion(
             user_id=user_id,
@@ -261,9 +263,7 @@ async def add_to_watchlist(
     async def _sync_trakt_watchlist():
         try:
             async with async_session_factory() as session:
-                result = await session.execute(
-                    select(User).where(User.id == user_id)
-                )
+                result = await session.execute(select(User).where(User.id == user_id))
                 user = result.scalar_one_or_none()
                 if not user or not user.trakt_access_token:
                     return

--- a/backend/routers/tournaments.py
+++ b/backend/routers/tournaments.py
@@ -424,7 +424,10 @@ async def submit_match_result_endpoint(
     """Submit a tournament match result."""
     uid = current_user.id
     tournament = await _load_tournament(tournament_id, uid, db)
-    winner_id = uuid.UUID(body.winner_movie_id)
+    try:
+        winner_id = uuid.UUID(body.winner_movie_id)
+    except ValueError:
+        raise HTTPException(status_code=400, detail="Invalid winner_movie_id")
 
     try:
         loser_id = validate_match(tournament, match_id, winner_id)

--- a/backend/tests/test_auth.py
+++ b/backend/tests/test_auth.py
@@ -177,7 +177,9 @@ class TestGetCurrentUserId:
             "exp": datetime.now(timezone.utc) + timedelta(hours=1),
             "iat": old_iat,
         }
-        token = pyjwt.encode(payload, https_settings.SECRET_KEY, algorithm=JWT_ALGORITHM)
+        token = pyjwt.encode(
+            payload, https_settings.SECRET_KEY, algorithm=JWT_ALGORITHM
+        )
         request = _make_request({COOKIE_NAME: token})
         response = _make_response()
         await get_current_user_id(request, response, _make_db())
@@ -280,9 +282,13 @@ class TestEnsureFreshToken:
     def _make_user(self, expires_soon: bool = True) -> MagicMock:
         user = MagicMock()
         if expires_soon:
-            user.trakt_token_expires_at = datetime.now(timezone.utc) - timedelta(hours=1)
+            user.trakt_token_expires_at = datetime.now(timezone.utc) - timedelta(
+                hours=1
+            )
         else:
-            user.trakt_token_expires_at = datetime.now(timezone.utc) + timedelta(hours=2)
+            user.trakt_token_expires_at = datetime.now(timezone.utc) + timedelta(
+                hours=2
+            )
         user.trakt_refresh_token = "refresh-tok"
         user.trakt_access_token = "old-access"
         return user

--- a/backend/tests/test_rankings_service.py
+++ b/backend/tests/test_rankings_service.py
@@ -125,6 +125,24 @@ def test_parse_decade_without_s():
     assert parse_decade("1980") == (1980, 1989)
 
 
+def test_parse_decade_invalid_raises_value_error():
+    """Non-numeric decade string must raise ValueError."""
+    with pytest.raises(ValueError):
+        parse_decade("invalid")
+
+
+def test_parse_decade_empty_string_raises_value_error():
+    """Empty string must raise ValueError."""
+    with pytest.raises(ValueError):
+        parse_decade("")
+
+
+def test_parse_decade_partial_numeric_raises_value_error():
+    """Partially numeric decade string must raise ValueError."""
+    with pytest.raises(ValueError):
+        parse_decade("19x0s")
+
+
 # --- elo_to_letterboxd_rating ---
 
 

--- a/backend/tests/test_security_headers.py
+++ b/backend/tests/test_security_headers.py
@@ -1,4 +1,5 @@
 """Tests for security response headers set by the add_security_headers middleware."""
+
 from __future__ import annotations
 
 import pytest


### PR DESCRIPTION
## Summary

Fixes #198: Unhandled exceptions on malformed input causing HTTP 500 errors

This PR addresses four locations where `uuid.UUID()` or `int()` calls on user-controlled input propagate unhandled `ValueError` exceptions, resulting in HTTP 500 errors instead of proper HTTP 400 validation responses.

## Changes

### Files Modified

- **backend/routers/rankings.py** (+4/-1): Wrap `get_user_rankings()` call in `try/except ValueError → HTTPException(400)`
- **backend/routers/suggestions.py** (+10/-2): Add two `try/except` blocks for UUID parsing
  - Extract and validate UUID in `_get_user_suggestion()` 
  - Skip malformed `movie_id` values in `_create_suggestions()`
- **backend/routers/tournaments.py** (+5/-1): Wrap `uuid.UUID()` call in `submit_match_result_endpoint()` with `try/except ValueError → HTTPException(400)`
- **backend/tests/test_rankings_service.py** (+18): Add 3 new tests for `parse_decade()` invalid inputs

### Error Scenarios Fixed

| Route | Input | Before | After |
|-------|-------|--------|-------|
| `GET /api/rankings?decade=abc` | Invalid decade string | HTTP 500 | HTTP 400 |
| `POST /api/suggestions/{id}/dismiss` | Invalid UUID in path | HTTP 500 | HTTP 400 |
| `POST /api/suggestions/...` | AI returns malformed movie_id | HTTP 500 | Logs warning, skipped |
| `POST /tournaments/{id}/matches/{id}` | Invalid winner_movie_id in body | HTTP 500 | HTTP 400 |

## Validation

✅ **Type Check**: ruff — 0 errors
✅ **Lint**: ruff — 0 errors, 0 warnings  
✅ **Format**: 5 files auto-formatted
✅ **Backend Tests**: 228 passed (including 3 new tests)
✅ **Frontend Tests**: 108 passed

### Test Coverage

Added 3 new tests for edge cases:
- `test_parse_decade_invalid_raises_value_error`
- `test_parse_decade_empty_string_raises_value_error`
- `test_parse_decade_partial_numeric_raises_value_error`

Fixes #198