### PR TITLE
Fix: add row locking to prevent ELO race condition in duels

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -54,7 +54,7 @@ def _scrub_sensitive(event: dict, hint: dict) -> dict:
     """Strip OAuth tokens and secret keys from Sentry stack frame locals.
 
     Scrubs using two strategies:
-    - Exact match against _SCRUB_KEYS (explicit allowlist of known sensitive fields)
+    - Exact match against _SCRUB_KEYS (denylist of known sensitive fields)
     - Substring match: any local variable whose name contains "token" or "secret"
       (case-insensitive) is also filtered, covering future fields automatically.
 

--- a/backend/services/duel.py
+++ b/backend/services/duel.py
@@ -106,8 +106,10 @@ async def process_duel(
     first_id, second_id = sorted([movie_a_id, movie_b_id])
     first_um = await get_user_movie(db, user_id, first_id, for_update=True)
     second_um = await get_user_movie(db, user_id, second_id, for_update=True)
-    um_a = first_um if first_id == movie_a_id else second_um
-    um_b = second_um if first_id == movie_a_id else first_um
+    if first_id == movie_a_id:
+        um_a, um_b = first_um, second_um
+    else:
+        um_a, um_b = second_um, first_um
 
     um_a_seen_was_none = um_a.seen is None
     um_b_seen_was_none = um_b.seen is None

--- a/backend/services/duel.py
+++ b/backend/services/duel.py
@@ -69,12 +69,18 @@ class ProcessDuelResult:
 
 
 async def get_user_movie(
-    db: AsyncSession, user_id: uuid.UUID, movie_id: uuid.UUID
+    db: AsyncSession,
+    user_id: uuid.UUID,
+    movie_id: uuid.UUID,
+    *,
+    for_update: bool = False,
 ) -> UserMovie:
     """Fetch an existing UserMovie or raise if not found."""
     stmt = select(UserMovie).where(
         UserMovie.user_id == user_id, UserMovie.movie_id == movie_id
     )
+    if for_update:
+        stmt = stmt.with_for_update()
     result = await db.execute(stmt)
     um = result.scalar_one_or_none()
     if not um:
@@ -96,8 +102,12 @@ async def process_duel(
     FastAPI dependency).  Returns a ``DuelResult`` ready to send to the client.
     """
     # ── Fetch / create user_movies ──────────────────────────────────
-    um_a = await get_user_movie(db, user_id, movie_a_id)
-    um_b = await get_user_movie(db, user_id, movie_b_id)
+    # Acquire row locks in deterministic UUID order to prevent deadlocks
+    first_id, second_id = sorted([movie_a_id, movie_b_id])
+    first_um = await get_user_movie(db, user_id, first_id, for_update=True)
+    second_um = await get_user_movie(db, user_id, second_id, for_update=True)
+    um_a = first_um if first_id == movie_a_id else second_um
+    um_b = second_um if first_id == movie_a_id else first_um
 
     um_a_seen_was_none = um_a.seen is None
     um_b_seen_was_none = um_b.seen is None

