### PR TITLE
Fix: enforce privacy policy consent on LLM-calling endpoints

### DIFF
--- a/backend/routers/suggestions.py
+++ b/backend/routers/suggestions.py
@@ -129,6 +129,14 @@ async def _create_suggestions(
     return await _get_active_suggestions(user_id, db, media_type)
 
 
+def _require_consent(user: User) -> None:
+    if not user.privacy_policy_accepted:
+        raise HTTPException(
+            status_code=403,
+            detail="Privacy policy consent required to use AI suggestions",
+        )
+
+
 @router.get("", response_model=SuggestionsResponse)
 @limiter.limit("10/minute")
 async def get_suggestions(
@@ -140,8 +148,7 @@ async def get_suggestions(
     """Return current suggestions. Generate if stale (>24h) or missing."""
     uid = current_user.id
 
-    if not current_user.privacy_policy_accepted:
-        raise HTTPException(status_code=403, detail="Privacy policy consent required to use AI suggestions")
+    _require_consent(current_user)
 
     # Check if user has enough ranked films
     if not await has_enough_ranked(uid, db, media_type=media_type):
@@ -191,8 +198,7 @@ async def regenerate_suggestions(
     """Force regeneration. Rate-limited: 3 per day."""
     uid = current_user.id
 
-    if not current_user.privacy_policy_accepted:
-        raise HTTPException(status_code=403, detail="Privacy policy consent required to use AI suggestions")
+    _require_consent(current_user)
 
     if not await has_enough_ranked(uid, db, media_type=media_type):
         return SuggestionsResponse(suggestions=[], status="not_enough_films")

--- a/backend/routers/suggestions.py
+++ b/backend/routers/suggestions.py
@@ -140,6 +140,9 @@ async def get_suggestions(
     """Return current suggestions. Generate if stale (>24h) or missing."""
     uid = current_user.id
 
+    if not current_user.privacy_policy_accepted:
+        raise HTTPException(status_code=403, detail="Privacy policy consent required to use AI suggestions")
+
     # Check if user has enough ranked films
     if not await has_enough_ranked(uid, db, media_type=media_type):
         return SuggestionsResponse(suggestions=[], status="not_enough_films")
@@ -187,6 +190,9 @@ async def regenerate_suggestions(
 ):
     """Force regeneration. Rate-limited: 3 per day."""
     uid = current_user.id
+
+    if not current_user.privacy_policy_accepted:
+        raise HTTPException(status_code=403, detail="Privacy policy consent required to use AI suggestions")
 
     if not await has_enough_ranked(uid, db, media_type=media_type):
         return SuggestionsResponse(suggestions=[], status="not_enough_films")

--- a/backend/routers/tournaments.py
+++ b/backend/routers/tournaments.py
@@ -249,6 +249,10 @@ async def regenerate_tournament(
     uid = current_user.id
     tournament = await _load_tournament(tournament_id, uid, db)
 
+    # Enforce consent before revealing any business-logic details
+    if not current_user.privacy_policy_accepted:
+        raise HTTPException(status_code=403, detail="Privacy policy consent required to use AI curation")
+
     if not tournament.is_ai_curated:
         raise HTTPException(
             status_code=400, detail="Only AI-curated tournaments can be regenerated"
@@ -269,9 +273,6 @@ async def regenerate_tournament(
         raise HTTPException(
             status_code=400, detail="Maximum regeneration attempts (3) reached"
         )
-
-    if not current_user.privacy_policy_accepted:
-        raise HTTPException(status_code=403, detail="Privacy policy consent required to use AI curation")
 
     try:
         user_movies = await get_filtered_ranked_films(

--- a/backend/routers/tournaments.py
+++ b/backend/routers/tournaments.py
@@ -110,6 +110,14 @@ async def _load_tournament(
     return tournament
 
 
+def _require_consent(user: User) -> None:
+    if not user.privacy_policy_accepted:
+        raise HTTPException(
+            status_code=403,
+            detail="Privacy policy consent required to use AI curation",
+        )
+
+
 # ── Endpoints ─────────────────────────────────────────────────────────
 
 
@@ -194,8 +202,7 @@ async def create_tournament(
     ai_llm_response = None
 
     if body.ai_curated:
-        if not current_user.privacy_policy_accepted:
-            raise HTTPException(status_code=403, detail="Privacy policy consent required to use AI curation")
+        _require_consent(current_user)
         try:
             seeded_films, llm_result = await curate_and_select_films(
                 user_movies=user_movies,
@@ -250,8 +257,7 @@ async def regenerate_tournament(
     tournament = await _load_tournament(tournament_id, uid, db)
 
     # Enforce consent before revealing any business-logic details
-    if not current_user.privacy_policy_accepted:
-        raise HTTPException(status_code=403, detail="Privacy policy consent required to use AI curation")
+    _require_consent(current_user)
 
     if not tournament.is_ai_curated:
         raise HTTPException(

--- a/backend/routers/tournaments.py
+++ b/backend/routers/tournaments.py
@@ -194,6 +194,8 @@ async def create_tournament(
     ai_llm_response = None
 
     if body.ai_curated:
+        if not current_user.privacy_policy_accepted:
+            raise HTTPException(status_code=403, detail="Privacy policy consent required to use AI curation")
         try:
             seeded_films, llm_result = await curate_and_select_films(
                 user_movies=user_movies,
@@ -267,6 +269,9 @@ async def regenerate_tournament(
         raise HTTPException(
             status_code=400, detail="Maximum regeneration attempts (3) reached"
         )
+
+    if not current_user.privacy_policy_accepted:
+        raise HTTPException(status_code=403, detail="Privacy policy consent required to use AI curation")
 
     try:
         user_movies = await get_filtered_ranked_films(

--- a/backend/tests/test_consent_guard.py
+++ b/backend/tests/test_consent_guard.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import os
 import uuid
+from datetime import datetime, timezone
 from unittest.mock import AsyncMock, MagicMock, patch
 
 os.environ.setdefault("TOKEN_ENC_KEY", "test-secret-key-for-unit-tests-32b")
@@ -78,6 +79,25 @@ class TestSuggestionsConsentGuard:
         assert resp.status_code == 200
         assert resp.json()["status"] == "not_enough_films"
 
+    def test_regenerate_suggestions_allowed_with_consent(self):
+        """POST /api/suggestions/regenerate proceeds past consent check when policy accepted."""
+        user = _make_user(privacy_policy_accepted=True)
+        mock_db = AsyncMock()
+        app.dependency_overrides[get_current_user] = lambda: user
+        app.dependency_overrides[get_db] = lambda: mock_db
+
+        with patch(
+            "backend.routers.suggestions.has_enough_ranked",
+            new_callable=AsyncMock,
+            return_value=False,
+        ):
+            with TestClient(app, raise_server_exceptions=False) as client:
+                resp = client.post("/api/suggestions/regenerate")
+
+        # Should pass consent check and hit "not_enough_films" path
+        assert resp.status_code == 200
+        assert resp.json()["status"] == "not_enough_films"
+
 
 # ---------------------------------------------------------------------------
 # Tournament endpoints — consent guard
@@ -95,13 +115,6 @@ class TestTournamentConsentGuard:
         """POST /api/tournaments with ai_curated=true returns 403 when no consent."""
         user = _make_user(privacy_policy_accepted=False)
         mock_db = AsyncMock()
-
-        # Mock enough DB results so we get past the pre-checks
-        mock_result = MagicMock()
-        mock_result.scalars.return_value.all.return_value = [
-            MagicMock() for _ in range(16)
-        ]
-        mock_db.execute.return_value = mock_result
 
         app.dependency_overrides[get_current_user] = lambda: user
         app.dependency_overrides[get_db] = lambda: mock_db
@@ -127,11 +140,30 @@ class TestTournamentConsentGuard:
         """POST /api/tournaments with ai_curated=false does not require consent."""
         user = _make_user(privacy_policy_accepted=False)
         mock_db = AsyncMock()
+        mock_db.commit = AsyncMock()
+        mock_db.refresh = AsyncMock()
+        mock_db.add = MagicMock()
+        mock_db.flush = AsyncMock()
+
+        mock_films = [MagicMock() for _ in range(8)]
 
         app.dependency_overrides[get_current_user] = lambda: user
         app.dependency_overrides[get_db] = lambda: mock_db
 
-        mock_films = [MagicMock() for _ in range(8)]
+        mock_tournament = MagicMock()
+        mock_tournament.id = uuid.uuid4()
+        mock_tournament.matches = []
+        mock_tournament.is_ai_curated = False
+        mock_tournament.name = "Test"
+        mock_tournament.filter_type = None
+        mock_tournament.filter_value = None
+        mock_tournament.bracket_size = 8
+        mock_tournament.status = "active"
+        mock_tournament.champion_movie_id = None
+        mock_tournament.tagline = None
+        mock_tournament.theme_description = None
+        mock_tournament.created_at = datetime.now(timezone.utc)
+        mock_tournament.completed_at = None
 
         with patch(
             "backend.routers.tournaments.get_filtered_ranked_films",
@@ -140,11 +172,11 @@ class TestTournamentConsentGuard:
         ), patch(
             "backend.routers.tournaments.create_tournament_bracket",
             new_callable=AsyncMock,
+        ), patch(
+            "backend.routers.tournaments._load_tournament",
+            new_callable=AsyncMock,
+            return_value=mock_tournament,
         ):
-            mock_db.commit = AsyncMock()
-            mock_db.refresh = AsyncMock()
-            mock_db.add = MagicMock()
-
             with TestClient(app, raise_server_exceptions=False) as client:
                 resp = client.post(
                     "/api/tournaments",
@@ -154,8 +186,66 @@ class TestTournamentConsentGuard:
                     },
                 )
 
-        # Should not be 403 — non-AI tournaments don't need consent
-        assert resp.status_code != 403
+        # Non-AI tournaments must not be blocked by consent guard
+        assert resp.status_code == 200
+        assert resp.status_code < 500, f"Unexpected server error: {resp.status_code}"
+
+    def test_create_ai_tournament_allowed_with_consent(self):
+        """POST /api/tournaments with ai_curated=true proceeds when consent given."""
+        user = _make_user(privacy_policy_accepted=True)
+        mock_db = AsyncMock()
+        mock_db.flush = AsyncMock()
+
+        mock_films = [MagicMock() for _ in range(8)]
+        mock_llm_result = {
+            "name": "Test Tournament",
+            "tagline": "t",
+            "theme_description": "d",
+        }
+
+        tournament_id = uuid.uuid4()
+        mock_tournament = MagicMock()
+        mock_tournament.id = tournament_id
+        mock_tournament.matches = []
+        mock_tournament.is_ai_curated = True
+        mock_tournament.name = "Test Tournament"
+        mock_tournament.filter_type = None
+        mock_tournament.filter_value = None
+        mock_tournament.bracket_size = 8
+        mock_tournament.status = "active"
+        mock_tournament.champion_movie_id = None
+        mock_tournament.tagline = "t"
+        mock_tournament.theme_description = "d"
+        mock_tournament.created_at = datetime.now(timezone.utc)
+        mock_tournament.completed_at = None
+
+        app.dependency_overrides[get_current_user] = lambda: user
+        app.dependency_overrides[get_db] = lambda: mock_db
+
+        with patch(
+            "backend.routers.tournaments.get_filtered_ranked_films",
+            new_callable=AsyncMock,
+            return_value=mock_films,
+        ), patch(
+            "backend.routers.tournaments.curate_and_select_films",
+            new_callable=AsyncMock,
+            return_value=(mock_films, mock_llm_result),
+        ), patch(
+            "backend.routers.tournaments.create_tournament_bracket",
+            new_callable=AsyncMock,
+        ), patch(
+            "backend.routers.tournaments._load_tournament",
+            new_callable=AsyncMock,
+            return_value=mock_tournament,
+        ):
+            with TestClient(app, raise_server_exceptions=False) as client:
+                resp = client.post(
+                    "/api/tournaments",
+                    json={"ai_curated": True, "bracket_size": 8},
+                )
+
+        # Consenting user must not be blocked
+        assert resp.status_code == 200
 
     def test_regenerate_tournament_requires_consent(self):
         """POST /api/tournaments/{id}/regenerate returns 403 when no consent."""
@@ -188,3 +278,65 @@ class TestTournamentConsentGuard:
 
         assert resp.status_code == 403
         assert "consent" in resp.json()["detail"].lower()
+
+    def test_regenerate_tournament_allowed_with_consent(self):
+        """POST /api/tournaments/{id}/regenerate proceeds when consent given."""
+        user = _make_user(privacy_policy_accepted=True)
+        mock_db = AsyncMock()
+
+        tournament_id = uuid.uuid4()
+
+        mock_tournament = MagicMock()
+        mock_tournament.id = tournament_id
+        mock_tournament.user_id = user.id
+        mock_tournament.is_ai_curated = True
+        mock_tournament.matches = []
+        mock_tournament.llm_response = {"_regen_count": 0, "_theme_hint": ""}
+        mock_tournament.bracket_size = 8
+        mock_tournament.filter_type = None
+        mock_tournament.filter_value = None
+        mock_tournament.name = "Test Tournament"
+        mock_tournament.tagline = "t"
+        mock_tournament.theme_description = "d"
+        mock_tournament.status = "active"
+        mock_tournament.champion_movie_id = None
+        mock_tournament.created_at = datetime.now(timezone.utc)
+        mock_tournament.completed_at = None
+
+        # Set up db.execute to return a result whose scalar_one() returns mock_tournament
+        mock_execute_result = MagicMock()
+        mock_execute_result.scalar_one.return_value = mock_tournament
+        mock_db.execute = AsyncMock(return_value=mock_execute_result)
+
+        mock_films = [MagicMock() for _ in range(8)]
+        mock_llm_result = {
+            "name": "Regenerated Tournament",
+            "tagline": "new",
+            "theme_description": "new desc",
+        }
+
+        app.dependency_overrides[get_current_user] = lambda: user
+        app.dependency_overrides[get_db] = lambda: mock_db
+
+        with patch(
+            "backend.routers.tournaments._load_tournament",
+            new_callable=AsyncMock,
+            return_value=mock_tournament,
+        ), patch(
+            "backend.routers.tournaments.get_filtered_ranked_films",
+            new_callable=AsyncMock,
+            return_value=mock_films,
+        ), patch(
+            "backend.routers.tournaments.curate_and_select_films",
+            new_callable=AsyncMock,
+            return_value=(mock_films, mock_llm_result),
+        ), patch(
+            "backend.routers.tournaments.create_tournament_bracket",
+            new_callable=AsyncMock,
+        ):
+            with TestClient(app, raise_server_exceptions=False) as client:
+                resp = client.post(f"/api/tournaments/{tournament_id}/regenerate")
+
+        # Consenting user must not be blocked by the consent guard (403)
+        assert resp.status_code != 403
+        assert resp.status_code < 500, f"Unexpected server error: {resp.status_code}"

--- a/backend/tests/test_consent_guard.py
+++ b/backend/tests/test_consent_guard.py
@@ -9,7 +9,6 @@ from unittest.mock import AsyncMock, MagicMock, patch
 os.environ.setdefault("TOKEN_ENC_KEY", "test-secret-key-for-unit-tests-32b")
 os.environ.setdefault("SECRET_KEY", "test-secret-key-for-unit-tests!!")
 
-import pytest
 from fastapi.testclient import TestClient
 
 from backend.main import app

--- a/backend/tests/test_consent_guard.py
+++ b/backend/tests/test_consent_guard.py
@@ -1,0 +1,191 @@
+"""Tests for privacy policy consent enforcement on LLM-calling endpoints."""
+
+from __future__ import annotations
+
+import os
+import uuid
+from unittest.mock import AsyncMock, MagicMock, patch
+
+os.environ.setdefault("TOKEN_ENC_KEY", "test-secret-key-for-unit-tests-32b")
+os.environ.setdefault("SECRET_KEY", "test-secret-key-for-unit-tests!!")
+
+import pytest
+from fastapi.testclient import TestClient
+
+from backend.main import app
+from backend.db import get_db
+from backend.routers.auth import get_current_user
+
+
+def _make_user(*, privacy_policy_accepted: bool = False):
+    user = MagicMock()
+    user.id = uuid.uuid4()
+    user.privacy_policy_accepted = privacy_policy_accepted
+    return user
+
+
+# ---------------------------------------------------------------------------
+# Suggestions endpoints — consent guard
+# ---------------------------------------------------------------------------
+
+
+class TestSuggestionsConsentGuard:
+    def setup_method(self):
+        app.dependency_overrides.clear()
+
+    def teardown_method(self):
+        app.dependency_overrides.clear()
+
+    def test_get_suggestions_requires_consent(self):
+        """GET /api/suggestions returns 403 when user has not accepted privacy policy."""
+        user = _make_user(privacy_policy_accepted=False)
+        app.dependency_overrides[get_current_user] = lambda: user
+        app.dependency_overrides[get_db] = lambda: AsyncMock()
+
+        with TestClient(app, raise_server_exceptions=False) as client:
+            resp = client.get("/api/suggestions")
+
+        assert resp.status_code == 403
+        assert "consent" in resp.json()["detail"].lower()
+
+    def test_regenerate_suggestions_requires_consent(self):
+        """POST /api/suggestions/regenerate returns 403 when user has not accepted privacy policy."""
+        user = _make_user(privacy_policy_accepted=False)
+        app.dependency_overrides[get_current_user] = lambda: user
+        app.dependency_overrides[get_db] = lambda: AsyncMock()
+
+        with TestClient(app, raise_server_exceptions=False) as client:
+            resp = client.post("/api/suggestions/regenerate")
+
+        assert resp.status_code == 403
+        assert "consent" in resp.json()["detail"].lower()
+
+    def test_get_suggestions_allowed_with_consent(self):
+        """GET /api/suggestions proceeds past consent check when policy accepted."""
+        user = _make_user(privacy_policy_accepted=True)
+        mock_db = AsyncMock()
+        app.dependency_overrides[get_current_user] = lambda: user
+        app.dependency_overrides[get_db] = lambda: mock_db
+
+        with patch(
+            "backend.routers.suggestions.has_enough_ranked",
+            new_callable=AsyncMock,
+            return_value=False,
+        ):
+            with TestClient(app, raise_server_exceptions=False) as client:
+                resp = client.get("/api/suggestions")
+
+        # Should pass consent check and hit "not_enough_films" path
+        assert resp.status_code == 200
+        assert resp.json()["status"] == "not_enough_films"
+
+
+# ---------------------------------------------------------------------------
+# Tournament endpoints — consent guard
+# ---------------------------------------------------------------------------
+
+
+class TestTournamentConsentGuard:
+    def setup_method(self):
+        app.dependency_overrides.clear()
+
+    def teardown_method(self):
+        app.dependency_overrides.clear()
+
+    def test_create_ai_tournament_requires_consent(self):
+        """POST /api/tournaments with ai_curated=true returns 403 when no consent."""
+        user = _make_user(privacy_policy_accepted=False)
+        mock_db = AsyncMock()
+
+        # Mock enough DB results so we get past the pre-checks
+        mock_result = MagicMock()
+        mock_result.scalars.return_value.all.return_value = [
+            MagicMock() for _ in range(16)
+        ]
+        mock_db.execute.return_value = mock_result
+
+        app.dependency_overrides[get_current_user] = lambda: user
+        app.dependency_overrides[get_db] = lambda: mock_db
+
+        with patch(
+            "backend.routers.tournaments.get_filtered_ranked_films",
+            new_callable=AsyncMock,
+            return_value=[MagicMock() for _ in range(16)],
+        ):
+            with TestClient(app, raise_server_exceptions=False) as client:
+                resp = client.post(
+                    "/api/tournaments",
+                    json={
+                        "ai_curated": True,
+                        "bracket_size": 8,
+                    },
+                )
+
+        assert resp.status_code == 403
+        assert "consent" in resp.json()["detail"].lower()
+
+    def test_create_non_ai_tournament_no_consent_required(self):
+        """POST /api/tournaments with ai_curated=false does not require consent."""
+        user = _make_user(privacy_policy_accepted=False)
+        mock_db = AsyncMock()
+
+        app.dependency_overrides[get_current_user] = lambda: user
+        app.dependency_overrides[get_db] = lambda: mock_db
+
+        mock_films = [MagicMock() for _ in range(8)]
+
+        with patch(
+            "backend.routers.tournaments.get_filtered_ranked_films",
+            new_callable=AsyncMock,
+            return_value=mock_films,
+        ), patch(
+            "backend.routers.tournaments.create_tournament_bracket",
+            new_callable=AsyncMock,
+        ):
+            mock_db.commit = AsyncMock()
+            mock_db.refresh = AsyncMock()
+            mock_db.add = MagicMock()
+
+            with TestClient(app, raise_server_exceptions=False) as client:
+                resp = client.post(
+                    "/api/tournaments",
+                    json={
+                        "ai_curated": False,
+                        "bracket_size": 8,
+                    },
+                )
+
+        # Should not be 403 — non-AI tournaments don't need consent
+        assert resp.status_code != 403
+
+    def test_regenerate_tournament_requires_consent(self):
+        """POST /api/tournaments/{id}/regenerate returns 403 when no consent."""
+        user = _make_user(privacy_policy_accepted=False)
+        mock_db = AsyncMock()
+
+        tournament_id = uuid.uuid4()
+
+        # Mock tournament object
+        mock_tournament = MagicMock()
+        mock_tournament.id = tournament_id
+        mock_tournament.user_id = user.id
+        mock_tournament.is_ai_curated = True
+        mock_tournament.matches = []  # no played matches
+        mock_tournament.llm_response = {"_regen_count": 0}
+        mock_tournament.bracket_size = 8
+        mock_tournament.filter_type = None
+        mock_tournament.filter_value = None
+
+        app.dependency_overrides[get_current_user] = lambda: user
+        app.dependency_overrides[get_db] = lambda: mock_db
+
+        with patch(
+            "backend.routers.tournaments._load_tournament",
+            new_callable=AsyncMock,
+            return_value=mock_tournament,
+        ):
+            with TestClient(app, raise_server_exceptions=False) as client:
+                resp = client.post(f"/api/tournaments/{tournament_id}/regenerate")
+
+        assert resp.status_code == 403
+        assert "consent" in resp.json()["detail"].lower()


### PR DESCRIPTION
## Summary

Enforces privacy policy consent at the backend level for all endpoints that send user behavioral data to third-party LLM services. Previously, consent was only checked in the frontend UI, allowing authenticated users to bypass the consent requirement by calling the API directly.

**Issue**: Fixes #259

## Changes

### Endpoints Updated
- **`GET /api/suggestions`** — Returns 403 if user has not accepted privacy policy
- **`POST /api/suggestions/regenerate`** — Returns 403 if user has not accepted privacy policy  
- **`POST /api/tournaments` (ai_curated path)** — Returns 403 if `ai_curated=true` and user has not accepted privacy policy
- **`POST /api/tournaments/{id}/regenerate`** — Returns 403 if user has not accepted privacy policy

### Implementation Details

**Files modified:**
- `backend/routers/suggestions.py` — Added consent checks in `get_suggestions()` and `regenerate_suggestions()`
- `backend/routers/tournaments.py` — Added consent checks in `create_tournament()` and `regenerate_tournament()`
- `backend/tests/test_consent_guard.py` — New comprehensive test file (6 tests covering all 4 endpoints + positive/negative cases)

**Guard pattern used:**
```python
if not current_user.privacy_policy_accepted:
    raise HTTPException(status_code=403, detail="Privacy policy consent required to use AI [feature]")
```

### Scope Notes

- ✅ Non-AI-curated tournaments do **not** require consent (they don't call LLM)
- ✅ Guard is added at the earliest point before LLM calls
- ✅ Uses existing `User.privacy_policy_accepted` field from DB (set by `/api/auth/consent` endpoint)

## Validation

| Check | Result |
|-------|--------|
| Backend Tests | ✅ 404 passed (includes 6 new consent guard tests) |
| Lint | ✅ 0 errors (removed 1 unused import) |
| Frontend Tests | ✅ 131 passed |
| Build | ✅ Success |

### Test Coverage

- ✅ GET /api/suggestions returns 403 when consent not accepted
- ✅ POST /api/suggestions/regenerate returns 403 when consent not accepted
- ✅ POST /api/tournaments with ai_curated=true returns 403 when consent not accepted
- ✅ POST /api/tournaments/{id}/regenerate returns 403 when consent not accepted
- ✅ GET /api/suggestions returns 200 when consent is accepted
- ✅ POST /api/tournaments with ai_curated=false succeeds without consent requirement

---

🤖 Generated with Claude Code