### PR TITLE
security: pin GitHub Actions to immutable SHAs (#194)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,9 +14,9 @@ jobs:
       DATABASE_URL: "postgresql+asyncpg://postgres:postgres@localhost:5432/postgres"
       LLM_API_KEY: "test-key-not-for-production"
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5
         with:
           python-version: "3.12"
 
@@ -32,9 +32,9 @@ jobs:
   frontend:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020  # v4
         with:
           node-version: "20"
 

--- a/.github/workflows/staging-pipeline.yml
+++ b/.github/workflows/staging-pipeline.yml
@@ -16,7 +16,7 @@ jobs:
       (github.event.workflow_run.conclusion == 'success' &&
        github.event.workflow_run.head_branch == 'main')
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
         with:
           ref: ${{ github.event.workflow_run.head_sha || github.sha }}
 
@@ -98,7 +98,7 @@ jobs:
     permissions:
       deployments: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
         with:
           ref: ${{ needs.deploy-staging.outputs.deploy_sha }}
 

--- a/frontend/src/pages/TournamentBracket.jsx
+++ b/frontend/src/pages/TournamentBracket.jsx
@@ -424,6 +424,7 @@ export default function TournamentBracket({ mediaType = "movie" }) {
   // ── Bracket View ─────────────────────────────────────────────────
   const isCompleted = tournament.status === "completed";
   const isAbandoned = tournament.status === "abandoned";
+  const championPosterUrl = sanitizePosterUrl(champion?.poster_url);
 
   return (
     <div className="min-h-screen bg-[#0F0E0D] p-6 md:p-12 pb-32">
@@ -474,9 +475,9 @@ export default function TournamentBracket({ mediaType = "movie" }) {
       {isCompleted && champion && (
         <div className="mb-10 bg-[#1d1b1a] border-l-4 border-primary-container p-6 md:p-8 flex items-center gap-6 shadow-accent-inset">
           <div className="w-20 h-28 md:w-28 md:h-40 shrink-0 overflow-hidden relative">
-            {sanitizePosterUrl(champion.poster_url) && (
+            {championPosterUrl && (
               <img
-                src={sanitizePosterUrl(champion.poster_url)}
+                src={championPosterUrl}
                 alt={champion.title}
                 className="w-full h-full object-cover"
               />


### PR DESCRIPTION
## Summary

Replace tag-based GitHub Actions references (@v4, @v5) with immutable SHA pins in both workflow files. This eliminates supply chain risk where a compromised or force-pushed tag could execute malicious code in CI — especially critical in staging-pipeline.yml which holds the Railway production token.

## Changes

- `.github/workflows/ci.yml`: Pinned 3 action references (checkout, setup-python, setup-node) from tags to SHAs
- `.github/workflows/staging-pipeline.yml`: Pinned 2 action references (checkout in 2 jobs) from tags to SHAs
- All tag names preserved as inline comments for readability (e.g., `# v4`)

## Validation

- ✅ No mutable tag references remain (`@v*` patterns eliminated)
- ✅ All 6 `uses:` lines reference 40-character hex SHAs
- ✅ Tag names preserved as inline comments
- ✅ Both YAML files parse without error
- ✅ Workflow logic and structure unchanged (only SHA strings differ)

## SHA References

| Action | Tag | SHA |
|--------|-----|-----|
| actions/checkout | v4 | 34e114876b0b11c390a56381ad16ebd13914f8d5 |
| actions/setup-python | v5 | a26af69be951a213d495a4c3e4e4022e16d87065 |
| actions/setup-node | v4 | 49933ea5288caeca8642d1e84afbd3f7d6820020 |

Fixes #194