### PR TITLE
Fix: redact user feedback title from logs

### DIFF
--- a/backend/routers/feedback.py
+++ b/backend/routers/feedback.py
@@ -144,7 +144,7 @@ async def submit_feedback(
     db.add(report)
     await db.flush()
 
-    logger.info("feedback_submitted user_id=%s title=%r", current_user.id, title[:50])
+    logger.info("feedback_submitted id=%s user_id=%s title_len=%d", report.id, current_user.id, len(title))
 
     return FeedbackReportResponse(id=str(report.id), created_at=report.created_at)
 

--- a/backend/routers/feedback.py
+++ b/backend/routers/feedback.py
@@ -144,7 +144,12 @@ async def submit_feedback(
     db.add(report)
     await db.flush()
 
-    logger.info("feedback_submitted id=%s user_id=%s title_len=%d", report.id, current_user.id, len(title.strip()))
+    logger.info(
+        "feedback_submitted id=%s user_id=%s title_len=%d",
+        report.id,
+        current_user.id,
+        len(title.strip()),
+    )
 
     return FeedbackReportResponse(id=str(report.id), created_at=report.created_at)
 

--- a/backend/routers/feedback.py
+++ b/backend/routers/feedback.py
@@ -144,7 +144,7 @@ async def submit_feedback(
     db.add(report)
     await db.flush()
 
-    logger.info("feedback_submitted id=%s user_id=%s title_len=%d", report.id, current_user.id, len(title))
+    logger.info("feedback_submitted id=%s user_id=%s title_len=%d", report.id, current_user.id, len(title.strip()))
 
     return FeedbackReportResponse(id=str(report.id), created_at=report.created_at)
 

--- a/backend/services/sync.py
+++ b/backend/services/sync.py
@@ -181,16 +181,10 @@ async def sync_ratings_to_simkl(
         if um.movie.simkl_id is None:
             continue  # Can't rate on SIMKL without a SIMKL ID
         simkl_rating = elo_to_trakt_rating(um.elo)
-        try:
-            await _rate_with_retry_simkl(
-                client, um.movie.simkl_id, simkl_rating,
-                media_type=um.movie.media_type,
-            )
-            synced += 1
-        except Exception:
-            logger.exception(
-                "Failed to sync SIMKL rating for simkl_id=%s", um.movie.simkl_id
-            )
-            failed += 1
+        await _rate_with_retry_simkl(
+            client, um.movie.simkl_id, simkl_rating,
+            media_type=um.movie.media_type,
+        )
+        synced += 1
 
     return {"synced": synced, "failed": failed}

--- a/backend/services/sync.py
+++ b/backend/services/sync.py
@@ -181,10 +181,16 @@ async def sync_ratings_to_simkl(
         if um.movie.simkl_id is None:
             continue  # Can't rate on SIMKL without a SIMKL ID
         simkl_rating = elo_to_trakt_rating(um.elo)
-        await _rate_with_retry_simkl(
-            client, um.movie.simkl_id, simkl_rating,
-            media_type=um.movie.media_type,
-        )
-        synced += 1
+        try:
+            await _rate_with_retry_simkl(
+                client, um.movie.simkl_id, simkl_rating,
+                media_type=um.movie.media_type,
+            )
+            synced += 1
+        except Exception:
+            logger.exception(
+                "Failed to sync SIMKL rating for simkl_id=%s", um.movie.simkl_id
+            )
+            failed += 1
 
     return {"synced": synced, "failed": failed}

--- a/backend/tests/test_feedback.py
+++ b/backend/tests/test_feedback.py
@@ -217,6 +217,21 @@ class TestSubmitFeedback:
         response = self._post(client, description="x" * 5000)
         assert response.status_code == 201
 
+    def test_log_does_not_contain_title_content(self, client):
+        """SEC-17: feedback log must not contain user-supplied title text."""
+        pii_title = "Bug: missing from Alice Smith's watchlist"
+        with patch("backend.routers.feedback.logger") as mock_logger:
+            response = self._post(client, title=pii_title)
+        assert response.status_code == 201
+        # Collect all string args passed to logger.info
+        logged_text = " ".join(
+            str(arg)
+            for call in mock_logger.info.call_args_list
+            for arg in call.args + tuple(call.kwargs.values())
+        )
+        assert pii_title not in logged_text
+        assert "Alice Smith" not in logged_text
+
 
 class TestAdminListFeedback:
     def _get(self, client, reports=None):

--- a/backend/tests/test_feedback.py
+++ b/backend/tests/test_feedback.py
@@ -223,14 +223,19 @@ class TestSubmitFeedback:
         with patch("backend.routers.feedback.logger") as mock_logger:
             response = self._post(client, title=pii_title)
         assert response.status_code == 201
+        assert mock_logger.info.called, "Expected at least one logger.info call after feedback submission"
         # Collect all string args passed to logger.info
         logged_text = " ".join(
             str(arg)
             for call in mock_logger.info.call_args_list
             for arg in call.args + tuple(call.kwargs.values())
         )
+        # Negative: no PII
         assert pii_title not in logged_text
         assert "Alice Smith" not in logged_text
+        # Positive: safe metadata is present
+        assert "feedback_submitted" in logged_text
+        assert "title_len" in logged_text
 
 
 class TestAdminListFeedback:


### PR DESCRIPTION
## Summary

Fixed security issue where user feedback titles containing potentially sensitive information were being logged in plaintext. The endpoint now logs only metadata (report ID, user ID, title length) instead of the actual title content.

## Changes

- **backend/routers/feedback.py**: Replaced `title[:50]` in log statement with report.id and len(title)
- **backend/tests/test_feedback.py**: Added test asserting title content is not present in log output

## Validation

- ✅ All 466 backend tests passed
- ✅ All 137 frontend tests passed  
- ✅ Type check passed (vite build successful)
- ✅ Linting passed
- ✅ Production build successful

## Related Issue

Fixes #304