### PR TITLE
Fix: replace leaked internal exception details with generic error messages

### DIFF
--- a/backend/routers/duels.py
+++ b/backend/routers/duels.py
@@ -100,8 +100,8 @@ async def submit_duel(
 
     try:
         result = await process_duel(db, uid, movie_a_id, movie_b_id, outcome, mode)
-    except ValueError as e:
-        raise HTTPException(status_code=400, detail=str(e))
+    except ValueError:
+        raise HTTPException(status_code=400, detail="Invalid duel submission")
 
     # Trakt sync in background (fire-and-forget)
     if (

--- a/backend/routers/duels.py
+++ b/backend/routers/duels.py
@@ -101,6 +101,7 @@ async def submit_duel(
     try:
         result = await process_duel(db, uid, movie_a_id, movie_b_id, outcome, mode)
     except ValueError:
+        logger.warning("Invalid duel submission for user %s", uid)
         raise HTTPException(status_code=400, detail="Invalid duel submission")
 
     # Trakt sync in background (fire-and-forget)

--- a/backend/routers/movies.py
+++ b/backend/routers/movies.py
@@ -73,8 +73,8 @@ async def get_movie_pair(
 
     try:
         pair = await select_pair(db, uid, last_pair_ids, media_type)
-    except ValueError as e:
-        raise HTTPException(status_code=404, detail=str(e))
+    except ValueError:
+        raise HTTPException(status_code=404, detail="No eligible pair found")
 
     movie_a, movie_b = pair
     schema_a = _user_movie_to_schema(movie_a)

--- a/backend/routers/movies.py
+++ b/backend/routers/movies.py
@@ -74,6 +74,7 @@ async def get_movie_pair(
     try:
         pair = await select_pair(db, uid, last_pair_ids, media_type)
     except ValueError:
+        logger.info("No eligible pair for user %s media_type=%s", uid, media_type)
         raise HTTPException(status_code=404, detail="No eligible pair found")
 
     movie_a, movie_b = pair

--- a/backend/routers/suggestions.py
+++ b/backend/routers/suggestions.py
@@ -159,6 +159,7 @@ async def get_suggestions(
         )
     except ValueError:
         # LLM_API_KEY not configured
+        logger.warning("AI features unavailable (LLM_API_KEY not configured) for user %s", uid)
         raise HTTPException(status_code=503, detail="AI features are not available")
     except Exception:
         logger.exception("Failed to generate suggestions for user %s", uid)
@@ -214,6 +215,8 @@ async def regenerate_suggestions(
             status="ready",
         )
     except ValueError:
+        # LLM_API_KEY not configured
+        logger.warning("AI features unavailable (LLM_API_KEY not configured) for user %s", uid)
         raise HTTPException(status_code=503, detail="AI features are not available")
     except Exception:
         logger.exception("Failed to regenerate suggestions for user %s", uid)

--- a/backend/routers/suggestions.py
+++ b/backend/routers/suggestions.py
@@ -157,9 +157,9 @@ async def get_suggestions(
             suggestions=[_build_suggestion_schema(s) for s in new_suggestions],
             status="ready",
         )
-    except ValueError as e:
+    except ValueError:
         # LLM_API_KEY not configured
-        raise HTTPException(status_code=503, detail=str(e))
+        raise HTTPException(status_code=503, detail="AI features are not available")
     except Exception:
         logger.exception("Failed to generate suggestions for user %s", uid)
         raise HTTPException(
@@ -213,8 +213,8 @@ async def regenerate_suggestions(
             suggestions=[_build_suggestion_schema(s) for s in new_suggestions],
             status="ready",
         )
-    except ValueError as e:
-        raise HTTPException(status_code=503, detail=str(e))
+    except ValueError:
+        raise HTTPException(status_code=503, detail="AI features are not available")
     except Exception:
         logger.exception("Failed to regenerate suggestions for user %s", uid)
         raise HTTPException(

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -1,0 +1,9 @@
+"""Shared pytest configuration for backend tests.
+
+Sets required environment variables before any test module is imported,
+so that pydantic-settings can build the Settings object at collection time.
+"""
+import os
+
+os.environ.setdefault("DATABASE_URL", "postgresql+asyncpg://localhost/ci_test")
+os.environ.setdefault("SECRET_KEY", "test-secret-key-for-unit-tests!!")

--- a/backend/tests/test_duel_router.py
+++ b/backend/tests/test_duel_router.py
@@ -195,6 +195,30 @@ class TestSubmitDuel:
         )
         assert response.status_code == 422
 
+    def test_process_duel_value_error_returns_generic_400(self):
+        """ValueError from process_duel must return 400 with generic detail — not str(e)."""
+        mid_a = str(uuid.uuid4())
+        mid_b = str(uuid.uuid4())
+        token = encode_pair_token(mid_a, mid_b)
+        with patch(
+            "backend.routers.duels.process_duel", new_callable=AsyncMock
+        ) as mock_pd:
+            mock_pd.side_effect = ValueError("Movie not in your pool: some internal detail")
+            client = TestClient(app)
+            response = client.post(
+                "/api/duels",
+                json={
+                    "movie_a_id": mid_a,
+                    "movie_b_id": mid_b,
+                    "outcome": "a_wins",
+                    "mode": "discovery",
+                    "pair_token": token,
+                },
+            )
+        assert response.status_code == 400
+        assert response.json()["detail"] == "Invalid duel submission"
+        assert "pool" not in response.json()["detail"]
+
 
 # ---------------------------------------------------------------------------
 # Purge old duel records

--- a/backend/tests/test_duel_service.py
+++ b/backend/tests/test_duel_service.py
@@ -8,6 +8,8 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
+from sqlalchemy.dialects import postgresql
+
 from backend.services.duel import (
     MIN_SEEN_UNRANKED,
     MIN_TOTAL_SEEN,
@@ -119,8 +121,6 @@ async def test_get_user_movie_with_for_update():
     um = await get_user_movie(db, uid, mid, for_update=True)
     assert um is existing
     assert len(captured_stmts) == 1
-    from sqlalchemy.dialects import postgresql
-
     compiled = captured_stmts[0].compile(dialect=postgresql.dialect())
     assert "FOR UPDATE" in str(compiled).upper()
 

--- a/backend/tests/test_movies_router.py
+++ b/backend/tests/test_movies_router.py
@@ -20,14 +20,14 @@ from backend.services.token_crypto import _fernet  # noqa: E402
 
 _fernet.cache_clear()
 
-from backend.routers.movies import _decode_pair_token, _encode_pair_token  # noqa: E402
+from backend.utils.tokens import decode_pair_token, encode_pair_token  # noqa: E402
 
 
 def test_pair_token_round_trips():
     id_a = str(uuid.uuid4())
     id_b = str(uuid.uuid4())
-    token = _encode_pair_token(id_a, id_b)
-    result = _decode_pair_token(token)
+    token = encode_pair_token(id_a, id_b)
+    result = decode_pair_token(token)
     assert result == {id_a, id_b}
 
 
@@ -35,20 +35,20 @@ def test_pair_token_is_opaque():
     """Token must not contain the raw UUIDs in plaintext (base64 or otherwise)."""
     id_a = str(uuid.uuid4())
     id_b = str(uuid.uuid4())
-    token = _encode_pair_token(id_a, id_b)
+    token = encode_pair_token(id_a, id_b)
     # Strip any base64 padding and check neither UUID appears in the token
     assert id_a not in token
     assert id_b not in token
 
 
 def test_pair_token_invalid_returns_none():
-    assert _decode_pair_token("not-a-valid-token") is None
-    assert _decode_pair_token("") is None
+    assert decode_pair_token("not-a-valid-token") is None
+    assert decode_pair_token("") is None
 
 
 def test_pair_token_tampered_returns_none():
     id_a = str(uuid.uuid4())
     id_b = str(uuid.uuid4())
-    token = _encode_pair_token(id_a, id_b)
+    token = encode_pair_token(id_a, id_b)
     tampered = token[:-4] + "XXXX"
-    assert _decode_pair_token(tampered) is None
+    assert decode_pair_token(tampered) is None

--- a/backend/tests/test_rate_limiting.py
+++ b/backend/tests/test_rate_limiting.py
@@ -132,6 +132,7 @@ def test_get_movie_pair_endpoint_reachable():
     # 404 is expected (not enough films); confirms endpoint + Request param works
     assert resp.status_code == 404
     assert resp.status_code != 500
+    assert resp.json()["detail"] == "No eligible pair found"
 
 
 def test_export_csv_endpoint_reachable():

--- a/backend/tests/test_suggestions_router.py
+++ b/backend/tests/test_suggestions_router.py
@@ -66,6 +66,31 @@ class TestGetSuggestions:
         assert body["status"] == "not_enough_films"
         assert body["suggestions"] == []
 
+    def test_get_suggestions_503_when_llm_key_missing(self):
+        """GET /api/suggestions returns 503 with generic detail when LLM key not configured."""
+        user = _make_user(privacy_policy_accepted=True)
+        app.dependency_overrides[get_current_user] = lambda: user
+        app.dependency_overrides[get_db] = lambda: AsyncMock()
+
+        with patch(
+            "backend.routers.suggestions.has_enough_ranked",
+            new_callable=AsyncMock,
+            return_value=True,
+        ), patch(
+            "backend.routers.suggestions._get_active_suggestions",
+            new_callable=AsyncMock,
+            return_value=[],
+        ), patch(
+            "backend.routers.suggestions._create_suggestions",
+            new_callable=AsyncMock,
+            side_effect=ValueError("LLM_API_KEY not configured"),
+        ):
+            with TestClient(app, raise_server_exceptions=False) as client:
+                resp = client.get("/api/suggestions")
+
+        assert resp.status_code == 503
+        assert resp.json()["detail"] == "AI features are not available"
+
 
 # ---------------------------------------------------------------------------
 # Item 6: regenerate daily limit & 503
@@ -137,3 +162,4 @@ class TestRegenerateSuggestions:
                 resp = client.post("/api/suggestions/regenerate")
 
         assert resp.status_code == 503
+        assert resp.json()["detail"] == "AI features are not available"

--- a/backend/utils/tokens.py
+++ b/backend/utils/tokens.py
@@ -14,7 +14,7 @@ def decode_pair_token(token: str) -> set[str] | None:
         raw = decrypt_token(token)
         parts = raw.split(",")
         if len(parts) == 2:
-            return {parts[0], parts[1]}
+            return set(parts)
     except Exception:
         pass
     return None


### PR DESCRIPTION
## Summary

Fixes #363 by replacing direct exception message forwarding with hardcoded generic error messages across four router endpoints. This prevents internal system details (LLM API configuration, pool membership state, media type specifics) from leaking to authenticated API clients.

## Changes

**Files Modified:**
- `backend/routers/movies.py` (line 77)
  - Replaced `str(e)` with `"No eligible pair found"`
  - Prevents media_type interpolation from reaching clients

- `backend/routers/duels.py` (line 104)
  - Replaced `str(e)` with `"Invalid duel submission"`
  - Hides pool membership state details

- `backend/routers/suggestions.py` (lines 162 and 217)
  - Replaced two `str(e)` instances with `"AI features are not available"`
  - Prevents LLM_API_KEY configuration hints and .env file paths from reaching clients

**Additional fixes during validation:**
- `backend/tests/conftest.py` - Created to set required environment variables before test collection
- `backend/tests/test_movies_router.py` - Updated imports to use `encode_pair_token`/`decode_pair_token` from `backend.utils.tokens`

## Validation

✅ **Type check / Build**: 1790 modules transformed, built in 276ms  
✅ **Frontend Tests**: 145 passed, 0 failed  
✅ **Backend Tests**: 631 passed, 0 failed (26 warnings)  
✅ **Lint**: 0 errors  

The pattern mirrors the safe error handling already used in `backend/routers/rankings.py:66-67`, where ValueError exceptions are caught without forwarding the exception message to clients.

Fixes #363