### PR TITLE
Fix: tighten CSV export rate limit from 6/minute to 10/hour (#172)

### DIFF
--- a/backend/routers/rankings.py
+++ b/backend/routers/rankings.py
@@ -114,7 +114,7 @@ async def get_stats(
 
 
 @router.get("/export/csv")
-@limiter.limit("6/minute")  # CSV generation is expensive; tighter than other endpoints
+@limiter.limit("10/hour")  # per-user via _rate_limit_key; 10 exports/hour is ample for CSV downloads
 async def export_csv(
     request: Request,
     current_user: User = Depends(get_current_user),

--- a/backend/tests/test_auth.py
+++ b/backend/tests/test_auth.py
@@ -14,6 +14,8 @@ import pytest
 from fastapi import HTTPException
 
 from backend.config import Settings
+from backend.rate_limit import limiter
+from backend.schemas import UserSettingsUpdate
 from starlette.requests import Request as StarletteRequest
 
 from backend.routers.auth import (
@@ -365,8 +367,6 @@ def _make_starlette_request() -> StarletteRequest:
         "client": ("127.0.0.1", 12345),
         "app": MagicMock(),
     }
-    scope["app"].state = MagicMock()
-    scope["app"].state.limiter = MagicMock()
     scope["app"].state.limiter.enabled = False
     return StarletteRequest(scope)
 
@@ -406,9 +406,6 @@ class TestUpdateSettings:
     @pytest.mark.asyncio
     async def test_update_settings_disables_sync(self, monkeypatch):
         """Disables sync: sets flag to False and returns updated response."""
-        from backend.schemas import UserSettingsUpdate
-        from backend.rate_limit import limiter
-
         monkeypatch.setattr(limiter, "enabled", False)
 
         user = self._make_user(sync_ratings=True)

--- a/backend/tests/test_rate_limiting.py
+++ b/backend/tests/test_rate_limiting.py
@@ -42,6 +42,15 @@ def test_export_csv_is_registered_with_rate_limiter():
     assert "backend.routers.rankings.export_csv" in limiter._Limiter__marked_for_limiting
 
 
+def test_export_csv_rate_limit_is_10_per_hour():
+    """export_csv rate limit must be exactly 10/hour (not 6/minute or any other value)."""
+    limits = limiter._route_limits.get("backend.routers.rankings.export_csv", [])
+    limit_strings = [str(lim.limit) for lim in limits]
+    assert any("10 per 1 hour" in s for s in limit_strings), (
+        f"Expected '10/hour' limit on export_csv, got: {limit_strings}"
+    )
+
+
 def test_list_tournaments_is_registered_with_rate_limiter():
     """list_tournaments must be registered in the slowapi limiter."""
     assert "backend.routers.tournaments.list_tournaments" in limiter._Limiter__marked_for_limiting

--- a/backend/tests/test_rate_limiting.py
+++ b/backend/tests/test_rate_limiting.py
@@ -1,4 +1,4 @@
-"""Tests for rate limiting enforcement and SQL cap boundaries on PR #223 endpoints."""
+"""Tests for rate limiting enforcement and SQL cap boundaries."""
 
 from __future__ import annotations
 
@@ -44,6 +44,10 @@ def test_export_csv_is_registered_with_rate_limiter():
 
 def test_export_csv_rate_limit_is_10_per_hour():
     """export_csv rate limit must be exactly 10/hour (not 6/minute or any other value)."""
+    # _route_limits is a private slowapi API (single-underscore, not name-mangled).
+    # Intentional: consistent with _Limiter__marked_for_limiting usage above.
+    # If a slowapi upgrade renames this, the test will error loudly — which is correct.
+    # slowapi is pinned with --require-hashes in requirements.txt (see PR #237).
     limits = limiter._route_limits.get("backend.routers.rankings.export_csv", [])
     limit_strings = [str(lim.limit) for lim in limits]
     assert any("10 per 1 hour" in s for s in limit_strings), (


### PR DESCRIPTION
## Summary

Fixes the rate limit on `/api/rankings/export/csv` endpoint. The limit was set to `"6/minute"` (360/hour) which is 36× more permissive than the required `"10/hour"`. 

This is a security fix for FD-010: the endpoint was protected but not to spec. PR #239 contained the correct fix but was closed without merging, leaving the wrong limit in place.

## Changes

### `backend/routers/rankings.py` (line 117)
- Changed rate limit decorator from `@limiter.limit("6/minute")` to `@limiter.limit("10/hour")`
- Updated comment to reflect per-user keying via `_rate_limit_key`

### `backend/tests/test_rate_limiting.py` (new test)
- Added `test_export_csv_rate_limit_is_10_per_hour()` to pin the exact limit value
- Prevents regression to wrong limit values (like "6/minute")

## Validation

✅ All tests pass: 338 passed, 0 failed  
✅ Lint checks pass: ruff clean  
✅ New test validates the exact limit value  

The per-user rate limit keying (FD-003) is already complete in `rate_limit.py`, so the correct limit can be applied immediately.

## Issue

Fixes #172