### PR TITLE
Fix: redact PII from SIMKL profile error log

### DIFF
--- a/backend/routers/auth.py
+++ b/backend/routers/auth.py
@@ -412,7 +412,9 @@ async def simkl_callback(
         simkl_user_id = str(profile["user"]["ids"]["simkl"])
         simkl_username = profile["user"].get("name", simkl_user_id)
     except (KeyError, TypeError) as exc:
-        profile_summary = list(profile.keys()) if isinstance(profile, dict) else type(profile).__name__
+        profile_summary = (
+            list(profile.keys()) if isinstance(profile, dict) else type(profile).__name__
+        )
         logger.error("Unexpected SIMKL profile response. Keys: %s", profile_summary, exc_info=True)
         raise HTTPException(
             status_code=502,

--- a/backend/routers/auth.py
+++ b/backend/routers/auth.py
@@ -412,7 +412,8 @@ async def simkl_callback(
         simkl_user_id = str(profile["user"]["ids"]["simkl"])
         simkl_username = profile["user"].get("name", simkl_user_id)
     except (KeyError, TypeError) as exc:
-        logger.error("Unexpected SIMKL profile response. Keys: %s", list(profile.keys()) if isinstance(profile, dict) else type(profile).__name__, exc_info=True)
+        profile_summary = list(profile.keys()) if isinstance(profile, dict) else type(profile).__name__
+        logger.error("Unexpected SIMKL profile response. Keys: %s", profile_summary, exc_info=True)
         raise HTTPException(
             status_code=502,
             detail="Unexpected response from SIMKL profile API",

--- a/backend/routers/auth.py
+++ b/backend/routers/auth.py
@@ -412,7 +412,7 @@ async def simkl_callback(
         simkl_user_id = str(profile["user"]["ids"]["simkl"])
         simkl_username = profile["user"].get("name", simkl_user_id)
     except (KeyError, TypeError) as exc:
-        logger.error("Unexpected SIMKL profile response: %s", profile, exc_info=True)
+        logger.error("Unexpected SIMKL profile response. Keys: %s", list(profile.keys()) if isinstance(profile, dict) else type(profile).__name__, exc_info=True)
         raise HTTPException(
             status_code=502,
             detail="Unexpected response from SIMKL profile API",

--- a/backend/services/pool.py
+++ b/backend/services/pool.py
@@ -364,9 +364,7 @@ async def _upsert_simkl_pool(
     await db.flush()
 
     # Map remaining SIMKL IDs to movie UUIDs
-    remaining_ids = [
-        sid for sid in pool if sid not in simkl_id_to_movie_uuid
-    ]
+    remaining_ids = [sid for sid in pool if sid not in simkl_id_to_movie_uuid]
     if remaining_ids:
         result = await db.execute(
             select(Movie.id, Movie.trakt_id).where(

--- a/backend/tests/test_auth.py
+++ b/backend/tests/test_auth.py
@@ -752,6 +752,73 @@ class TestSimklCallback:
             )
         assert exc.value.status_code == 400
 
+    @pytest.mark.asyncio
+    async def test_malformed_profile_dict_raises_502_and_redacts_pii(
+        self, monkeypatch, caplog
+    ):
+        """502 is raised and log contains only dict keys, not values, when profile is malformed."""
+        import logging
+
+        monkeypatch.setattr(limiter, "enabled", False)
+
+        mock_tokens = AsyncMock(return_value={"access_token": "tok"})
+        mock_client = AsyncMock()
+        mock_client.get_profile = AsyncMock(
+            return_value={"secret_token": "PII_VALUE", "user": None}
+        )
+
+        monkeypatch.setattr("backend.routers.auth.SimklClient.exchange_code", mock_tokens)
+        monkeypatch.setattr("backend.routers.auth.SimklClient", lambda **kw: mock_client)
+
+        request = _make_starlette_request(cookies={OAUTH_SIMKL_STATE_COOKIE: "state123"})
+
+        with caplog.at_level(logging.ERROR, logger="backend.routers.auth"):
+            with pytest.raises(HTTPException) as exc_info:
+                await simkl_callback(
+                    code="code123",
+                    state="state123",
+                    request=request,
+                    background_tasks=MagicMock(),
+                    settings=SETTINGS,
+                    db=AsyncMock(),
+                )
+
+        assert exc_info.value.status_code == 502
+        assert "PII_VALUE" not in caplog.text  # value must NOT appear
+        assert "secret_token" in caplog.text  # key is acceptable
+
+    @pytest.mark.asyncio
+    async def test_non_dict_profile_raises_502_and_logs_type_name(
+        self, monkeypatch, caplog
+    ):
+        """502 is raised and log contains type name when profile is not a dict."""
+        import logging
+
+        monkeypatch.setattr(limiter, "enabled", False)
+
+        mock_tokens = AsyncMock(return_value={"access_token": "tok"})
+        mock_client = AsyncMock()
+        mock_client.get_profile = AsyncMock(return_value=None)  # non-dict
+
+        monkeypatch.setattr("backend.routers.auth.SimklClient.exchange_code", mock_tokens)
+        monkeypatch.setattr("backend.routers.auth.SimklClient", lambda **kw: mock_client)
+
+        request = _make_starlette_request(cookies={OAUTH_SIMKL_STATE_COOKIE: "state123"})
+
+        with caplog.at_level(logging.ERROR, logger="backend.routers.auth"):
+            with pytest.raises(HTTPException) as exc_info:
+                await simkl_callback(
+                    code="code123",
+                    state="state123",
+                    request=request,
+                    background_tasks=MagicMock(),
+                    settings=SETTINGS,
+                    db=AsyncMock(),
+                )
+
+        assert exc_info.value.status_code == 502
+        assert "NoneType" in caplog.text
+
 
 # ---------------------------------------------------------------------------
 # Additional update_settings SIMKL tests


### PR DESCRIPTION
## Summary

Redacts personally identifiable information (PII) from SIMKL profile error logs. When parsing the SIMKL profile response fails, the full profile dict containing email and real name fields is logged. This fix logs only the dictionary keys instead, preserving diagnostic value while preventing sensitive data exposure to log aggregation systems.

## Changes

- **File**: `backend/routers/auth.py` (line 415)
- **Change**: Replace full `profile` dict in error log with `list(profile.keys())`
- **Guard**: Added `isinstance(profile, dict)` check to handle non-dict responses gracefully

## Test Coverage

- ✅ Backend tests: 510 passed
- ✅ Frontend tests: 137 passed
- ✅ Lint checks: passed
- ✅ Type checks: passed

## Validation

The fix maintains existing error handling behavior (HTTPException 502 still raised) while preventing PII leakage. Diagnostic information from dictionary keys is preserved for debugging structure issues.

Fixes #295