### PR TITLE
Fix: require opt-in before syncing ELO ratings to Trakt

### DIFF
--- a/backend/db_models.py
+++ b/backend/db_models.py
@@ -79,6 +79,9 @@ class User(Base):
         default=lambda: datetime(1970, 1, 1, tzinfo=timezone.utc),
         server_default="1970-01-01T00:00:00+00:00",
     )
+    sync_ratings_to_trakt: Mapped[bool] = mapped_column(
+        Boolean, nullable=False, server_default="false"
+    )
 
     user_movies: Mapped[list[UserMovie]] = relationship(
         back_populates="user", cascade="all, delete-orphan"

--- a/backend/db_models.py
+++ b/backend/db_models.py
@@ -80,7 +80,7 @@ class User(Base):
         server_default="1970-01-01T00:00:00+00:00",
     )
     sync_ratings_to_trakt: Mapped[bool] = mapped_column(
-        Boolean, nullable=False, server_default="false"
+        Boolean, nullable=False, default=False, server_default="false"
     )
 
     user_movies: Mapped[list[UserMovie]] = relationship(

--- a/backend/main.py
+++ b/backend/main.py
@@ -64,7 +64,8 @@ def _scrub_sensitive(event: dict, hint: dict) -> dict:
         for frame in (exc_val.get("stacktrace") or {}).get("frames") or []:
             vars_ = frame.get("vars") or {}
             for key in list(vars_):
-                if key in _SCRUB_KEYS or "token" in key.lower() or "secret" in key.lower():
+                lower = key.lower()
+                if key in _SCRUB_KEYS or "token" in lower or "secret" in lower:
                     vars_[key] = "[Filtered]"
     return event
 

--- a/backend/migrations/versions/016_add_sync_ratings_toggle.py
+++ b/backend/migrations/versions/016_add_sync_ratings_toggle.py
@@ -1,0 +1,32 @@
+"""Add sync_ratings_to_trakt opt-in toggle to users.
+
+Revision ID: 016
+Revises: 015
+Create Date: 2026-05-16
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+revision: str = "016"
+down_revision: Union[str, None] = "015"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "users",
+        sa.Column(
+            "sync_ratings_to_trakt",
+            sa.Boolean(),
+            nullable=False,
+            server_default="false",
+        ),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("users", "sync_ratings_to_trakt")

--- a/backend/routers/auth.py
+++ b/backend/routers/auth.py
@@ -25,7 +25,7 @@ from backend.config import Settings, get_settings
 from backend.rate_limit import limiter
 from backend.db import async_session_factory, get_db
 from backend.db_models import User, UserMovie
-from backend.schemas import UserResponse
+from backend.schemas import UserResponse, UserSettingsUpdate
 from backend.services.pool import populate_movie_pool
 from backend.services.tmdb import backfill_posters
 from backend.services.trakt import TraktClient
@@ -320,6 +320,25 @@ async def me(user: User = Depends(get_current_user)):
         id=str(user.id),
         trakt_username=user.trakt_username,
         created_at=user.created_at,
+        sync_ratings_to_trakt=user.sync_ratings_to_trakt,
+    )
+
+
+@router.patch("/api/me/settings", response_model=UserResponse)
+async def update_settings(
+    body: UserSettingsUpdate,
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+):
+    """Update user preferences."""
+    current_user.sync_ratings_to_trakt = body.sync_ratings_to_trakt
+    await db.commit()
+    await db.refresh(current_user)
+    return UserResponse(
+        id=str(current_user.id),
+        trakt_username=current_user.trakt_username,
+        created_at=current_user.created_at,
+        sync_ratings_to_trakt=current_user.sync_ratings_to_trakt,
     )
 
 

--- a/backend/routers/auth.py
+++ b/backend/routers/auth.py
@@ -325,8 +325,10 @@ async def me(user: User = Depends(get_current_user)):
 
 
 @router.patch("/api/me/settings", response_model=UserResponse)
+@limiter.limit("30/minute")
 async def update_settings(
     body: UserSettingsUpdate,
+    request: Request,
     current_user: User = Depends(get_current_user),
     db: AsyncSession = Depends(get_db),
 ):

--- a/backend/routers/duels.py
+++ b/backend/routers/duels.py
@@ -35,7 +35,7 @@ async def _sync_ratings_background(
             user_stmt = select(User).where(User.id == user_id)
             result = await session.execute(user_stmt)
             user = result.scalar_one_or_none()
-            if not user or not user.trakt_access_token:
+            if not user or not user.trakt_access_token or not user.sync_ratings_to_trakt:
                 return
             user = await ensure_fresh_token(user, session)
             await session.commit()

--- a/backend/schemas.py
+++ b/backend/schemas.py
@@ -14,6 +14,11 @@ class UserResponse(BaseModel):
     id: str
     trakt_username: str
     created_at: datetime
+    sync_ratings_to_trakt: bool
+
+
+class UserSettingsUpdate(BaseModel):
+    sync_ratings_to_trakt: bool
 
 
 MediaType = Literal["movie", "show"]

--- a/backend/tests/test_auth.py
+++ b/backend/tests/test_auth.py
@@ -14,6 +14,8 @@ import pytest
 from fastapi import HTTPException
 
 from backend.config import Settings
+from starlette.requests import Request as StarletteRequest
+
 from backend.routers.auth import (
     COOKIE_NAME,
     JWT_ALGORITHM,
@@ -23,6 +25,7 @@ from backend.routers.auth import (
     create_jwt,
     ensure_fresh_token,
     get_current_user_id,
+    update_settings,
 )
 
 
@@ -344,3 +347,79 @@ class TestEnsureFreshToken:
         expected = now + timedelta(seconds=3600)
         actual = user.trakt_token_expires_at
         assert abs((actual - expected).total_seconds()) < 5
+
+
+# ---------------------------------------------------------------------------
+# update_settings
+# ---------------------------------------------------------------------------
+
+
+def _make_starlette_request() -> StarletteRequest:
+    """Create a minimal real Starlette Request for rate-limited endpoints."""
+    scope = {
+        "type": "http",
+        "method": "PATCH",
+        "path": "/api/me/settings",
+        "query_string": b"",
+        "headers": [],
+        "client": ("127.0.0.1", 12345),
+        "app": MagicMock(),
+    }
+    scope["app"].state = MagicMock()
+    scope["app"].state.limiter = MagicMock()
+    scope["app"].state.limiter.enabled = False
+    return StarletteRequest(scope)
+
+
+class TestUpdateSettings:
+    def _make_user(self, sync_ratings: bool = False) -> MagicMock:
+        user = MagicMock()
+        user.id = "00000000-0000-0000-0000-000000000001"
+        user.trakt_username = "testuser"
+        user.created_at = datetime(2024, 1, 1, tzinfo=timezone.utc)
+        user.sync_ratings_to_trakt = sync_ratings
+        return user
+
+    @pytest.mark.asyncio
+    async def test_update_settings_enables_sync(self, monkeypatch):
+        """Enables sync: sets flag to True, commits, refreshes, and returns updated response."""
+        from backend.schemas import UserSettingsUpdate
+        from backend.rate_limit import limiter
+
+        monkeypatch.setattr(limiter, "enabled", False)
+
+        user = self._make_user(sync_ratings=False)
+        db = AsyncMock()
+
+        result = await update_settings(
+            body=UserSettingsUpdate(sync_ratings_to_trakt=True),
+            request=_make_starlette_request(),
+            current_user=user,
+            db=db,
+        )
+
+        assert user.sync_ratings_to_trakt is True
+        db.commit.assert_awaited_once()
+        db.refresh.assert_awaited_once_with(user)
+        assert result.sync_ratings_to_trakt is True
+
+    @pytest.mark.asyncio
+    async def test_update_settings_disables_sync(self, monkeypatch):
+        """Disables sync: sets flag to False and returns updated response."""
+        from backend.schemas import UserSettingsUpdate
+        from backend.rate_limit import limiter
+
+        monkeypatch.setattr(limiter, "enabled", False)
+
+        user = self._make_user(sync_ratings=True)
+        db = AsyncMock()
+
+        result = await update_settings(
+            body=UserSettingsUpdate(sync_ratings_to_trakt=False),
+            request=_make_starlette_request(),
+            current_user=user,
+            db=db,
+        )
+
+        assert user.sync_ratings_to_trakt is False
+        assert result.sync_ratings_to_trakt is False

--- a/backend/tests/test_media_type_filtering.py
+++ b/backend/tests/test_media_type_filtering.py
@@ -252,3 +252,87 @@ async def test_sync_ratings_background_refresh_failure_is_swallowed():
         await _sync_ratings_background(uid, mid_a, 1100, mid_b, 900)
 
         mock_sync.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_sync_ratings_background_skips_when_opt_out():
+    """_sync_ratings_background skips sync when sync_ratings_to_trakt is False."""
+    from backend.routers.duels import _sync_ratings_background
+
+    mock_user = MagicMock()
+    mock_user.trakt_access_token = "valid_token"
+    mock_user.sync_ratings_to_trakt = False
+
+    with (
+        patch("backend.routers.duels.async_session_factory") as mock_factory,
+        patch(
+            "backend.routers.duels.ensure_fresh_token", new_callable=AsyncMock
+        ) as mock_refresh,
+        patch(
+            "backend.routers.duels.sync_post_duel", new_callable=AsyncMock
+        ) as mock_sync,
+    ):
+        mock_session = AsyncMock()
+        mock_factory.return_value.__aenter__ = AsyncMock(return_value=mock_session)
+        mock_factory.return_value.__aexit__ = AsyncMock(return_value=False)
+        mock_exec_result = MagicMock()
+        mock_exec_result.scalar_one_or_none.return_value = mock_user
+        mock_session.execute.return_value = mock_exec_result
+
+        await _sync_ratings_background(
+            uuid.uuid4(), uuid.uuid4(), 1100, uuid.uuid4(), 900
+        )
+
+        mock_refresh.assert_not_awaited()
+        mock_sync.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_sync_ratings_background_syncs_when_opt_in():
+    """_sync_ratings_background syncs when sync_ratings_to_trakt is True."""
+    from backend.routers.duels import _sync_ratings_background
+
+    uid = uuid.uuid4()
+    mid_a = uuid.uuid4()
+    mid_b = uuid.uuid4()
+
+    mock_user = MagicMock()
+    mock_user.trakt_access_token = "valid_token"
+    mock_user.sync_ratings_to_trakt = True
+
+    mock_movie_row_a = MagicMock()
+    mock_movie_row_a.id = mid_a
+    mock_movie_row_a.trakt_id = 111
+    mock_movie_row_a.media_type = "movie"
+
+    mock_movie_row_b = MagicMock()
+    mock_movie_row_b.id = mid_b
+    mock_movie_row_b.trakt_id = 222
+    mock_movie_row_b.media_type = "movie"
+
+    mock_user_result = MagicMock()
+    mock_user_result.scalar_one_or_none.return_value = mock_user
+
+    mock_movies_result = MagicMock()
+    mock_movies_result.all.return_value = [mock_movie_row_a, mock_movie_row_b]
+
+    mock_session = AsyncMock()
+    mock_session.execute.side_effect = [mock_user_result, mock_movies_result]
+
+    with (
+        patch("backend.routers.duels.async_session_factory") as mock_factory,
+        patch(
+            "backend.routers.duels.ensure_fresh_token",
+            new_callable=AsyncMock,
+            return_value=mock_user,
+        ),
+        patch(
+            "backend.routers.duels.sync_post_duel", new_callable=AsyncMock
+        ) as mock_sync,
+    ):
+        mock_factory.return_value.__aenter__ = AsyncMock(return_value=mock_session)
+        mock_factory.return_value.__aexit__ = AsyncMock(return_value=False)
+
+        await _sync_ratings_background(uid, mid_a, 1100, mid_b, 900)
+
+        mock_sync.assert_awaited_once()

--- a/backend/tests/test_schemas.py
+++ b/backend/tests/test_schemas.py
@@ -326,9 +326,13 @@ class TestResponseModels:
         from datetime import datetime, timezone
 
         ur = UserResponse(
-            id="abc", trakt_username="testuser", created_at=datetime.now(timezone.utc)
+            id="abc",
+            trakt_username="testuser",
+            created_at=datetime.now(timezone.utc),
+            sync_ratings_to_trakt=False,
         )
         assert ur.trakt_username == "testuser"
+        assert ur.sync_ratings_to_trakt is False
 
     def test_movie_pair_response(self):
         ma = MovieWithStateSchema(id="1", trakt_id=1, title="A")

--- a/backend/tests/test_schemas.py
+++ b/backend/tests/test_schemas.py
@@ -22,6 +22,7 @@ from backend.schemas import (
     SwipeSubmit,
     TournamentCreate,
     UserResponse,
+    UserSettingsUpdate,
 )
 
 
@@ -340,6 +341,14 @@ class TestResponseModels:
         pr = MoviePairResponse(movie_a=ma, movie_b=mb)
         assert pr.next_pair_token is None
         assert pr.movie_a.title == "A"
+
+    def test_user_settings_update_accepts_bool(self):
+        s = UserSettingsUpdate(sync_ratings_to_trakt=True)
+        assert s.sync_ratings_to_trakt is True
+
+    def test_user_settings_update_rejects_non_bool(self):
+        with pytest.raises(ValidationError):
+            UserSettingsUpdate(sync_ratings_to_trakt="not-a-boolean-value")
 
     def test_feedback_report_response(self):
         from datetime import datetime, timezone

--- a/docs/PRD.md
+++ b/docs/PRD.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-FilmDuel is a web app that helps users discover and rank movies and TV shows through pairwise comparisons. Users authenticate with their Trakt account, toggle between Movies and TV Shows via the nav bar, classify films rapidly via a Tinder-style swipe session, then duel seen films against each other to build an ELO-ranked library. Ratings sync back to Trakt in real time.
+FilmDuel is a web app that helps users discover and rank movies and TV shows through pairwise comparisons. Users authenticate with their Trakt account, toggle between Movies and TV Shows via the nav bar, classify films rapidly via a Tinder-style swipe session, then duel seen films against each other to build an ELO-ranked library. ELO ratings can optionally sync back to Trakt in real time when the user enables the "Sync to Trakt" toggle.
 
 The experience has two distinct modes that alternate naturally:
 - **Swipe** — fast, mindless sorting. Seen it or not?
@@ -18,7 +18,7 @@ The experience should feel like a game — fast, opinionated, oddly compelling.
 - Generate meaningful ELO rankings through enjoyable head-to-head duels
 - Always show interesting match-ups (good vs good, bad vs bad — not random)
 - Surface films the user has forgotten they've seen
-- Sync ratings back to Trakt so the data lives somewhere useful
+- Optionally sync ELO ratings back to Trakt (user opt-in) so the data lives somewhere useful
 - Export rankings to Letterboxd CSV format
 
 ---

--- a/frontend/src/__tests__/App.test.jsx
+++ b/frontend/src/__tests__/App.test.jsx
@@ -7,9 +7,16 @@ describe("App", () => {
   beforeEach(() => {
     vi.stubGlobal(
       "fetch",
-      vi.fn(() =>
-        Promise.resolve({ ok: true, json: () => Promise.resolve({}) })
-      )
+      vi.fn((url) => {
+        if (url === "/api/me") {
+          return Promise.resolve({
+            ok: true,
+            status: 200,
+            json: () => Promise.resolve({ sync_ratings_to_trakt: false }),
+          });
+        }
+        return Promise.resolve({ ok: true, status: 204, json: () => Promise.resolve(null) });
+      })
     );
   });
 
@@ -121,7 +128,7 @@ describe("App", () => {
       "fetch",
       vi.fn((url) => {
         if (url === "/api/me") {
-          return Promise.resolve({ ok: true, json: () => Promise.resolve({}) });
+          return Promise.resolve({ ok: true, status: 200, json: () => Promise.resolve({ sync_ratings_to_trakt: false }) });
         }
         if (url.includes("/api/rankings") && !url.includes("stats")) {
           return Promise.resolve({

--- a/frontend/src/__tests__/Nav.test.jsx
+++ b/frontend/src/__tests__/Nav.test.jsx
@@ -3,8 +3,100 @@ import { MemoryRouter } from "react-router-dom";
 import { describe, it, expect, beforeEach, vi } from "vitest";
 import Nav from "../components/Nav";
 
+// ── Sync to Trakt toggle tests (use vi.mock to control api module) ─────────
+
+vi.mock("../api", async (importOriginal) => {
+  const actual = await importOriginal();
+  return {
+    ...actual,
+    getMe: vi.fn(),
+    updateSettings: vi.fn(() => Promise.resolve()),
+  };
+});
+
+import { getMe, updateSettings } from "../api";
+
+
+describe("Nav — Sync to Trakt toggle", () => {
+  const renderNav = () =>
+    render(
+      <MemoryRouter>
+        <Nav />
+      </MemoryRouter>
+    );
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("renders toggle in OFF state when user has sync disabled", async () => {
+    getMe.mockResolvedValueOnce({ sync_ratings_to_trakt: false });
+    renderNav();
+    await waitFor(() => {
+      const toggle = screen.getByRole("switch");
+      expect(toggle).toHaveAttribute("aria-checked", "false");
+    });
+  });
+
+  it("renders toggle in ON state when user has sync enabled", async () => {
+    getMe.mockResolvedValueOnce({ sync_ratings_to_trakt: true });
+    renderNav();
+    await waitFor(() => {
+      const toggle = screen.getByRole("switch");
+      expect(toggle).toHaveAttribute("aria-checked", "true");
+    });
+  });
+
+  it("toggles ON and calls updateSettings when clicked while OFF", async () => {
+    getMe.mockResolvedValueOnce({ sync_ratings_to_trakt: false });
+    renderNav();
+    await waitFor(() => screen.getByRole("switch"));
+    fireEvent.click(screen.getByRole("switch"));
+    await waitFor(() => {
+      expect(screen.getByRole("switch")).toHaveAttribute("aria-checked", "true");
+      expect(updateSettings).toHaveBeenCalledWith({ sync_ratings_to_trakt: true });
+    });
+  });
+
+  it("toggles OFF and calls updateSettings when clicked while ON", async () => {
+    getMe.mockResolvedValueOnce({ sync_ratings_to_trakt: true });
+    renderNav();
+    await waitFor(() => screen.getByRole("switch"));
+    fireEvent.click(screen.getByRole("switch"));
+    await waitFor(() => {
+      expect(screen.getByRole("switch")).toHaveAttribute("aria-checked", "false");
+      expect(updateSettings).toHaveBeenCalledWith({ sync_ratings_to_trakt: false });
+    });
+  });
+
+  it("defaults to OFF when getMe returns null", async () => {
+    getMe.mockResolvedValueOnce(null);
+    renderNav();
+    await waitFor(() => {
+      expect(screen.getByRole("switch")).toHaveAttribute("aria-checked", "false");
+    });
+  });
+
+  it("rolls back toggle state when updateSettings fails", async () => {
+    getMe.mockResolvedValueOnce({ sync_ratings_to_trakt: false });
+    updateSettings.mockRejectedValueOnce(new Error("Network error"));
+    renderNav();
+    await waitFor(() => screen.getByRole("switch"));
+    fireEvent.click(screen.getByRole("switch"));
+    // After failure, toggle should roll back to OFF
+    await waitFor(() => {
+      expect(screen.getByRole("switch")).toHaveAttribute("aria-checked", "false");
+    });
+  });
+});
+
 describe("Nav", () => {
   beforeEach(() => {
+    vi.clearAllMocks();
+    // The api module is mocked above. Set safe defaults for the existing Nav tests.
+    getMe.mockResolvedValue(null);
+    updateSettings.mockResolvedValue(null);
+    // logout is also mocked; stub fetch so the Sign Out test can verify the call
     vi.stubGlobal(
       "fetch",
       vi.fn(() =>

--- a/frontend/src/__tests__/api.test.js
+++ b/frontend/src/__tests__/api.test.js
@@ -8,6 +8,7 @@ import {
   getMe,
   logout,
   submitFeedback,
+  updateSettings,
 } from "../api";
 
 describe("api", () => {
@@ -166,6 +167,22 @@ describe("api", () => {
         json: () => Promise.reject(new Error("not json")),
       });
       await expect(getRankings()).rejects.toThrow("Request failed");
+    });
+  });
+
+  // updateSettings
+  describe("updateSettings", () => {
+    it("sends PATCH to /api/me/settings with serialized body", async () => {
+      mockFetchOk({ id: "1", trakt_username: "u", created_at: "2024-01-01T00:00:00Z", sync_ratings_to_trakt: true });
+      await updateSettings({ sync_ratings_to_trakt: true });
+      expect(fetch).toHaveBeenCalledWith(
+        "/api/me/settings",
+        expect.objectContaining({
+          method: "PATCH",
+          body: JSON.stringify({ sync_ratings_to_trakt: true }),
+          headers: expect.objectContaining({ "Content-Type": "application/json" }),
+        })
+      );
     });
   });
 

--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -63,6 +63,13 @@ export function logout() { return request("/auth/logout", { method: "POST" }); }
 
 export function syncTrakt() { return request("/api/sync", { method: "POST" }); }
 
+export function updateSettings(payload) {
+  return request("/api/me/settings", {
+    method: "PATCH",
+    body: JSON.stringify(payload),
+  });
+}
+
 // ── Tournaments ──────────────────────────────────────────────────────
 
 export function getTournaments() {

--- a/frontend/src/components/Nav.jsx
+++ b/frontend/src/components/Nav.jsx
@@ -17,15 +17,23 @@ export default function Nav({ mediaType, setMediaType }) {
   const [syncRatings, setSyncRatings] = useState(false);
 
   useEffect(() => {
-    getMe().then((user) => {
-      if (user) setSyncRatings(user.sync_ratings_to_trakt);
-    });
+    getMe()
+      .then((user) => {
+        if (user) setSyncRatings(user.sync_ratings_to_trakt);
+      })
+      .catch(() => {
+        // Leave syncRatings at false (safe default).
+      });
   }, []);
 
   const handleSyncToggle = async () => {
     const next = !syncRatings;
     setSyncRatings(next);
-    await updateSettings({ sync_ratings_to_trakt: next });
+    try {
+      await updateSettings({ sync_ratings_to_trakt: next });
+    } catch {
+      setSyncRatings(!next); // rollback on failure
+    }
   };
 
   const handleLogout = async () => {
@@ -111,15 +119,16 @@ export default function Nav({ mediaType, setMediaType }) {
         >
           Report Issue
         </button>
-        <label className="flex items-center justify-between w-full cursor-pointer py-2 group">
-          <span className="text-[#F5F0E8]/30 group-hover:text-[#F5F0E8]/60 font-headline font-bold uppercase text-xs tracking-widest transition-colors">
+        <div className="flex items-center justify-between w-full py-2 group">
+          <span className="text-[#F5F0E8]/30 group-hover:text-[#F5F0E8]/60 font-headline font-bold uppercase text-xs tracking-widest transition-colors cursor-default">
             Sync to Trakt
           </span>
           <button
             role="switch"
             aria-checked={syncRatings}
+            aria-label="Sync to Trakt"
             onClick={handleSyncToggle}
-            className={`relative w-9 h-5 rounded-full transition-colors ${
+            className={`relative w-9 h-5 rounded-full transition-colors cursor-pointer ${
               syncRatings ? "bg-primary-container" : "bg-[#F5F0E8]/20"
             }`}
           >
@@ -129,7 +138,7 @@ export default function Nav({ mediaType, setMediaType }) {
               }`}
             />
           </button>
-        </label>
+        </div>
         <button
           onClick={handleLogout}
           className="w-full text-[#F5F0E8]/30 hover:text-[#F5F0E8]/60 font-headline font-bold uppercase text-xs tracking-widest py-2 transition-colors"

--- a/frontend/src/components/Nav.jsx
+++ b/frontend/src/components/Nav.jsx
@@ -1,6 +1,6 @@
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import { Link, useLocation } from "react-router-dom";
-import { logout } from "../api";
+import { logout, getMe, updateSettings } from "../api";
 import ReportIssueModal from "./ReportIssueModal";
 
 const navItems = [
@@ -14,6 +14,19 @@ const navItems = [
 export default function Nav({ mediaType, setMediaType }) {
   const location = useLocation();
   const [showFeedback, setShowFeedback] = useState(false);
+  const [syncRatings, setSyncRatings] = useState(false);
+
+  useEffect(() => {
+    getMe().then((user) => {
+      if (user) setSyncRatings(user.sync_ratings_to_trakt);
+    });
+  }, []);
+
+  const handleSyncToggle = async () => {
+    const next = !syncRatings;
+    setSyncRatings(next);
+    await updateSettings({ sync_ratings_to_trakt: next });
+  };
 
   const handleLogout = async () => {
     await logout();
@@ -98,6 +111,25 @@ export default function Nav({ mediaType, setMediaType }) {
         >
           Report Issue
         </button>
+        <label className="flex items-center justify-between w-full cursor-pointer py-2 group">
+          <span className="text-[#F5F0E8]/30 group-hover:text-[#F5F0E8]/60 font-headline font-bold uppercase text-xs tracking-widest transition-colors">
+            Sync to Trakt
+          </span>
+          <button
+            role="switch"
+            aria-checked={syncRatings}
+            onClick={handleSyncToggle}
+            className={`relative w-9 h-5 rounded-full transition-colors ${
+              syncRatings ? "bg-primary-container" : "bg-[#F5F0E8]/20"
+            }`}
+          >
+            <span
+              className={`absolute top-0.5 left-0.5 w-4 h-4 bg-[#0F0E0D] rounded-full transition-transform ${
+                syncRatings ? "translate-x-4" : ""
+              }`}
+            />
+          </button>
+        </label>
         <button
           onClick={handleLogout}
           className="w-full text-[#F5F0E8]/30 hover:text-[#F5F0E8]/60 font-headline font-bold uppercase text-xs tracking-widest py-2 transition-colors"


### PR DESCRIPTION
## Summary
Fixes #173: Adds user opt-in requirement for automatic ELO-to-Trakt rating synchronization.

The application was previously pushing ELO-derived ratings (1-10 scale) to Trakt automatically after every duel without user consent. Since Trakt ratings are public by default, this behavior violated user privacy and data control principles. This PR adds an explicit opt-in toggle that defaults to opt-out for all users.

## Changes
- **Backend**:
  - Add `sync_ratings_to_trakt` boolean field to User model (defaults to False)
  - Create Alembic migration 016 to add the database column
  - Guard background task `_sync_ratings_background()` with opt-in check
  - Add `PATCH /api/me/settings` endpoint to manage user preferences
  - Update `UserResponse` schema to include new setting

- **Frontend**:
  - Add `updateSettings()` API function to send setting changes to backend
  - Add toggle UI in Navigation component for users to opt-in/out

- **Tests**:
  - Add opt-in/opt-out test coverage for background task
  - Fix existing `test_user_response` to account for new field

## Validation
✅ All tests pass:
- Backend: 331 tests passed
- Frontend: 112 tests passed  
- Frontend build: Success

## Technical Details
**Root cause**: The background task guarded only on `user.trakt_access_token` existence, with no per-user preference check.

**Solution approach**: 
1. Add opt-in toggle to User model (defaults to False for privacy)
2. Check toggle in background task guard condition
3. Expose toggle via PATCH API endpoint for user control
4. Add UI toggle in Navigation component

**Backwards compatibility**: Existing users default to opt-out (privacy-safe). Users must explicitly enable syncing.

Fixes #173