--- a/backend/tests/test_duel_service.py
+++ b/backend/tests/test_duel_service.py
@@ -52,17 +52,23 @@ def _make_fake_execute(
             else:
                 result.scalar_one.return_value = total_seen
             return result
-        # UserMovie select queries — extract movie_id from WHERE clause
+        # UserMovie select queries — extract movie_id from WHERE clause.
+        # We introspect the SQLAlchemy AST (.whereclause.clauses[1].right.value)
+        # because sorted lock order makes call-order dispatch incorrect.
+        # If SQLAlchemy changes its AST layout, the except raises loudly so the
+        # failure is immediately visible rather than producing a confusing ValueError.
         try:
             movie_id = stmt.whereclause.clauses[1].right.value
             if movie_id in movie_map:
                 result.scalar_one_or_none.return_value = movie_map[movie_id]
                 return result
-        except (AttributeError, IndexError):
-            pass
-        # Fallback for any additional queries
-        result.scalar_one.return_value = seen_unranked
-        return result
+            raise AssertionError(
+                f"movie_id {movie_id!r} not in movie_map {list(movie_map)}"
+            )
+        except (AttributeError, IndexError) as exc:
+            raise AssertionError(
+                f"Failed to extract movie_id from WHERE clause — SQLAlchemy AST may have changed: {exc}"
+            ) from exc
 
     return fake_execute
 
@@ -87,6 +93,31 @@ async def test_get_user_movie_existing():
 
     um = await get_user_movie(db, uid, mid)
     assert um is existing
+
+
+@pytest.mark.asyncio
+async def test_get_user_movie_with_for_update():
+    """Verify that for_update=True causes with_for_update() to be applied to the statement."""
+    uid = uuid.uuid4()
+    mid = uuid.uuid4()
+    existing = _make_user_movie(uid, mid)
+
+    captured_stmts = []
+
+    async def capturing_execute(stmt):
+        captured_stmts.append(stmt)
+        result = MagicMock()
+        result.scalar_one_or_none.return_value = existing
+        return result
+
+    db = AsyncMock()
+    db.execute = capturing_execute
+
+    um = await get_user_movie(db, uid, mid, for_update=True)
+    assert um is existing
+    assert len(captured_stmts) == 1
+    # SQLAlchemy Select.__str__() includes "FOR UPDATE" when with_for_update() is applied
+    assert "FOR UPDATE" in str(captured_stmts[0]).upper()
 
 
 @pytest.mark.asyncio
@@ -131,6 +162,34 @@ async def test_process_duel_a_wins_elo():
     assert um_b.battles == 6
     assert um_a.seen is True
     assert um_b.seen is True
+
+
+@pytest.mark.asyncio
+async def test_process_duel_a_wins_reversed_sort_order():
+    """
+    When movie_b_id sorts before movie_a_id in UUID order, um_a/um_b must still
+    refer to the correct movies. This exercises the 'else' branch at duel.py:109-110.
+    """
+    uid = uuid.uuid4()
+    # Force movie_b_id < movie_a_id lexicographically
+    mid_b = uuid.UUID("00000000-0000-0000-0000-000000000001")
+    mid_a = uuid.UUID("ffffffff-ffff-ffff-ffff-ffffffffffff")
+
+    um_a = _make_user_movie(uid, mid_a, elo=1000, battles=5)
+    um_b = _make_user_movie(uid, mid_b, elo=1000, battles=5)
+
+    db = AsyncMock()
+    db.execute = _make_fake_execute(um_a, um_b)
+
+    result = await process_duel(db, uid, mid_a, mid_b, "a_wins", "discovery")
+
+    # A is the winner — must gain ELO regardless of UUID sort order
+    assert result.api_result.movie_a_elo_delta > 0, "A (winner) should gain ELO"
+    assert result.api_result.movie_b_elo_delta < 0, "B (loser) should lose ELO"
+    assert um_a.seen is True
+    assert um_b.seen is True
+    assert um_a.battles == 6
+    assert um_b.battles == 6
 
 
 # ---------------------------------------------------------------------------

--- a/backend/tests/test_duel_service.py
+++ b/backend/tests/test_duel_service.py
@@ -35,33 +35,31 @@ def _make_user_movie(
 def _make_fake_execute(
     um_a: MagicMock, um_b: MagicMock, seen_unranked: int = 5, total_seen: int = 20
 ):
-    """Build a fake db.execute that dispatches by SQL statement content, not call order."""
-    returned_a = False
-    returned_b = False
+    """Build a fake db.execute that dispatches by movie_id bound parameter."""
+    movie_map = {
+        um_a.movie_id: um_a,
+        um_b.movie_id: um_b,
+    }
 
     async def fake_execute(stmt):
-        nonlocal returned_a, returned_b
         result = MagicMock()
         stmt_str = str(stmt)
         # Count queries (contain 'count')
         if "count" in stmt_str.lower():
             # Distinguish seen_unranked (battles == 0) from total_seen
-            if "battles" in stmt_str.lower() or (
-                not returned_a and "count" in stmt_str.lower()
-            ):
+            if "battles" in stmt_str.lower():
                 result.scalar_one.return_value = seen_unranked
             else:
                 result.scalar_one.return_value = total_seen
             return result
-        # UserMovie select queries — return um_a first, then um_b
-        if not returned_a:
-            returned_a = True
-            result.scalar_one_or_none.return_value = um_a
-            return result
-        if not returned_b:
-            returned_b = True
-            result.scalar_one_or_none.return_value = um_b
-            return result
+        # UserMovie select queries — extract movie_id from WHERE clause
+        try:
+            movie_id = stmt.whereclause.clauses[1].right.value
+            if movie_id in movie_map:
+                result.scalar_one_or_none.return_value = movie_map[movie_id]
+                return result
+        except (AttributeError, IndexError):
+            pass
         # Fallback for any additional queries
         result.scalar_one.return_value = seen_unranked
         return result


### PR DESCRIPTION
## Summary

Fixes #170 — Race condition in `get_user_movie()` where concurrent duel submissions corrupt ELO rankings and undercount battles due to missing row locking.

## Problem

When two duels are processed concurrently for the same `UserMovie`, both transactions read the stale ELO/battles values, compute ELO deltas from the same baseline, and both commit. This results in:
- `battles` undercounted (N+2 becomes N+1)
- `ELO` reflecting only one of the two duels

Root cause: `get_user_movie()` uses a plain `SELECT` with no row lock (`.with_for_update()`).

## Changes

### `backend/services/duel.py`

**1. Add `for_update` parameter to `get_user_movie()`** (lines 71-82)
- Add optional `for_update: bool = False` parameter
- Apply `.with_for_update()` to statement when `for_update=True`
- Maintains backward compatibility with existing callers

**2. Acquire row locks in deterministic order in `process_duel()`** (lines 99-100)
- Sort movie IDs to establish consistent lock order: `sorted([movie_a_id, movie_b_id])`
- Pass `for_update=True` to both `get_user_movie()` calls
- Prevents deadlocks by eliminating circular-wait conditions

### `backend/tests/test_duel_service.py`

Updated test mock to dispatch by `movie_id` extracted from SQLAlchemy statement, since sorted lock order changed fetch order.

## Implementation Details

The fix mirrors the existing correct pattern from `backend/services/tournament.py:363-376`, which already uses `.with_for_update()` for row locking before ELO updates.

Lock order invariant:
```
Transaction A: locks[movie_1, movie_2]
Transaction B: locks[movie_1, movie_2]  # Same order due to sort
```

This eliminates circular-wait deadlock:
- ~~T1 locks A, waits for B; T2 locks B, waits for A~~
- ✅ T1 locks A then B; T2 waits for A, then locks A and B in same order

## Validation

All tests pass:
- ✅ **Backend tests**: 335 passed, 0 failed
- ✅ **Frontend tests**: 119 passed, 0 failed  
- ✅ **Python syntax**: No errors
- ✅ **Frontend build**: Compiled successfully

Database behavior:
- PostgreSQL (production): `FOR UPDATE` fully supported, row locks enforced
- SQLite (tests): Silently ignores `FOR UPDATE`, tests unaffected

---

Fixes #170