### PR TITLE
security: fix SIGTERM propagation with dedicated entrypoint script

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,8 +18,10 @@ RUN useradd --create-home --shell /usr/sbin/nologin appuser  # Debian path; Alpi
 COPY alembic.ini ./
 COPY backend/ ./backend/
 COPY --from=frontend-build /app/frontend/dist ./frontend/dist
+COPY entrypoint.sh /entrypoint.sh
+RUN chmod +x /entrypoint.sh
 
 USER appuser
 
 EXPOSE ${PORT:-8080}
-CMD ["sh", "-c", "alembic upgrade head && exec uvicorn backend.main:app --host 0.0.0.0 --port ${PORT:-8080} --proxy-headers --forwarded-allow-ips='*'"]
+ENTRYPOINT ["/entrypoint.sh"]

--- a/backend/services/suggest.py
+++ b/backend/services/suggest.py
@@ -146,20 +146,19 @@ async def _call_llm(taste_profile: dict, candidates: list[dict]) -> list[dict]:
         "- Prefer films with higher community ratings when taste-fit is similar"
     )
 
-    def _safe_title_genres(item: dict) -> tuple[str, str]:
-        title = _sanitize_llm_input(item["title"], max_len=150)
-        genres = ", ".join(
+    def _safe_genres(item: dict) -> str:
+        return ", ".join(
             _sanitize_llm_input(g, max_len=50) for g in (item.get("genres") or [])
         )
-        return title, genres
 
     def _safe_film_line(f: dict) -> str:
-        title, genres = _safe_title_genres(f)
-        return f"- {title} ({f['year']}) [{genres}] ELO: {f['elo']}"
+        title = _sanitize_llm_input(f["title"], max_len=150)
+        return f"- {title} ({f['year']}) [{_safe_genres(f)}] ELO: {f['elo']}"
 
     def _safe_candidate_line(c: dict) -> str:
-        title, genres = _safe_title_genres(c)
-        return f"- trakt_id={c['trakt_id']}: {title} ({c['year']}) [{genres}] rating={c['community_rating'] or 'N/A'}"
+        title = _sanitize_llm_input(c["title"], max_len=150)
+        rating = c["community_rating"] or "N/A"
+        return f"- trakt_id={c['trakt_id']}: {title} ({c['year']}) [{_safe_genres(c)}] rating={rating}"
 
     user_message = (
         "## User Taste Profile\n\n"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -5,4 +5,4 @@ exec uvicorn backend.main:app \
   --host 0.0.0.0 \
   --port "${PORT:-8080}" \
   --proxy-headers \
-  --forwarded-allow-ips='*'
+  --forwarded-allow-ips='*'  # Trusts Railway's reverse proxy; assumes container is not directly internet-reachable

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+set -e
+alembic upgrade head
+exec uvicorn backend.main:app \
+  --host 0.0.0.0 \
+  --port "${PORT:-8080}" \
+  --proxy-headers \
+  --forwarded-allow-ips='*'


### PR DESCRIPTION
## Summary

- Replace `CMD ["sh", "-c", "alembic upgrade head && exec uvicorn ..."]` with a dedicated `entrypoint.sh` script
- Use `ENTRYPOINT ["/entrypoint.sh"]` exec form so the script runs as PID 1
- `exec uvicorn` inside the script ensures uvicorn becomes PID 1 after migrations, receiving SIGTERM cleanly

Fixes #196.

## Test plan

- [ ] `docker build -t filmduel-test .` succeeds
- [ ] `docker run -d --name fd-test filmduel-test` starts successfully with migrations applied
- [ ] `docker stop fd-test` produces a clean shutdown (uvicorn logs "Shutting down", exit code 0)

🤖 Generated with [Claude Code](https://claude.com/claude-code)