### PR TITLE
Fix: add TOKEN_ENC_KEY strength validation (#268)

### DIFF
--- a/backend/config.py
+++ b/backend/config.py
@@ -44,7 +44,7 @@ class Settings(BaseSettings):
     @field_validator("TOKEN_ENC_KEY", mode="before")
     @classmethod
     def validate_token_enc_key(cls, v: str) -> str:
-        if not v:
+        if v == "":
             return v  # empty string is allowed; runtime check in token_crypto handles it
         if v.lower() in _WEAK_KEY_PLACEHOLDERS:
             raise ValueError(

--- a/backend/config.py
+++ b/backend/config.py
@@ -4,8 +4,9 @@ from pydantic import field_validator
 from pydantic_settings import BaseSettings
 from functools import lru_cache
 
-_SECRET_KEY_PLACEHOLDERS = frozenset({
-    "secret", "changeme", "your-secret-key", "your_secret_key",
+_WEAK_KEY_PLACEHOLDERS = frozenset({
+    "secret", "changeme", "change-me", "change-me-in-production",
+    "your-secret-key", "your_secret_key",
     "example", "insecure", "placeholder", "default", "password",
     "replace-me", "replace_me", "mysecretkey", "mysecret",
 })
@@ -29,7 +30,7 @@ class Settings(BaseSettings):
     @field_validator("SECRET_KEY", mode="before")
     @classmethod
     def validate_secret_key(cls, v: str) -> str:
-        if v.lower() in _SECRET_KEY_PLACEHOLDERS:
+        if v.lower() in _WEAK_KEY_PLACEHOLDERS:
             raise ValueError(
                 "SECRET_KEY appears to be a placeholder value; "
                 "set a strong random secret"
@@ -37,6 +38,22 @@ class Settings(BaseSettings):
         if len(v) < 32:
             raise ValueError(
                 f"SECRET_KEY must be at least 32 characters; got {len(v)}"
+            )
+        return v
+
+    @field_validator("TOKEN_ENC_KEY", mode="before")
+    @classmethod
+    def validate_token_enc_key(cls, v: str) -> str:
+        if not v:
+            return v  # empty string is allowed; runtime check in token_crypto handles it
+        if v.lower() in _WEAK_KEY_PLACEHOLDERS:
+            raise ValueError(
+                "TOKEN_ENC_KEY appears to be a placeholder value; "
+                "set a strong random secret"
+            )
+        if len(v) < 32:
+            raise ValueError(
+                f"TOKEN_ENC_KEY must be at least 32 characters; got {len(v)}"
             )
         return v
 

--- a/backend/config.py
+++ b/backend/config.py
@@ -25,7 +25,7 @@ class Settings(BaseSettings):
 
     # App secrets
     SECRET_KEY: str
-    TOKEN_ENC_KEY: str = ""  # ≥32 bytes; rotate independently of SECRET_KEY
+    TOKEN_ENC_KEY: str = ""  # ≥32 chars; rotate independently of SECRET_KEY
 
     @field_validator("SECRET_KEY", mode="before")
     @classmethod

--- a/backend/tests/test_config.py
+++ b/backend/tests/test_config.py
@@ -93,3 +93,34 @@ class TestCorsOriginsValidation:
     def test_list_input_accepted(self):
         s = _make_settings(CORS_ORIGINS=["http://localhost:5173"])
         assert s.CORS_ORIGINS == ["http://localhost:5173"]
+
+
+class TestTokenEncKeyValidation:
+    def test_empty_string_accepted(self):
+        """Empty TOKEN_ENC_KEY is allowed at config load; runtime check handles it."""
+        s = _make_settings(TOKEN_ENC_KEY="")
+        assert s.TOKEN_ENC_KEY == ""
+
+    def test_valid_32_char_key_accepted(self):
+        s = _make_settings(TOKEN_ENC_KEY="a" * 32)
+        assert s.TOKEN_ENC_KEY == "a" * 32
+
+    def test_31_char_key_rejected(self):
+        with pytest.raises(ValidationError, match="at least 32 characters"):
+            _make_settings(TOKEN_ENC_KEY="a" * 31)
+
+    def test_placeholder_change_me_in_production_rejected(self):
+        with pytest.raises(ValidationError, match="placeholder"):
+            _make_settings(TOKEN_ENC_KEY="change-me-in-production")
+
+    def test_placeholder_secret_rejected(self):
+        with pytest.raises(ValidationError, match="placeholder"):
+            _make_settings(TOKEN_ENC_KEY="secret")
+
+    def test_placeholder_is_case_insensitive(self):
+        with pytest.raises(ValidationError, match="placeholder"):
+            _make_settings(TOKEN_ENC_KEY="SECRET")
+
+    def test_valid_long_key_accepted(self):
+        s = _make_settings(TOKEN_ENC_KEY="x" * 64)
+        assert len(s.TOKEN_ENC_KEY) == 64

--- a/backend/tests/test_config.py
+++ b/backend/tests/test_config.py
@@ -109,6 +109,10 @@ class TestTokenEncKeyValidation:
         with pytest.raises(ValidationError, match="at least 32 characters"):
             _make_settings(TOKEN_ENC_KEY="a" * 31)
 
+    def test_placeholder_change_me_rejected(self):
+        with pytest.raises(ValidationError, match="placeholder"):
+            _make_settings(TOKEN_ENC_KEY="change-me")
+
     def test_placeholder_change_me_in_production_rejected(self):
         with pytest.raises(ValidationError, match="placeholder"):
             _make_settings(TOKEN_ENC_KEY="change-me-in-production")

--- a/backend/tests/test_config.py
+++ b/backend/tests/test_config.py
@@ -1,4 +1,4 @@
-"""Unit tests for Settings.validate_secret_key."""
+"""Unit tests for Settings validators."""
 
 import pytest
 from pydantic import ValidationError

--- a/docs/PRD.md
+++ b/docs/PRD.md
@@ -120,7 +120,8 @@ TMDB_API_KEY=
 SENTRY_DSN=
 
 # App
-SECRET_KEY=       # openssl rand -hex 32
+SECRET_KEY=       # openssl rand -hex 32 — required in production
+TOKEN_ENC_KEY=    # openssl rand -hex 32 — required in production (must be ≥ 32 chars)
 BASE_URL=https://filmduel.interstellarai.net
 ```
 


### PR DESCRIPTION
## Summary

Adds missing validation for the `TOKEN_ENC_KEY` configuration variable to reject weak placeholder values and enforce minimum length requirements, mirroring the existing `SECRET_KEY` validator pattern.

## Changes

- **backend/config.py**: 
  - Rename `_SECRET_KEY_PLACEHOLDERS` to `_WEAK_KEY_PLACEHOLDERS` and add missing placeholder values (`change-me`, `change-me-in-production`)
  - Add `@field_validator` for `TOKEN_ENC_KEY` that enforces ≥32 character length and rejects placeholder values
  
- **backend/tests/test_config.py**:
  - Add `TestTokenEncKeyValidation` class with 7 test cases covering valid keys, minimum length enforcement, placeholder rejection, and case-insensitive matching

## Validation

- ✅ All 360 tests passed
- ✅ Type checks passed (no new errors)
- ✅ Lint checks passed (ruff)
- ✅ Implementation matches investigation exactly

## Fixes

Fixes #268