### PR TITLE
Fix: clear session cookie on auth failure

### DIFF
--- a/backend/routers/auth.py
+++ b/backend/routers/auth.py
@@ -113,6 +113,11 @@ async def get_current_user_id(
     token = request.cookies.get(COOKIE_NAME)
     if not token:
         raise HTTPException(status_code=401, detail="Not authenticated")
+
+    def _reject(detail: str) -> None:
+        response.delete_cookie(COOKIE_NAME)
+        raise HTTPException(status_code=401, detail=detail)
+
     try:
         payload = jwt.decode(
             token,
@@ -126,35 +131,33 @@ async def get_current_user_id(
         raw_orig = payload.get("orig_iat")
         if raw_orig is not None:
             if not isinstance(raw_orig, (int, float)):
-                raise HTTPException(status_code=401, detail="Invalid session")
+                _reject("Invalid session")
             orig_iat = datetime.fromtimestamp(float(raw_orig), tz=timezone.utc)
         else:
             orig_iat = iat  # legacy tokens: treat iat as orig_iat
         if not user_id:
-            raise HTTPException(
-                status_code=401, detail="Invalid session — missing subject"
-            )
+            _reject("Invalid session — missing subject")
     except jwt.ExpiredSignatureError:
-        raise HTTPException(status_code=401, detail="Session expired")
+        _reject("Session expired")
     except jwt.InvalidTokenError:
-        raise HTTPException(status_code=401, detail="Invalid session")
+        _reject("Invalid session")
 
     # Server-side revocation: catches logout from another device or admin revoke.
     invalid_before = await db.scalar(
         select(User.tokens_invalid_before).where(User.id == uuid.UUID(user_id))
     )
     if invalid_before is None:
-        raise HTTPException(status_code=401, detail="User not found")
+        _reject("User not found")
     if invalid_before.tzinfo is None:
         invalid_before = invalid_before.replace(tzinfo=timezone.utc)
     if iat < invalid_before:
-        raise HTTPException(status_code=401, detail="Session revoked")
+        _reject("Session revoked")
 
     now = datetime.now(timezone.utc)
 
     # Hard cap: absolute 30-day session lifetime regardless of activity.
     if now - orig_iat > SESSION_MAX_LIFETIME:
-        raise HTTPException(status_code=401, detail="Session expired")
+        _reject("Session expired")
 
     # Sliding refresh: only re-issue if the token is older than REFRESH_INTERVAL.
     if now - iat > REFRESH_INTERVAL:

--- a/backend/routers/auth.py
+++ b/backend/routers/auth.py
@@ -6,6 +6,7 @@ import logging
 import secrets
 import uuid
 from datetime import datetime, timedelta, timezone
+from typing import NoReturn
 from urllib.parse import urlencode
 
 import jwt
@@ -114,7 +115,7 @@ async def get_current_user_id(
     if not token:
         raise HTTPException(status_code=401, detail="Not authenticated")
 
-    def _reject(detail: str) -> None:
+    def _reject(detail: str) -> NoReturn:
         response.delete_cookie(COOKIE_NAME)
         raise HTTPException(status_code=401, detail=detail)
 

--- a/backend/tests/test_auth.py
+++ b/backend/tests/test_auth.py
@@ -68,6 +68,21 @@ def _make_response() -> MagicMock:
     return MagicMock()
 
 
+def _make_jwt_payload(**overrides) -> dict:
+    """Build a JWT payload dict with test defaults; use overrides for per-test variations."""
+    now = datetime.now(timezone.utc)
+    base = {
+        "sub": "550e8400-e29b-41d4-a716-446655440000",
+        "jti": "x",
+        "iss": "filmduel",
+        "aud": "filmduel",
+        "exp": now + timedelta(hours=1),
+        "iat": now - timedelta(hours=1),
+    }
+    base.update(overrides)
+    return base
+
+
 # ---------------------------------------------------------------------------
 # create_jwt
 # ---------------------------------------------------------------------------
@@ -320,15 +335,7 @@ class TestGetCurrentUserId:
         """A session older than SESSION_MAX_DAYS must be rejected even if JWT is fresh."""
         monkeypatch.setattr("backend.routers.auth.get_settings", lambda: SETTINGS)
         orig = datetime.now(timezone.utc) - SESSION_MAX_LIFETIME - timedelta(hours=1)
-        payload = {
-            "sub": "550e8400-e29b-41d4-a716-446655440000",
-            "jti": "x",
-            "iss": "filmduel",
-            "aud": "filmduel",
-            "exp": datetime.now(timezone.utc) + timedelta(hours=1),
-            "iat": datetime.now(timezone.utc) - timedelta(hours=1),
-            "orig_iat": orig.timestamp(),
-        }
+        payload = _make_jwt_payload(orig_iat=orig.timestamp())
         token = pyjwt.encode(payload, SETTINGS.SECRET_KEY, algorithm=JWT_ALGORITHM)
         request = _make_request({COOKIE_NAME: token})
         response = _make_response()
@@ -344,15 +351,7 @@ class TestGetCurrentUserId:
         monkeypatch.setattr("backend.routers.auth.get_settings", lambda: SETTINGS)
         orig = datetime.now(timezone.utc) - timedelta(days=5)
         old_iat = datetime.now(timezone.utc) - REFRESH_INTERVAL - timedelta(hours=1)
-        payload = {
-            "sub": "550e8400-e29b-41d4-a716-446655440000",
-            "jti": "x",
-            "iss": "filmduel",
-            "aud": "filmduel",
-            "exp": datetime.now(timezone.utc) + timedelta(hours=1),
-            "iat": old_iat,
-            "orig_iat": orig.timestamp(),
-        }
+        payload = _make_jwt_payload(iat=old_iat, orig_iat=orig.timestamp())
         token = pyjwt.encode(payload, SETTINGS.SECRET_KEY, algorithm=JWT_ALGORITHM)
         request = _make_request({COOKIE_NAME: token})
         response = _make_response()
@@ -373,15 +372,7 @@ class TestGetCurrentUserId:
     async def test_legacy_token_without_orig_iat_accepted(self, monkeypatch):
         """Tokens missing orig_iat (issued before the fix) should still work."""
         monkeypatch.setattr("backend.routers.auth.get_settings", lambda: SETTINGS)
-        payload = {
-            "sub": "550e8400-e29b-41d4-a716-446655440000",
-            "jti": "x",
-            "iss": "filmduel",
-            "aud": "filmduel",
-            "exp": datetime.now(timezone.utc) + timedelta(hours=1),
-            "iat": datetime.now(timezone.utc) - timedelta(hours=1),
-            # no orig_iat
-        }
+        payload = _make_jwt_payload()  # no orig_iat — simulates a pre-fix token
         token = pyjwt.encode(payload, SETTINGS.SECRET_KEY, algorithm=JWT_ALGORITHM)
         request = _make_request({COOKIE_NAME: token})
         response = _make_response()
@@ -393,15 +384,7 @@ class TestGetCurrentUserId:
         """Refreshing a legacy token should set orig_iat = iat in the new token."""
         monkeypatch.setattr("backend.routers.auth.get_settings", lambda: SETTINGS)
         old_iat = datetime.now(timezone.utc) - REFRESH_INTERVAL - timedelta(hours=1)
-        payload = {
-            "sub": "550e8400-e29b-41d4-a716-446655440000",
-            "jti": "x",
-            "iss": "filmduel",
-            "aud": "filmduel",
-            "exp": datetime.now(timezone.utc) + timedelta(hours=1),
-            "iat": old_iat,
-            # no orig_iat — simulates a pre-fix token
-        }
+        payload = _make_jwt_payload(iat=old_iat)  # no orig_iat — simulates a pre-fix token
         token = pyjwt.encode(payload, SETTINGS.SECRET_KEY, algorithm=JWT_ALGORITHM)
         request = _make_request({COOKIE_NAME: token})
         response = _make_response()
@@ -425,15 +408,7 @@ class TestGetCurrentUserId:
         # Session started 29d 23h ago — 1h left before hard cap
         orig = datetime.now(timezone.utc) - SESSION_MAX_LIFETIME + timedelta(hours=1)
         old_iat = datetime.now(timezone.utc) - REFRESH_INTERVAL - timedelta(hours=1)
-        payload = {
-            "sub": "550e8400-e29b-41d4-a716-446655440000",
-            "jti": "x",
-            "iss": "filmduel",
-            "aud": "filmduel",
-            "exp": datetime.now(timezone.utc) + timedelta(hours=1),
-            "iat": old_iat,
-            "orig_iat": orig.timestamp(),
-        }
+        payload = _make_jwt_payload(iat=old_iat, orig_iat=orig.timestamp())
         token = pyjwt.encode(payload, SETTINGS.SECRET_KEY, algorithm=JWT_ALGORITHM)
         request = _make_request({COOKIE_NAME: token})
         response = _make_response()
@@ -452,15 +427,7 @@ class TestGetCurrentUserId:
         monkeypatch.setattr("backend.routers.auth.get_settings", lambda: SETTINGS)
         orig = datetime.now(timezone.utc) - timedelta(days=5)  # well within 30 days
         old_iat = datetime.now(timezone.utc) - REFRESH_INTERVAL - timedelta(hours=1)
-        payload = {
-            "sub": "550e8400-e29b-41d4-a716-446655440000",
-            "jti": "x",
-            "iss": "filmduel",
-            "aud": "filmduel",
-            "exp": datetime.now(timezone.utc) + timedelta(hours=1),
-            "iat": old_iat,
-            "orig_iat": orig.timestamp(),
-        }
+        payload = _make_jwt_payload(iat=old_iat, orig_iat=orig.timestamp())
         token = pyjwt.encode(payload, SETTINGS.SECRET_KEY, algorithm=JWT_ALGORITHM)
         request = _make_request({COOKIE_NAME: token})
         response = _make_response()
@@ -475,15 +442,7 @@ class TestGetCurrentUserId:
         # 29 days 20 hours old — only 4 hours of session lifetime remain
         orig = datetime.now(timezone.utc) - SESSION_MAX_LIFETIME + timedelta(hours=4)
         old_iat = datetime.now(timezone.utc) - REFRESH_INTERVAL - timedelta(hours=1)
-        payload = {
-            "sub": "550e8400-e29b-41d4-a716-446655440000",
-            "jti": "x",
-            "iss": "filmduel",
-            "aud": "filmduel",
-            "exp": datetime.now(timezone.utc) + timedelta(hours=1),
-            "iat": old_iat,
-            "orig_iat": orig.timestamp(),
-        }
+        payload = _make_jwt_payload(iat=old_iat, orig_iat=orig.timestamp())
         token = pyjwt.encode(payload, SETTINGS.SECRET_KEY, algorithm=JWT_ALGORITHM)
         request = _make_request({COOKIE_NAME: token})
         response = _make_response()
@@ -498,15 +457,10 @@ class TestGetCurrentUserId:
     async def test_malformed_orig_iat_raises_401(self, monkeypatch):
         """A token with a non-numeric orig_iat claim should raise 401, not 500."""
         monkeypatch.setattr("backend.routers.auth.get_settings", lambda: SETTINGS)
-        payload = {
-            "sub": "550e8400-e29b-41d4-a716-446655440000",
-            "jti": "x",
-            "iss": "filmduel",
-            "aud": "filmduel",
-            "exp": datetime.now(timezone.utc) + timedelta(hours=1),
-            "iat": datetime.now(timezone.utc),
-            "orig_iat": "not-a-timestamp",  # malformed
-        }
+        payload = _make_jwt_payload(
+            iat=datetime.now(timezone.utc),
+            orig_iat="not-a-timestamp",  # malformed
+        )
         token = pyjwt.encode(payload, SETTINGS.SECRET_KEY, algorithm=JWT_ALGORITHM)
         request = _make_request({COOKIE_NAME: token})
         response = _make_response()

--- a/backend/tests/test_auth.py
+++ b/backend/tests/test_auth.py
@@ -253,6 +253,7 @@ class TestGetCurrentUserId:
             await get_current_user_id(request, response, _make_db())
         assert exc_info.value.status_code == 401
         assert "expired" in exc_info.value.detail.lower()
+        response.delete_cookie.assert_called_once_with(COOKIE_NAME)
 
     @pytest.mark.asyncio
     async def test_invalid_token_raises_401(self, monkeypatch):
@@ -264,6 +265,7 @@ class TestGetCurrentUserId:
             await get_current_user_id(request, response, _make_db())
         assert exc_info.value.status_code == 401
         assert "Invalid session" in exc_info.value.detail
+        response.delete_cookie.assert_called_once_with(COOKIE_NAME)
 
     @pytest.mark.asyncio
     async def test_wrong_secret_raises_401(self, monkeypatch):
@@ -276,6 +278,7 @@ class TestGetCurrentUserId:
         with pytest.raises(HTTPException) as exc_info:
             await get_current_user_id(request, response, _make_db())
         assert exc_info.value.status_code == 401
+        response.delete_cookie.assert_called_once_with(COOKIE_NAME)
 
     @pytest.mark.asyncio
     async def test_token_missing_sub_raises_401(self, monkeypatch):
@@ -295,6 +298,7 @@ class TestGetCurrentUserId:
             await get_current_user_id(request, response, _make_db())
         assert exc_info.value.status_code == 401
         assert "missing subject" in exc_info.value.detail.lower()
+        response.delete_cookie.assert_called_once_with(COOKIE_NAME)
 
     @pytest.mark.asyncio
     async def test_revoked_token_raises_401(self, monkeypatch):
@@ -309,6 +313,7 @@ class TestGetCurrentUserId:
             await get_current_user_id(request, response, _make_db(future_revocation))
         assert exc_info.value.status_code == 401
         assert "revoked" in exc_info.value.detail.lower()
+        response.delete_cookie.assert_called_once_with(COOKIE_NAME)
 
     @pytest.mark.asyncio
     async def test_hard_cap_rejects_session_older_than_30_days(self, monkeypatch):
@@ -331,6 +336,7 @@ class TestGetCurrentUserId:
             await get_current_user_id(request, response, _make_db())
         assert exc_info.value.status_code == 401
         assert "expired" in exc_info.value.detail.lower()
+        response.delete_cookie.assert_called_once_with(COOKIE_NAME)
 
     @pytest.mark.asyncio
     async def test_refresh_preserves_orig_iat(self, monkeypatch):
@@ -508,6 +514,22 @@ class TestGetCurrentUserId:
             await get_current_user_id(request, response, _make_db())
         assert exc_info.value.status_code == 401
         assert "Invalid session" in exc_info.value.detail
+        response.delete_cookie.assert_called_once_with(COOKIE_NAME)
+
+    @pytest.mark.asyncio
+    async def test_user_not_found_clears_cookie(self, monkeypatch):
+        """When DB returns no user, cookie must be cleared."""
+        monkeypatch.setattr("backend.routers.auth.get_settings", lambda: SETTINGS)
+        user_id = "550e8400-e29b-41d4-a716-446655440000"
+        token = create_jwt(user_id, SETTINGS)
+        request = _make_request({COOKIE_NAME: token})
+        response = _make_response()
+        db = AsyncMock()
+        db.scalar.return_value = None  # simulate missing user
+        with pytest.raises(HTTPException) as exc_info:
+            await get_current_user_id(request, response, db)
+        assert exc_info.value.status_code == 401
+        response.delete_cookie.assert_called_once_with(COOKIE_NAME)
 
 
 # ---------------------------------------------------------------------------

--- a/backend/tests/test_auth.py
+++ b/backend/tests/test_auth.py
@@ -529,6 +529,7 @@ class TestGetCurrentUserId:
         with pytest.raises(HTTPException) as exc_info:
             await get_current_user_id(request, response, db)
         assert exc_info.value.status_code == 401
+        assert "not found" in exc_info.value.detail.lower()
         response.delete_cookie.assert_called_once_with(COOKIE_NAME)
 
 


### PR DESCRIPTION
## Summary

Fixes #266: When JWT validation fails in `get_current_user_id`, the HTTP 401 exception is raised but the invalid session cookie is not deleted from the browser. This causes the browser to repeatedly resend the stale cookie on subsequent requests, resulting in cascading 401 responses until the cookie naturally expires (up to 72 hours).

**Root cause**: `get_current_user_id` has access to the `response` object but never calls `response.delete_cookie()` before raising 401 exceptions when a token is present.

## Changes

### `backend/routers/auth.py`

- Added a local `_reject()` helper function inside `get_current_user_id` that clears the session cookie and raises HTTPException(401) in one operation
- Replaced all direct `raise HTTPException(401, ...)` statements with `_reject(...)` calls for paths where a token is present
- Pattern mirrors the existing `logout` handler which correctly clears cookies

**Affected validation paths:**
- Invalid token structure or claims
- Expired signature
- Missing subject (user ID)
- User not found in database
- Token revoked (invalidated before timestamp)
- Session absolute lifetime exceeded (30-day cap)

### `backend/tests/test_auth.py`

- Added `response.delete_cookie.assert_called_once_with(COOKIE_NAME)` assertions to 7 existing 401 test cases
- Added new test case `test_user_not_found_clears_cookie` to cover the database lookup failure path
- No assertion added to `test_no_cookie_raises_401` (nothing to delete when no cookie exists)

## Validation

**Test results**: 364 tests passed, 0 failed
- All 30 auth tests pass, including 8 tests validating cookie deletion on 401 paths
- Full test suite passes without regressions

**Manual verification**: 
1. Invalid/expired cookies now trigger a `Set-Cookie: filmduel_session=; Max-Age=0` response header
2. Subsequent requests after auth failure return "Not authenticated" instead of repeated "Invalid session" errors

## Scope

This change is isolated to the auth validation path and doesn't affect:
- The "no cookie present" path (line 115, nothing to delete)
- The logout handler (already correct)
- Cookie attributes or security settings
- Other API endpoints or authentication mechanisms

Fixes #266