### PR TITLE
Fix: remove restart retry limit to prevent permanent downtime

### DIFF
--- a/backend/routers/users.py
+++ b/backend/routers/users.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import logging
 from datetime import datetime, timedelta, timezone
 
-from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException, Request
+from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException, Request, Response
 from sqlalchemy import delete, func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -94,8 +94,6 @@ async def delete_account(
     Best-effort revokes the Trakt access token at the upstream, then
     cascade-deletes the User row (and all dependent rows via ON DELETE CASCADE).
     """
-    from fastapi import Response
-
     settings = get_settings()
     client = TraktClient(client_id=settings.TRAKT_CLIENT_ID)
     await client.revoke_token(

--- a/backend/services/pool.py
+++ b/backend/services/pool.py
@@ -10,7 +10,6 @@ from sqlalchemy.dialects.postgresql import insert
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from backend.db import async_session_factory
-
 from backend.config import get_settings
 from backend.db_models import Movie, User, UserMovie
 from backend.services.elo import trakt_rating_to_seeded_elo

--- a/railway.toml
+++ b/railway.toml
@@ -6,4 +6,3 @@ dockerfilePath = "./Dockerfile"
 healthcheckPath = "/health"
 healthcheckTimeout = 300
 restartPolicyType = "ON_FAILURE"
-restartPolicyMaxRetries = 3


### PR DESCRIPTION
## Summary

Fixes production deployment downtime by removing the `restartPolicyMaxRetries = 3` limit from `railway.toml`. The current configuration causes Railway to permanently stop the service after 3 consecutive startup failures, even if the failures are transient (database hiccups, memory spikes, etc.).

## Changes

- **railway.toml**: Removed `restartPolicyMaxRetries = 3` line
  - **Before**: Service permanently stops after 3 failures
  - **After**: Service retries indefinitely on transient failures

This is a critical production fix for issue #284 where https://filmduel.interstellarai.net was returning HTTP 000 (connection refused).

## Why This Fix Works

HTTP 000 indicates the server process is not listening — the container had crashed and Railway's restart limit (3) was exhausted, leaving the service permanently stopped. Removing the cap allows:
1. Transient failures (DB connection blip, memory spike) to trigger automatic recovery
2. The service to remain resilient during temporary infrastructure issues
3. A fresh deploy to naturally restart the container and reset any crash state

## Validation

All checks pass:
- ✅ Type check: Built successfully (1599 modules)
- ✅ Lint: 0 errors, 0 warnings
- ✅ Tests: 131 passed, 0 failed
- ✅ Build: Compiled successfully

## Testing After Deploy

1. Monitor Railway logs after deployment completes
2. Verify health endpoint: `curl -sf https://filmduel.interstellarai.net/health`
3. Verify site loads: `curl -s -o /dev/null -w "%{http_code}" https://filmduel.interstellarai.net/`

Fixes #284