### PR TITLE
Fix: stop leaking internal error details in regenerate endpoint

### DIFF
--- a/backend/routers/tournaments.py
+++ b/backend/routers/tournaments.py
@@ -307,7 +307,8 @@ async def regenerate_tournament(
             theme_hint=original_hint,
         )
     except ValueError as e:
-        raise HTTPException(status_code=500, detail=str(e))
+        logger.error("AI curation failed during regeneration: %s", e)
+        raise HTTPException(status_code=500, detail="AI curation failed. Please try again.")
 
     # Delete existing matches
     from sqlalchemy import delete

--- a/backend/routers/tournaments.py
+++ b/backend/routers/tournaments.py
@@ -9,7 +9,7 @@ from typing import Optional
 
 from fastapi import APIRouter, Depends, HTTPException, Query, Request
 from pydantic import BaseModel
-from sqlalchemy import func, select
+from sqlalchemy import delete, func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import joinedload
 
@@ -228,7 +228,7 @@ async def create_tournament(
     # Create tournament record
     tournament = Tournament(
         user_id=uid,
-        name=ai_name if ai_name else body.name,
+        name=ai_name or body.name,
         filter_type=body.filter_type,
         filter_value=body.filter_value,
         bracket_size=body.bracket_size,
@@ -311,8 +311,6 @@ async def regenerate_tournament(
         raise HTTPException(status_code=500, detail="AI curation failed. Please try again.")
 
     # Delete existing matches
-    from sqlalchemy import delete
-
     await db.execute(
         delete(TournamentMatch).where(TournamentMatch.tournament_id == tournament_id)
     )

--- a/backend/tests/test_consent_guard.py
+++ b/backend/tests/test_consent_guard.py
@@ -361,3 +361,45 @@ class TestTournamentConsentGuard:
 
         # Consenting user must not be blocked by the consent guard
         assert resp.status_code == 200
+
+    def test_regenerate_tournament_curation_error_does_not_leak_details(self):
+        """POST /api/tournaments/{id}/regenerate must not expose internal ValueError details."""
+        user = _make_user(privacy_policy_accepted=True)
+        mock_db = AsyncMock()
+
+        tournament_id = uuid.uuid4()
+        internal_uuid = str(uuid.uuid4())
+
+        mock_tournament = MagicMock()
+        mock_tournament.id = tournament_id
+        mock_tournament.user_id = user.id
+        mock_tournament.is_ai_curated = True
+        mock_tournament.matches = []
+        mock_tournament.llm_response = {"_regen_count": 0, "_theme_hint": ""}
+        mock_tournament.bracket_size = 8
+        mock_tournament.filter_type = None
+        mock_tournament.filter_value = None
+
+        app.dependency_overrides[get_current_user] = lambda: user
+        app.dependency_overrides[get_db] = lambda: mock_db
+
+        with patch(
+            "backend.routers.tournaments._load_tournament",
+            new_callable=AsyncMock,
+            return_value=mock_tournament,
+        ), patch(
+            "backend.routers.tournaments.get_filtered_ranked_films",
+            new_callable=AsyncMock,
+            return_value=[MagicMock() for _ in range(8)],
+        ), patch(
+            "backend.routers.tournaments.curate_and_select_films",
+            new_callable=AsyncMock,
+            side_effect=ValueError(f"AI selected films not in candidate pool: {{{internal_uuid}}}"),
+        ):
+            with TestClient(app, raise_server_exceptions=False) as client:
+                resp = client.post(f"/api/tournaments/{tournament_id}/regenerate")
+
+        assert resp.status_code == 500
+        assert internal_uuid not in resp.text
+        assert "candidate pool" not in resp.text
+        assert resp.json()["detail"] == "AI curation failed. Please try again."

--- a/backend/tests/test_consent_guard.py
+++ b/backend/tests/test_consent_guard.py
@@ -403,3 +403,40 @@ class TestTournamentConsentGuard:
         assert internal_uuid not in resp.text
         assert "candidate pool" not in resp.text
         assert resp.json()["detail"] == "AI curation failed. Please try again."
+        # Guard against regressions where execution continues past the ValueError
+        # and db writes (delete matches, flush, update metadata) are silently triggered
+        mock_db.execute.assert_not_called()
+        mock_db.flush.assert_not_called()
+
+    def test_create_ai_tournament_curation_error_does_not_leak_details(self):
+        """POST /api/tournaments must not expose internal ValueError details from AI curation."""
+        user = _make_user(privacy_policy_accepted=True)
+        mock_db = AsyncMock()
+        mock_count_result = MagicMock()
+        mock_count_result.scalar_one.return_value = 0  # daily cap below limit
+        mock_db.execute.return_value = mock_count_result
+
+        internal_uuid = str(uuid.uuid4())
+
+        app.dependency_overrides[get_current_user] = lambda: user
+        app.dependency_overrides[get_db] = lambda: mock_db
+
+        with patch(
+            "backend.routers.tournaments.get_filtered_ranked_films",
+            new_callable=AsyncMock,
+            return_value=[MagicMock() for _ in range(8)],
+        ), patch(
+            "backend.routers.tournaments.curate_and_select_films",
+            new_callable=AsyncMock,
+            side_effect=ValueError(f"AI selected films not in candidate pool: {{{internal_uuid}}}"),
+        ):
+            with TestClient(app, raise_server_exceptions=False) as client:
+                resp = client.post(
+                    "/api/tournaments",
+                    json={"name": "Test", "bracket_size": 8, "ai_curated": True},
+                )
+
+        assert resp.status_code == 500
+        assert internal_uuid not in resp.text
+        assert "candidate pool" not in resp.text
+        assert resp.json()["detail"] == "AI curation failed. Please try again."


### PR DESCRIPTION
## Summary

Fix security issue where the `POST /api/tournaments/{id}/regenerate` endpoint was leaking internal film UUIDs and error details to API clients. The endpoint was catching `ValueError` exceptions from the AI curation service and exposing the raw exception message in HTTP responses.

## Changes

- **backend/routers/tournaments.py** (lines 309-310): Replace `detail=str(e)` with server-side logging and a generic error message, mirroring the pattern already in place for the `create_tournament` endpoint
- **backend/tests/test_consent_guard.py**: Add test verifying that `ValueError` exceptions during regeneration do not expose internal details in the HTTP response

## Validation

All checks passing:
- ✅ Type check: No errors
- ✅ Lint: 0 errors, 0 warnings  
- ✅ Backend tests: 560 passed
- ✅ Frontend tests: 139 passed
- ✅ Build: Compiled successfully

The fix ensures internal error details (film UUIDs, service-level error messages) are logged server-side while returning a generic message to API clients.

Fixes #289