### PR TITLE
Fix: remove unused 'draw' from DuelOutcome enum

### DIFF
--- a/backend/schemas.py
+++ b/backend/schemas.py
@@ -61,7 +61,6 @@ class DuelOutcome(str, Enum):
     a_only = "a_only"
     b_only = "b_only"
     neither = "neither"
-    draw = "draw"
 
 
 class DuelMode(str, Enum):

--- a/backend/tests/test_schemas.py
+++ b/backend/tests/test_schemas.py
@@ -46,6 +46,8 @@ class TestDuelOutcome:
         """'draw' is not a valid outcome; it must not exist in the enum."""
         with pytest.raises(AttributeError):
             _ = DuelOutcome.draw
+        with pytest.raises(ValueError):
+            _ = DuelOutcome("draw")
 
     def test_is_string_enum(self):
         assert isinstance(DuelOutcome.a_wins, str)

--- a/backend/tests/test_schemas.py
+++ b/backend/tests/test_schemas.py
@@ -38,10 +38,14 @@ class TestDuelOutcome:
         assert DuelOutcome.a_only == "a_only"
         assert DuelOutcome.b_only == "b_only"
         assert DuelOutcome.neither == "neither"
-        assert DuelOutcome.draw == "draw"
 
-    def test_has_exactly_six_members(self):
-        assert len(DuelOutcome) == 6
+    def test_has_exactly_five_members(self):
+        assert len(DuelOutcome) == 5
+
+    def test_draw_outcome_rejected(self):
+        """'draw' is not a valid outcome; it must not exist in the enum."""
+        with pytest.raises(AttributeError):
+            _ = DuelOutcome.draw
 
     def test_is_string_enum(self):
         assert isinstance(DuelOutcome.a_wins, str)
@@ -104,6 +108,15 @@ class TestDuelSubmit:
                 movie_a_id="550e8400-e29b-41d4-a716-446655440000",
                 movie_b_id="550e8400-e29b-41d4-a716-446655440001",
                 outcome="invalid_outcome",
+            )
+
+    def test_draw_outcome_rejected_by_schema(self):
+        """'draw' is not a valid outcome; DuelSubmit must reject it."""
+        with pytest.raises(ValidationError):
+            DuelSubmit(
+                movie_a_id="550e8400-e29b-41d4-a716-446655440000",
+                movie_b_id="550e8400-e29b-41d4-a716-446655440001",
+                outcome="draw",
             )
 
     def test_missing_movie_ids_rejected(self):


### PR DESCRIPTION
## Summary
Removes the unused `draw` value from the `DuelOutcome` enum that was never implemented in the service layer. This closes a security gap where API tampering with `outcome=\"draw\"` would create phantom Duel records with NULL ELO/movie fields.

## The Issue
The `DuelOutcome` enum includes a `draw` value, but `process_duel` has no handler for it. When a client sends `outcome="draw"`, the code falls through to an unintended branch, creating bare Duel records with NULL fields. While the UI never presents this option, it was exploitable via direct API calls.

## Changes
- **backend/schemas.py**: Removed `draw = "draw"` from DuelOutcome enum (1 line removed)
- **backend/tests/test_schemas.py**: Added regression tests confirming `draw` is rejected by schema validation and updated enum size assertion

## Validation
✅ All 373 tests pass
✅ Type checking passes (mypy)
✅ New tests confirm:
  - `draw` is no longer accepted by schema
  - `DuelOutcome` now has exactly 5 members
  - `DuelSubmit` with `outcome=\"draw\"` raises ValidationError

Fixes #263