### PR TITLE
Fix: add public domain smoke test to deploy pipeline

### DIFF
--- a/.github/workflows/staging-pipeline.yml
+++ b/.github/workflows/staging-pipeline.yml
@@ -130,6 +130,24 @@ jobs:
           echo "Production health check failed after 5 attempts"
           exit 1
 
+      - name: Smoke test production public domain
+        run: |
+          echo "=== /health (public domain) ==="
+          curl -sf --max-time 10 "https://filmduel.up.railway.app/health" | grep -q '"status":"ok"'
+          echo "PASS: /health"
+
+          echo "=== / (React SPA, public domain) ==="
+          STATUS=$(curl -o /dev/null -s -w "%{http_code}" --max-time 10 "https://filmduel.up.railway.app/")
+          [ "$STATUS" = "200" ] || { echo "FAIL: / returned $STATUS"; exit 1; }
+          echo "PASS: / returned $STATUS"
+
+          echo "=== /api/rankings (public domain) ==="
+          STATUS=$(curl -o /dev/null -s -w "%{http_code}" --max-time 10 "https://filmduel.up.railway.app/api/rankings")
+          [ "$STATUS" = "200" ] || [ "$STATUS" = "401" ] || [ "$STATUS" = "403" ] || {
+            echo "FAIL: /api/rankings returned unexpected $STATUS"; exit 1;
+          }
+          echo "PASS: /api/rankings returned $STATUS"
+
       - name: Record production deployment on GitHub
         if: always()
         env:


### PR DESCRIPTION
## Summary

Adds production public domain smoke tests to the deploy pipeline to catch failures like the HTTP 404 on `https://filmduel.up.railway.app` that went undetected in #128.

## Changes

- **File**: `.github/workflows/staging-pipeline.yml`
- **Action**: Added new "Smoke test production public domain" step in the `deploy-production` job after the health check
- **Scope**: The new step performs three hardcoded smoke tests against `https://filmduel.up.railway.app`:
  1. `/health` endpoint verification
  2. `/` (React SPA) returns 200
  3. `/api/rankings` returns valid status code

## Root Cause Analysis

The production deployment (`https://filmduel.up.railway.app`) returned HTTP 404 due to the custom domain being unmapped in the Railway dashboard. The pipeline reported "success" because `PRODUCTION_URL` (a GitHub secret) points to an internal Railway URL that remains reachable even when the public domain is broken. This is a blind spot in the CI/CD pipeline.

**Why this fix helps**:
- The new smoke test step hardcodes the public production domain, removing the dependency on the `PRODUCTION_URL` secret for production verification
- Any future failures in public domain routing will be caught immediately during deployment
- Mirrors the existing staging smoke tests pattern already in the codebase

## Validation

✅ **YAML syntax**: Valid  
✅ **Backend tests**: 343 passed, 0 failed  
✅ **Frontend tests**: 119 passed  
✅ **Frontend build**: Successful  

## Manual Steps Required

The following manual actions are required by the repository owner to fully resolve the issue:

1. **Railway dashboard**: Re-add the custom domain `filmduel.up.railway.app` to the web service
   - Navigate to [Railway project](https://railway.com/project/f69eb9d2-62ab-429e-8d39-6934633dd865?environmentId=b2aa1747-83f1-42d0-bfdf-0894beaad882)
   - Go to the **web** service → **Settings** → **Networking / Domains**
   - Re-add the custom domain

2. **GitHub secret**: Update `PRODUCTION_URL` to `https://filmduel.up.railway.app`
   - Navigate to repository Settings → Secrets and variables → Actions
   - Update the `PRODUCTION_URL` secret value

Fixes #128