### PR TITLE
fix(security): upgrade starlette to 1.3.1 to clear CVEs blocking CI

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -2015,9 +2015,9 @@ sqlalchemy==2.0.49 \
     # via
     #   -r backend/requirements.in
     #   alembic
-starlette==1.2.1 \
-    --hash=sha256:4de0082d08c8f6764a85a54cf1120d6939507a19905c7768acad2a9f875d2b89 \
-    --hash=sha256:9b9b5ebb992e67d6093741e63c2f59e4f6fff986f81163c087867bd7b924b3f6
+starlette==1.3.1 \
+    --hash=sha256:c7372aae11c3c3f26a42df7bd626cec2f47d03483d261d369516a615a53714c6 \
+    --hash=sha256:05d0213193f2fbaae60e2ecb593b4add4262ad4e46536b54abe36f11a71724e0
     # via
     #   -r backend/requirements.in
     #   fastapi


### PR DESCRIPTION
## Summary

Upgrades `starlette` from `1.2.1` to `1.3.1` in `backend/requirements.txt` to fix
two CVEs reported by `pip-audit` in the `security-scan` CI job.

## CVEs Fixed

| CVE | Package | Fixed in |
|-----|---------|----------|
| GHSA-82w8-qh3p-5jfq | starlette 1.2.1 | 1.3.1 |
| GHSA-jp82-jpqv-5vv3 | starlette 1.2.1 | 1.3.0 |

## Impact

- CI `security-scan` job has been red on `main`, blocking all PR merges
- Staging deploy pipeline is skipped (depends on green CI on main)
- Staging has been returning HTTP 404

## Change

Single file change: `backend/requirements.txt`
- `starlette==1.2.1` → `starlette==1.3.1`
- Updated SHA-256 hashes for both sdist and wheel

No changes to `backend/requirements.in` (lower bound `>=1.0.1` already covers 1.3.1).

Closes #347